### PR TITLE
Fluentロガーのログ出力をmessage、time、name、levelの情報に分割する #25

### DIFF
--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 2.6)
 add_subdirectory(sdo)
 add_subdirectory(local_service)
 add_subdirectory(ec)
+add_subdirectory(logger)
 
 
 if(VXWORKS)

--- a/src/ext/logger/CMakeLists.txt
+++ b/src/ext/logger/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required (VERSION 2.6)
+
+if(UNIX)
+	set(FLUENTBIT_ENABLE ${FLUENTBIT_ENABLE} CACHE BOOL "set FLUENTBIT_ENABLE")
+	if(FLUENTBIT_ENABLE)
+		add_subdirectory(fluentbit_stream)
+	endif(FLUENTBIT_ENABLE)
+endif(UNIX)
+

--- a/src/ext/logger/fluentbit_stream/CMakeLists.txt
+++ b/src/ext/logger/fluentbit_stream/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required (VERSION 2.6)
+
+project (FluentBit)
+
+
+
+set(FLUENTBIT_ROOT ${FLUENTBIT_ROOT} CACHE PATH "set FLUENTBIT_ROOT")
+
+
+if(NOT FLUENTBIT_ROOT)
+	message(FATAL_ERROR "Please set FLUENTBIT_ROOT.")
+endif()
+
+set(FLUENTBIT_WORKDIR ${FLUENTBIT_WORKDIR} CACHE PATH "set FLUENTBIT_WORKDIR")
+
+if(NOT FLUENTBIT_WORKDIR)
+	message(FATAL_ERROR "Please set FLUENTBIT_WORKDIR.")
+endif()
+
+
+
+
+
+include_directories(${FLUENTBIT_ROOT}/include)
+include_directories(${FLUENTBIT_ROOT}/lib/monkey/include)
+include_directories(${FLUENTBIT_ROOT}/lib/mbedtls-2.14.1/include)
+include_directories(${FLUENTBIT_ROOT}/lib/msgpack-3.1.1/include)
+include_directories(${FLUENTBIT_ROOT}/lib/flb_libco)
+include_directories(${FLUENTBIT_ROOT}/lib/jemalloc-5.1.0/include)
+include_directories(${FLUENTBIT_ROOT}/lib/jsmn)
+include_directories(${FLUENTBIT_ROOT}/lib/onigmo)
+include_directories(${FLUENTBIT_ROOT}/lib/sha1)
+include_directories(${FLUENTBIT_ROOT}/lib/sqlite-amalgamation-3400000)
+
+
+link_directories(${FLUENTBIT_WORKDIR}/lib)
+
+
+
+
+
+link_directories(${ORB_LINK_DIR})
+include_directories(
+		${RTM_INCLUDE_DIR}
+		${ORB_INCLUDE_DIR}
+		)
+
+ADD_DEFINITIONS(${ORB_C_FLAGS_LIST})
+
+
+set(target FluentBit)
+
+set(srcs FluentBit.cpp FluentBit.h)
+
+
+if(VXWORKS AND NOT RTP)
+	set(libs ${RTCSKEL_PROJECT_NAME})
+
+	add_executable(${target} ${srcs})
+	target_link_libraries(${target} ${libs} fluent-bit)
+	add_dependencies(${target} ${RTM_PROJECT_NAME})
+
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/logger
+				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/logger
+				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/logger
+				COMPONENT ext)
+else()
+	if(VXWORKS)
+		set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${COIL_PROJECT_NAME} ${RTCSKEL_PROJECT_NAME})
+	else(VXWORKS)
+		set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${COIL_PROJECT_NAME})
+	endif(VXWORKS)
+
+
+	add_library(${target} SHARED ${srcs})
+	target_link_libraries(${target} ${libs} ${RTM_LINKER_OPTION} fluent-bit)
+	add_dependencies(${target} ${RTM_PROJECT_NAME})
+	set_target_properties(${target} PROPERTIES PREFIX "")
+
+
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/logger
+				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/logger
+				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/logger
+				COMPONENT ext)
+endif()
+
+
+
+
+
+
+if(VXWORKS)
+	if(RTP)
+	else(RTP)	
+		set_target_properties(${target} PROPERTIES SUFFIX ".out")
+	endif(RTP)
+endif(VXWORKS)
+
+

--- a/src/ext/logger/fluentbit_stream/FluentBit.h
+++ b/src/ext/logger/fluentbit_stream/FluentBit.h
@@ -54,7 +54,7 @@ namespace RTC
    * @endif
    */
   class FluentBitStream
-    : public StreambufType
+    : public coil::LogStreamBuffer
   {
   public:
     FluentBitStream();
@@ -67,11 +67,12 @@ namespace RTC
 
     bool createInputStream(const coil::Properties& prop);
 
-  protected:
-    std::streamsize pushLogger();
+    int setServiceOption(const coil::Properties& prop);
 
-    virtual std::streamsize xsputn(const char_type* str,
-                                   std::streamsize insize);
+    virtual void write(int level, const std::string &name, const std::string &date, const std::string &mes);
+
+  protected:
+    std::streamsize pushLogger(int level, const std::string &name, const std::string &date, const char* mes);
 
   private:
     char m_buf[BUFFER_LEN];
@@ -287,7 +288,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual StreambufType* getStreamBuffer();
+    virtual coil::LogStreamBuffer* getStreamBuffer();
 
   protected:
     FluentBitStream m_fbstream;

--- a/src/lib/coil/CMakeLists.txt
+++ b/src/lib/coil/CMakeLists.txt
@@ -115,6 +115,7 @@ set(coil_srcs
 	common/coil/Timer.cpp
 	common/coil/crc.cpp
 	common/coil/stringutil.cpp
+	common/coil/Logger.cpp
 	${COIL_OS_DIR}/coil/Condition.cpp
 	${COIL_OS_DIR}/coil/DynamicLib.cpp
 	${COIL_OS_DIR}/coil/Mutex.cpp

--- a/src/lib/coil/common/Logger.cpp
+++ b/src/lib/coil/common/Logger.cpp
@@ -1,0 +1,480 @@
+﻿// -*- C++ -*-
+/*!
+ * @file Logger.h
+ * @brief log_streambuf and log_stream class
+ * @date $Date$
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2019
+ *     Noriaki Ando
+ *     Robot Innovation Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *     All rights reserved.
+ *
+ * $Id$
+ *
+ */
+
+#include <coil/Logger.h>
+
+
+
+namespace coil
+{
+  bool LogStream::m_lockEnable = true;
+  coil::Mutex LogStream::m_mutex("Mutex for Logger.");
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   * @else
+   * @brief Constructor
+   * @endif
+   */
+    LogStreamBuffer::LogStreamBuffer()
+    {
+    
+    }
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * デストラクタ。
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * Destructor
+     *
+     * @endif
+     */
+    LogStreamBuffer::~LogStreamBuffer()
+    {
+
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief ストリームを追加する
+     *
+     * LogStreamBuffer に実際の出力先であるストリームを追加する。
+     * ここで追加されたストリームの解体責任はユーザにあり、
+     * LogStreamBuffer 解体時には解体されることはない。
+     * また追加されているストリームを LogStreamBuffer の解体前に
+     * 解体してはならない。ストリームの解体は LogStreamBuffer の解体後に、
+     * ユーザが解体しなければならない。
+     *
+     * @param stream std::LogStreamBuffer 型のストリームへのポインタ
+     *
+     * @else
+     *
+     * @brief add stream
+     *
+     * This operation adds a stream that is actual output stream.
+     * User has responsibility to destruct the stream object, since
+     * this object never destructs the stream objects.  The added
+     * stream objects should not be destructed before the destruction
+     * of this object.  The stream destruction should be done by user
+     * after removing it from this object or destructing this object.
+     *
+     * @param stream a pointer to LogStreamBuffer type stream object
+     *
+     * @endif
+     */
+    void LogStreamBuffer::addStream(LogStreamBuffer *stream, bool cleanup)
+    {
+       m_streams.push_back(Stream(stream, cleanup));
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief ストリームを削除する
+     *
+     * LogStreamBuffer から出力先であるストリームを削除する。
+     * ここで削除されたストリームの解体責任はユーザにある。
+     *
+     * @param stream LogStreamBuffer 型のストリームへのポインタ
+     * @return 削除の成功(True)、失敗(False)
+     *
+     * @else
+     *
+     * @brief remove stream
+     *
+     * This operation remove a stream that is actual output stream.
+     * User has responsibility to destruct the stream object.
+     *
+     * @param stream a pointer to std::basic_streambuf type stream object
+     * @return Whether removing the stream succeeded.
+     *
+     * @endif
+     */
+    bool LogStreamBuffer::removeStream(LogStreamBuffer* stream)
+    {
+       std::vector<Stream>::iterator it;
+       for (it = m_streams.begin(); it != m_streams.end(); ++it)
+       {
+           if (it->stream_ == stream)
+           {
+               m_streams.erase(it);
+               return true;
+           }
+       }
+       return false;
+    }
+
+
+    /*!
+     * @if jp
+     *
+     * @brief ストリームバッファ取得
+     *
+     * ストリームバッファを返す。
+     *
+     * @return LogStreamBuffer リスト
+     *
+     * @else
+     *
+     * @brief Get stream buffer list
+     *
+     * Return a stream buffer list.
+     *
+     * @return LogStreamBuffer list
+     *
+     * @endif
+     */
+    std::vector<LogStreamBuffer*> LogStreamBuffer::getBuffers()
+    {
+        std::vector<LogStreamBuffer*> buffs;
+        std::vector<Stream>::iterator it;
+        for (it = m_streams.begin(); it != m_streams.end(); ++it)
+        {
+            buffs.push_back((*it).stream_);
+        }
+        return buffs;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief ログの出力
+     *
+     * 指定したメッセージのログを出力する
+     *
+     * @param level ログレベル
+     * @param name 名前
+     * @param date 時間
+     * @param mes メッセージ
+     *
+     *
+     * @else
+     *
+     * @brief log output
+     *
+     * 
+     *
+     * @param level log level
+     * @param name log name
+     * @param date time
+     * @param mes message
+     *
+     * @endif
+     */
+    void LogStreamBuffer::write(int level, const std::string &name, const std::string &date, const std::string &mes)
+    {
+        std::vector<Stream>::iterator it;
+        for (it = m_streams.begin(); it != m_streams.end(); ++it)
+        {
+            Guard gaurd((*it).mutex_);
+            (*it).stream_->write(level, name, date, mes);
+        }
+
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 標準出力のバッファのフラッシュ
+     *
+     * 
+     *
+     *
+     * @else
+     *
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    void LogStreamBuffer::flush()
+    {
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief コピーコンストラクタ
+     *
+     * コピーコンストラクタ
+     *
+     * @param x LogStreamBuffer オブジェクト
+     *
+     * @else
+     *
+     * @brief Copy Constructor
+     *
+     * Copy Constructor
+     *
+     * @param x LogStreamBuffer object
+     *
+     * @endif
+     */
+    LogStreamBuffer::LogStreamBuffer(const LogStreamBuffer& x)
+    {
+         this->m_streams = x.m_streams;
+    }
+
+
+
+    /*!
+     * @if jp
+     *
+     * @brief 代入演算子
+     *
+     * LogStreamBufferオブジェクトをコピーする。
+     *
+     * @param x LogStreamBuffer オブジェクト
+     *
+     * @return 代入結果
+     *
+     * @else
+     *
+     * @brief Assignment operator
+     *
+     * Copy a LogStreamBuffer object.
+     *
+     * @param x LogStreamBuffer object.
+     *
+     * @return Assignment result.
+     *
+     * @endif
+     */
+    LogStreamBuffer& LogStreamBuffer::operator=(const LogStreamBuffer& x)
+    {
+          this->m_streams = x.m_streams;
+          return *this;
+    }
+
+
+
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * コンストラクタ
+     *
+     * @param sb LogStreamBuffer 型オブジェクト
+     * @param levelmin ログレベルの最小値
+     * @param levelmax ログレベルの最大値
+     * @param デフォルトのログレベル
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * Constructor
+     *
+     * @param sb LogStreamBuffer type object
+     * @param levelmin minimum value for log level
+     * @param levelmax maximum value for log level
+     * @param level default log level
+     *
+     * @endif
+     */
+    LogStream::LogStream(LogStreamBuffer* sb, int levelmin, int levelmax, int level)
+          : ostream_type(sb), 
+            m_minLevel(levelmin), m_maxLevel(levelmax), m_logLevel(level)
+    {
+        if (m_minLevel >= m_maxLevel) throw std::bad_alloc();
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief ログレベル設定
+     *
+     * ログレベルを設定する。
+     *
+     * @param level ログレベル
+     *
+     * @else
+     *
+     * @brief Set the log level
+     *
+     * Set the log level.
+     *
+     * @param level Log level
+     *
+     * @endif
+     */
+    bool LogStream::setLevel(int level)
+    {
+        if (m_minLevel <= level && level <= m_maxLevel)
+        {
+            m_logLevel = level;
+            return true;
+        }
+        return false;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief ログレベル取得
+     *
+     * ログレベルを取得する。
+     *
+     * @return ログレベル
+     *
+     * @else
+     *
+     * @brief Get the log level
+     *
+     * Get the log level.
+     *
+     * @return Log level
+     *
+     * @endif
+     */
+    int LogStream::getLevel() const
+    {
+        return m_logLevel;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief ロックモード設定
+     *
+     * ロックモードを有効にする。
+     *
+     * @else
+     *
+     * @brief Enable the lock mode
+     *
+     * Enable the lock mode.
+     *
+     * @endif
+     */
+    void LogStream::enableLock()
+    {
+        m_lockEnable = true;
+    }
+
+
+    /*!
+     * @if jp
+     *
+     * @brief ロックモード解除
+     *
+     * ロックモードを無効にする。
+     *
+     * @else
+     *
+     * @brief Disable the lock mode
+     *
+     * Disable the lock mode.
+     *
+     * @endif
+     */
+    void LogStream::disableLock()
+    {
+        m_lockEnable = false;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 標準出力のバッファのフラッシュ
+     *
+     * @else
+     *
+     * @brief cout buffer flush
+     *
+     *
+     * @endif
+     */
+    void LogStream::flush()
+    {
+        if (ostream_type)
+        {
+            ostream_type->flush();
+        }
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief コピーコンストラクタ
+     *
+     * コピーコンストラクタ
+     *
+     * @param x LogStream オブジェクト
+     *
+     * @else
+     *
+     * @brief Copy Constructor
+     *
+     * Copy Constructor
+     *
+     * @param x LogStream object
+     *
+     * @endif
+     */
+    LogStream::LogStream(const LogStream& x)
+    {
+        this->m_minLevel = x.m_minLevel;
+        this->m_maxLevel = x.m_maxLevel;
+        this->m_logLevel = x.m_logLevel;
+        this->ostream_type = x.ostream_type;
+        this->m_lockEnable = x.m_lockEnable;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 代入演算子
+     *
+     * LogStreamオブジェクトをコピーする。
+     *
+     * @param x LogStreamオブジェクト
+     *
+     * @return 代入結果
+     *
+     * @else
+     *
+     * @brief Assignment operator
+     *
+     * Copy a LogStream object.
+     *
+     * @param x LogStream object.
+     *
+     * @return Assignment result.
+     *
+     * @endif
+     */
+    LogStream& LogStream::operator=(const LogStream& x)
+    {
+        this->m_minLevel = x.m_minLevel;
+        this->m_maxLevel = x.m_maxLevel;
+        this->m_logLevel = x.m_logLevel;
+        this->ostream_type = x.ostream_type;
+        this->m_lockEnable = x.m_lockEnable;
+        return *this;
+    }
+
+};  // namespace coil

--- a/src/lib/coil/common/Logger.h
+++ b/src/lib/coil/common/Logger.h
@@ -31,905 +31,583 @@
 #include <utility>
 #include <vector>
 
-#ifndef LINE_MAX
-#define LINE_MAX  1024
-#endif
 
-#define BUFFER_LEN LINE_MAX
 
 namespace coil
 {
   /*!
    * @if jp
    *
-   * @class log_streambuf
-   * @brief log_streambuf テンプレートクラス
+   * @class LogStreamBuffer
+   * @brief LogStreamBuffer基底クラス
    *
    * @else
    *
-   * @class log_streambuf
-   * @brief log_streambuf template class
+   * @class LogStreamBuffer
+   * @brief LogStreamBuffer base class
    *
    * @endif
    */
-  template <typename _CharT, typename _Traits = std::char_traits<_CharT> >
-  class log_streambuf
-    : public ::std::basic_streambuf<_CharT, _Traits>
+  class LogStreamBuffer
   {
+      typedef coil::Mutex Mutex;
+      typedef coil::Guard<coil::Mutex> Guard;
   public:
-    typedef _CharT                                       char_type;
-    typedef _Traits                                      traits_type;
-    typedef std::basic_streambuf<char_type, traits_type> streambuf_type;
-    typedef coil::Mutex Mutex;
-    typedef coil::Guard<coil::Mutex> Guard;
+      /*!
+       * @if jp
+       *
+       * @brief コンストラクタ
+       *
+       * コンストラクタ
+       *
+       * @else
+       *
+       * @brief Constructor
+       *
+       * Constructor
+       *
+       * @endif
+       */
+      LogStreamBuffer();
+      /*!
+       * @if jp
+       *
+       * @brief デストラクタ
+       *
+       * デストラクタ。
+       *
+       * @else
+       *
+       * @brief Destructor
+       *
+       * Destructor
+       *
+       * @endif
+       */
+      virtual ~LogStreamBuffer();
 
-    /*!
-     * @if jp
-     *
-     * @brief コンストラクタ
-     *
-     * コンストラクタ
-     *
-     * @else
-     *
-     * @brief Constructor
-     *
-     * Constructor
-     *
-     * @endif
-     */
-    log_streambuf()
-      : streambuf_type()
-    {
-      memset(m_buf, 0, BUFFER_LEN);
-      char *pStart = m_buf;
-      char *pEnd = m_buf + (BUFFER_LEN - 1);
-      this->setp(pStart, pEnd);
-      this->setg(pStart, pStart, pEnd);
-    }
+      /*!
+       * @if jp
+       *
+       * @brief ストリームを追加する
+       *
+       * LogStreamBuffer に実際の出力先であるストリームを追加する。
+       * ここで追加されたストリームの解体責任はユーザにあり、
+       * LogStreamBuffer 解体時には解体されることはない。
+       * また追加されているストリームを LogStreamBuffer の解体前に
+       * 解体してはならない。ストリームの解体は LogStreamBuffer の解体後に、
+       * ユーザが解体しなければならない。
+       *
+       * @param stream std::LogStreamBuffer 型のストリームへのポインタ
+       *
+       * @else
+       *
+       * @brief add stream
+       *
+       * This operation adds a stream that is actual output stream.
+       * User has responsibility to destruct the stream object, since
+       * this object never destructs the stream objects.  The added
+       * stream objects should not be destructed before the destruction
+       * of this object.  The stream destruction should be done by user
+       * after removing it from this object or destructing this object.
+       *
+       * @param stream a pointer to LogStreamBuffer type stream object
+       *
+       * @endif
+       */
+      void addStream(LogStreamBuffer *stream, bool cleanup = false);
 
-    /*!
-     * @if jp
-     *
-     * @brief デストラクタ
-     *
-     * デストラクタ。
-     *
-     * @else
-     *
-     * @brief Destructor
-     *
-     * Destructor
-     *
-     * @endif
-     */
-    virtual ~log_streambuf()
-    {
-    }
+      /*!
+       * @if jp
+       *
+       * @brief ストリームを削除する
+       *
+       * LogStreamBuffer から出力先であるストリームを削除する。
+       * ここで削除されたストリームの解体責任はユーザにある。
+       *
+       * @param stream LogStreamBuffer 型のストリームへのポインタ
+       * @return 削除の成功(True)、失敗(False)
+       *
+       * @else
+       *
+       * @brief remove stream
+       *
+       * This operation remove a stream that is actual output stream.
+       * User has responsibility to destruct the stream object.
+       *
+       * @param stream a pointer to std::basic_streambuf type stream object
+       * @return Whether removing the stream succeeded.
+       *
+       * @endif
+       */
+      bool removeStream(LogStreamBuffer* stream);
 
-    /*!
-     * @if jp
-     *
-     * @brief ストリームを追加する
-     *
-     * log_streambuf に実際の出力先であるストリームを追加する。
-     * ここで追加されたストリームの解体責任はユーザにあり、
-     * log_streambuf 解体時には解体されることはない。
-     * また追加されているストリームを log_streambuf の解体前に
-     * 解体してはならない。ストリームの解体は log_streambuf の解体後に、
-     * ユーザが解体しなければならない。
-     *
-     * @param stream std::basic_streambuf 型のストリームへのポインタ
-     *
-     * @else
-     *
-     * @brief Destructor
-     *
-     * This operation adds a stream that is actual output stream.
-     * User has responsibility to destruct the stream object, since
-     * this object never destructs the stream objects.  The added
-     * stream objects should not be destructed before the destruction
-     * of this object.  The stream destruction should be done by user
-     * after removing it from this object or destructing this object.
-     *
-     * @param stream a pointer to std::basic_streambuf type stream object
-     *
-     * @endif
-     */
-    void addStream(streambuf_type* stream, bool cleanup = false)
-    {
-      m_streams.push_back(Stream(stream, cleanup));
-    }
+      /*!
+       * @if jp
+       *
+       * @brief ストリームバッファ取得
+       *
+       * ストリームバッファを返す。
+       *
+       * @return LogStreamBuffer リスト
+       *
+       * @else
+       *
+       * @brief Get stream buffer list
+       *
+       * Return a stream buffer list.
+       *
+       * @return LogStreamBuffer list
+       *
+       * @endif
+       */
+      std::vector<LogStreamBuffer*> getBuffers();
 
-    /*!
-     * @if jp
-     *
-     * @brief ストリームを削除する
-     *
-     * log_streambuf から出力先であるストリームを削除する。
-     * ここで削除されたストリームの解体責任はユーザにある。
-     *
-     * @param stream std::basic_streambuf 型のストリームへのポインタ
-     *
-     * @else
-     *
-     * @brief Destructor
-     *
-     * This operation remove a stream that is actual output stream.
-     * User has responsibility to destruct the stream object.
-     *
-     * @param stream a pointer to std::basic_streambuf type stream object
-     * @return Whether removing the stream succeeded.
-     *
-     * @endif
-     */
-    bool removeStream(streambuf_type* stream)
-    {
-      std::vector<coil::log_streambuf<char>::Stream>::iterator it;
-      for ( it = m_streams.begin(); it != m_streams.end(); ++it )
-        {
-          if (it->stream_ == stream)
-            {
-              m_streams.erase(it);
-              return true;
-            }
-        }
-      return false;
-    }
+      /*!
+       * @if jp
+       *
+       * @brief ログの出力
+       *
+       * 指定したメッセージのログを出力する
+       *
+       * @param level ログレベル
+       * @param name 名前
+       * @param date 時間
+       * @param mes メッセージ
+       *
+       *
+       * @else
+       *
+       * @brief log output
+       *
+       * 
+       *
+       * @param level log level
+       * @param name log name
+       * @param date time
+       * @param mes message
+       *
+       * @endif
+       */
+      virtual void write(int level, const std::string &name, const std::string &date, const std::string &mes);
 
-    /*!
-     * @if jp
-     *
-     * @brief ストリームバッファ取得
-     *
-     * ストリームバッファを返す。
-     *
-     * @return streambuf_type リスト
-     *
-     * @else
-     *
-     * @brief Get stream buffer list
-     *
-     * Return a stream buffer list.
-     *
-     * @return streambuf_type list
-     *
-     * @endif
-     */
-    std::vector<streambuf_type*> getBuffers()
-    {
-      std::vector<streambuf_type*> buffs;
-      for (int i(0), len(m_streams.size()); i < len; ++i)
-        {
-          buffs.push_back(m_streams[i].stream_);
-        }
-      return buffs;
-    }
+      /*!
+       * @if jp
+       *
+       * @brief 標準出力のバッファのフラッシュ
+       *
+       * 
+       *
+       *
+       * @else
+       *
+       * @brief 
+       *
+       *
+       * @endif
+       */
+      virtual void flush();
 
-  protected:
-    /*!
-     * @if jp
-     *
-     * @brief basic_streambuf::xsputn のオーバーライド
-     *
-     * @param s 入力文字列へのポインタ
-     * @param n 入力文字数
-     * @return 入力文字列のサイズ
-     *
-     * @else
-     *
-     * @brief override of basic_streambuf::xsputn
-     *
-     * @param s a pointer to input characters
-     * @param n number of input characters
-     * @return input stream size
-     *
-     * @endif
-     */
-    virtual std::streamsize xsputn(const char_type* s, std::streamsize n)
-    {
-      stream_sputn();
-      for (size_t i(0), len(m_streams.size()); i < len; ++i)
-        {
-          Guard gaurd(m_streams[i].mutex_);
-          m_streams[i].stream_->sputn(s, n);
-        }
-      return n;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ストリームへ出力する。
-     *
-     * @return 出力した文字数
-     *
-     * @else
-     *
-     * @brief Write the stream buffer in stream.
-     *
-     * @return The number of characters written.
-     *
-     * @endif
-     */
-    virtual std::streamsize stream_sputn()
-    {
-      size_t bytes_to_write;
-      bytes_to_write = this->pptr() - this->gptr();
-      if (bytes_to_write > 0)
-        {
-          for (size_t i(0), len(m_streams.size()); i < len; ++i)
-            {
-              Guard gaurd(m_streams[i].mutex_);
-              m_streams[i].stream_->sputn(this->gptr(), bytes_to_write);
-            }
-          this->gbump(static_cast<int>(bytes_to_write));
-          if (this->gptr() >= this->pptr())
-            {
-              this->pbump(static_cast<int>(this->pbase() - this->pptr()));
-              this->gbump(static_cast<int>(this->pbase() - this->gptr()));
-            }
-        }
-      return bytes_to_write;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ストリームへ出力する。
-     *
-     * @param s 入力文字列へのポインタ
-     * @param n 入力文字数
-     * @return 入力文字列のサイズ
-     *
-     * @else
-     *
-     * @brief Writes up to n characters from the array pointed by s
-     *        to the output sequence controlled by the stream buffer.
-     *
-     * @param s a pointer to input characters
-     * @param n number of input characters
-     * @return The number of characters written.
-     *
-     * @endif
-     */
-    virtual std::streamsize stream_sputn(const char_type* s, std::streamsize n)
-    {
-
-      for (size_t i(0), len(m_streams.size()); i < len; ++i)
-        {
-          Guard gaurd(m_streams[i].mutex_);
-          m_streams[i].stream_->sputn(s, n);
-          m_streams[i].stream_->pubsync();
-        }
-      return n;
-    }
-    /*!
-     * @if jp
-     *
-     * @brief basic_streambuf::overflow のオーバーライド
-     *
-     * @param c 入力文字
-     * @return 返却値
-     *
-     * @else
-     *
-     * @brief override of basic_streambuf::overflow
-     *
-     * @param c input character
-     * @return return value
-     *
-     * @endif
-     */
-
-    virtual int overflow(int c = traits_type::eof())
-    {
-      Guard guard(m_mutex);
-//      if (traits_type::eq_int_type(c, traits_type::eof()))
-//        return c;
-//
-//      char_type last_char = traits_type::to_char_type(c);
-//      if (sputn(&last_char, 1) != 1)
-//        return traits_type::eof();
-//      else
-//        return c;
-
-      if (this->pbase())
-        {
-          if (this->pptr() > this->epptr() || this->pptr() < this->pbase())
-            return traits_type::eof();
-          // Add extra character to buffer if not EOF
-          if (!traits_type::eq_int_type(c, traits_type::eof()))
-            {
-              this->pbump(-1);
-              *(this->pptr()) = traits_type::to_char_type(c);
-              this->pbump(1);
-            }
-          // Number of characters to write to file
-          size_t bytes_to_write = this->pptr() - this->gptr();
-          // Overflow doesn't fail if nothing is to be written
-          if (bytes_to_write > 0)
-            {
-              if (stream_sputn(this->gptr(), bytes_to_write) != bytes_to_write)
-                return traits_type::eof();
-              // Reset next pointer to point to pbase on success
-              this->pbump(static_cast<int>(this->pbase() - this->pptr()));
-              this->gbump(static_cast<int>(this->pbase() - this->gptr()));
-            }
-        }
-      // Write extra character to file if not EOF
-      else if (!traits_type::eq_int_type(c, traits_type::eof()))
-        {
-          // Impromptu char buffer (allows "unbuffered" output)
-          char_type last_char = traits_type::to_char_type(c);
-          // If gzipped file won't accept this character, fail
-          if (stream_sputn(&last_char, 1) != 1)
-            return traits_type::eof();
-        }
-      // If you got here, you have succeeded (even if c was EOF)
-      // The return value should therefore be non-EOF
-      if (traits_type::eq_int_type(c, traits_type::eof()))
-        return traits_type::not_eof(c);
-      else
-        return c;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief basic_streambuf::sync のオーバーライド
-     *
-     * @return 返却値
-     *
-     * @else
-     *
-     * @brief override of basic_streambuf::sync
-     *
-     * @return return value
-     *
-     * @endif
-     */
-    virtual int sync()
-    {
-      if (this->pbase())
-        {
-          Guard guard(m_mutex);
-          if (this->pptr() > this->epptr() || this->pptr() < this->pbase())
-            return -1;
-
-          size_t bytes_to_write;
-          bytes_to_write = this->pptr() - this->gptr();
-          if (bytes_to_write > 0)
-            {
-              if (stream_sputn(this->gptr(), bytes_to_write) != bytes_to_write)
-                {
-                  return -1;
-                }
-              this->gbump(static_cast<int>(bytes_to_write));
-              if (this->gptr() >= this->pptr())
-                {
-                  this->pbump(static_cast<int>(this->pbase() - this->pptr()));
-                  this->gbump(static_cast<int>(this->pbase() - this->gptr()));
-                }
-            }
-        }
-      else
-        {
-          this->overflow();
-        }
-      return 0;
-    }
-
-  public:
-    /*!
-     * @if jp
-     *
-     * @brief ストリーム管理用構造体
-     *
-     * @else
-     *
-     * @brief Structure for stream management
-     *
-     * @endif
-     */
-    struct Stream
-    {
-      explicit Stream(streambuf_type* stream, bool cleanup = false)
-        : stream_(stream), cleanup_(cleanup)
+      /*!
+       * @if jp
+       *
+       * @brief ストリーム管理用構造体
+       *
+       * @else
+       *
+       * @brief Structure for stream management
+       *
+       * @endif
+       */
+      struct Stream
       {
-      }
+          explicit Stream(LogStreamBuffer* stream, bool cleanup = false)
+              : stream_(stream), cleanup_(cleanup)
+          {
+          }
 
-      virtual ~Stream()
-      {
-      }
+          virtual ~Stream()
+          {
+          }
 
-      Stream(const Stream& x)
-        : stream_(x.stream_), cleanup_(false)
-      {
-      }
+          Stream(const Stream& x)
+              : stream_(x.stream_), cleanup_(false)
+          {
+          }
 
-      Stream& operator=(const Stream& x)
-      {
-        Stream tmp(x);
-        tmp.swap(*this);
-        return *this;
-      }
+          Stream& operator=(const Stream& x)
+          {
+              Stream tmp(x);
+              tmp.swap(*this);
+              return *this;
+          }
 
-      void swap(Stream& x)
-      {
-        streambuf_type* stream = x.stream_;
-        bool cleanup = x.cleanup_;
+          void swap(Stream& x)
+          {
+              LogStreamBuffer* stream = x.stream_;
+              bool cleanup = x.cleanup_;
 
-        x.stream_ = this->stream_;
-        x.cleanup_ = this->cleanup_;
+              x.stream_ = this->stream_;
+              x.cleanup_ = this->cleanup_;
 
-        this->stream_ = stream;
-        this->cleanup_ = cleanup;
-      }
-      mutable Mutex mutex_;
-      streambuf_type* stream_;
-      bool cleanup_;
-    };
-
+              this->stream_ = stream;
+              this->cleanup_ = cleanup;
+          }
+          mutable Mutex mutex_;
+          LogStreamBuffer* stream_;
+          bool cleanup_;
+      };
   private:
-    /*!
-     * @if jp
-     *
-     * @brief コピーコンストラクタ
-     *
-     * コピーコンストラクタ
-     *
-     * @param x log_streambuf オブジェクト
-     *
-     * @else
-     *
-     * @brief Copy Constructor
-     *
-     * Copy Constructor
-     *
-     * @param x log_streambuf object
-     *
-     * @endif
-     */
-    log_streambuf(const log_streambuf& x);
+      /*!
+       * @if jp
+       *
+       * @brief コピーコンストラクタ
+       *
+       * コピーコンストラクタ
+       *
+       * @param x LogStreamBuffer オブジェクト
+       *
+       * @else
+       *
+       * @brief Copy Constructor
+       *
+       * Copy Constructor
+       *
+       * @param x LogStreamBuffer object
+       *
+       * @endif
+       */
+      LogStreamBuffer(const LogStreamBuffer& x);
 
-    /*!
-     * @if jp
-     *
-     * @brief 代入演算子
-     *
-     * log_streambufオブジェクトをコピーする。
-     *
-     * @param x log_streambuf オブジェクト
-     *
-     * @return 代入結果
-     *
-     * @else
-     *
-     * @brief Assignment operator
-     *
-     * Copy a log_streambuf object.
-     *
-     * @param x log_streambuf object.
-     *
-     * @return Assignment result.
-     *
-     * @endif
-     */
-    log_streambuf& operator=(const log_streambuf& x);
-
-    std::vector<Stream> m_streams;
-    Mutex m_mutex;
-    char m_buf[BUFFER_LEN];
+      /*!
+       * @if jp
+       *
+       * @brief 代入演算子
+       *
+       * LogStreamBufferオブジェクトをコピーする。
+       *
+       * @param x LogStreamBuffer オブジェクト
+       *
+       * @return 代入結果
+       *
+       * @else
+       *
+       * @brief Assignment operator
+       *
+       * Copy a LogStreamBuffer object.
+       *
+       * @param x LogStreamBuffer object.
+       *
+       * @return Assignment result.
+       *
+       * @endif
+       */
+      LogStreamBuffer& operator=(const LogStreamBuffer& x);
+      std::vector<Stream> m_streams;
   };
-
 
   /*!
    * @if jp
    *
-   * @class log_stream
-   * @brief log_stream テンプレートクラス
+   * @class LogStream
+   * @brief LogStream 基底クラス
    *
    * @else
    *
-   * @class log_stream
-   * @brief log_stream template class
+   * @class LogStream
+   * @brief LogStream base class
    *
    * @endif
    */
-  template <typename _CharT, typename _Traits = std::char_traits<_CharT> >
-  class log_stream
-    : public std::basic_ostream<_CharT, _Traits>
+  class LogStream
   {
   public:
-    // Types:
-    typedef _CharT                                       char_type;
-    typedef _Traits                                      traits_type;
-    typedef std::basic_ostream<char_type, traits_type>   ostream_type;
-    typedef std::basic_streambuf<char_type, traits_type> streambuf_type;
-    typedef coil::Mutex Mutex;
-    typedef coil::Guard<Mutex> Guard;
+      
+      /*!
+       * @if jp
+       *
+       * @brief コンストラクタ
+       *
+       * コンストラクタ
+       *
+       * @param sb LogStreamBuffer 型オブジェクト
+       * @param levelmin ログレベルの最小値
+       * @param levelmax ログレベルの最大値
+       * @param デフォルトのログレベル
+       *
+       * @else
+       *
+       * @brief Constructor
+       *
+       * Constructor
+       *
+       * @param sb LogStreamBuffer type object
+       * @param levelmin minimum value for log level
+       * @param levelmax maximum value for log level
+       * @param level default log level
+       *
+       * @endif
+       */
+      LogStream(LogStreamBuffer* sb, int levelmin, int levelmax, int level);
 
-    /*!
-     * @if jp
-     *
-     * @brief コンストラクタ
-     *
-     * コンストラクタ
-     *
-     * @param streambuf basic_streambuf 型オブジェクト
-     * @param levelmin ログレベルの最小値
-     * @param levelmax ログレベルの最大値
-     * @param デフォルトのログレベル
-     *
-     * @else
-     *
-     * @brief Constructor
-     *
-     * Constructor
-     *
-     * @param streambuf basic_streambuf type object
-     * @param levelmin minimum value for log level
-     * @param levelmax maximum value for log level
-     * @param level default log level
-     *
-     * @endif
-     */
-    log_stream(streambuf_type* sb, int levelmin, int levelmax, int level)
-      : ostream_type(sb),
-        m_minLevel(levelmin), m_maxLevel(levelmax), m_logLevel(level)
-    {
-      if (m_minLevel >= m_maxLevel) throw std::bad_alloc();
-      this->init(sb);
-    }
+      /*!
+       * @if jp
+       *
+       * @brief ログレベル設定
+       *
+       * ログレベルを設定する。
+       *
+       * @param level ログレベル
+       *
+       * @else
+       *
+       * @brief Set the log level
+       *
+       * Set the log level.
+       *
+       * @param level Log level
+       *
+       * @endif
+       */
+      bool setLevel(int level);
 
-    /*!
-     * @if jp
-     *
-     * @brief メッセージのヘッダ追加関数
-     *
-     * サブクラスにおいてこの関数をオーバーライドし、
-     * ログメッセージに適当な時刻などのヘッダを追加する。
-     *
-     * @else
-     *
-     * @brief Message header appender function
-     *
-     * Subclasses of this class should override this operation, and
-     * this function should be defined to append some header to the
-     * log messages.
-     *
-     * @endif
-     */
-    virtual void header(int level)
-    {
-      return;
-    }
+      /*!
+       * @if jp
+       *
+       * @brief ログレベル取得
+       *
+       * ログレベルを取得する。
+       *
+       * @return ログレベル
+       *
+       * @else
+       *
+       * @brief Get the log level
+       *
+       * Get the log level.
+       *
+       * @return Log level
+       *
+       * @endif
+       */
+      int getLevel() const;
 
-    /*!
-     * @if jp
-     *
-     * @brief ログレベル設定
-     *
-     * ログレベルを設定する。
-     *
-     * @param level ログレベル
-     *
-     * @else
-     *
-     * @brief Set the log level
-     *
-     * Set the log level.
-     *
-     * @param level Log level
-     *
-     * @endif
-     */
-    bool setLevel(int level)
-    {
-      if (m_minLevel <= level && level <= m_maxLevel)
-        {
-          m_logLevel = level;
-          return true;
-        }
-      return false;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ログレベル取得
-     *
-     * ログレベルを取得する。
-     *
-     * @return ログレベル
-     *
-     * @else
-     *
-     * @brief Get the log level
-     *
-     * Get the log level.
-     *
-     * @return Log level
-     *
-     * @endif
-     */
-    int getLevel() const
-    {
-      return m_logLevel;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ロックモード設定
-     *
-     * ロックモードを有効にする。
-     *
-     * @else
-     *
-     * @brief Enable the lock mode
-     *
-     * Enable the lock mode.
-     *
-     * @endif
-     */
-    void enableLock()
-    {
-      m_lockEnable = true;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ロックモード解除
-     *
-     * ロックモードを無効にする。
-     *
-     * @else
-     *
-     * @brief Disable the lock mode
-     *
-     * Disable the lock mode.
-     *
-     * @endif
-     */
-    void disableLock()
-    {
-      m_lockEnable = false;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ログストリームの取得
-     *
-     * 指定されたログレベルを判断し、ログストリームを取得する。
-     * 指定されたログレベルが設定されているログレベル以下の場合には、本クラスを
-     * 返す。
-     * 指定されたログレベルが設定されているログレベルを超えている場合には、
-     * ダミーログクラスを返す。
-     *
-     * @param level 指定ログレベル
-     *
-     * @return 対象ログストリーム
-     *
-     * @else
-     *
-     * @brief Acquire log stream
-     *
-     * Investigate the specified log level and get its log stream.
-     * If the specified log level is under the set log level, this class
-     * will be returned.
-     * If the specified log level exceeds the set log level, a dummy log class
-     * will be returned.
-     *
-     * @param level The specified log level
-     *
-     * @return Target log stream
-     *
-     * @endif
-     */
-    ostream_type& level(int level)
-    {
-      if (m_minLevel <= level && level <= m_logLevel)
-        {
-          header(level);
-          return *this;
-        }
-      else
-        {
-          return m_dummy;
-        }
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ログレベル有効チェック
-     *
-     * 指定されたログレベルが有効範囲かチェックし、有効・無効を返す。
-     *
-     * @param level ログレベル
-     *
-     * @return true: 有効, false: 無効
-     *
-     * @else
-     *
-     * @brief Log level effective check
-     *
-     * Check it whether an appointed log level is an effective range
-     * and return effective or invalidity.
-     *
-     * @param level Log level
-     *
-     * @return true: Valid, false: Invalid
-     *
-     * @endif
-     */
-    inline bool isValid(int level) const
-    {
-      return m_minLevel <= level && level <= m_logLevel;
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ログロック取得
-     * ロックモードが設定されている場合、ログのロックを取得する。
-     *
-     * @else
-     *
-     * @brief Acquire log lock
-     * Acquire log lock when the lock mode is set.
-     *
-     * @endif
-     */
-    inline void lock()
-    {
-      if (m_lockEnable) m_mutex.lock();
-    }
-
-    /*!
-     * @if jp
-     *
-     * @brief ログロック解放
-     * ロックモードが設定されている場合に、ログのロックを解放する。
-     *
-     * @else
-     *
-     * @brief Release the log lock
-     * Release the log lock when the lock mode is set.
-     *
-     * @endif
-     */
-    inline void unlock()
-    {
-      if (m_lockEnable) m_mutex.unlock();
-    }
+      /*!
+       * @if jp
+       *
+       * @brief ログの出力
+       *
+       * 指定したログメッセージを出力する
+       *
+       * @param level ログレベル
+       * @param mes ログメッセージ
+       *
+       *
+       * @else
+       *
+       * @brief log output
+       *
+       * 
+       * @param level log level
+       * @param mes log message
+       *
+       * @endif
+       */
+      virtual void write(int level, const std::string &mes) = 0;
 
 
+      /*!
+       * @if jp
+       *
+       * @brief ロックモード設定
+       *
+       * ロックモードを有効にする。
+       *
+       * @else
+       *
+       * @brief Enable the lock mode
+       *
+       * Enable the lock mode.
+       *
+       * @endif
+       */
+      void enableLock();
+
+
+      /*!
+       * @if jp
+       *
+       * @brief ロックモード解除
+       *
+       * ロックモードを無効にする。
+       *
+       * @else
+       *
+       * @brief Disable the lock mode
+       *
+       * Disable the lock mode.
+       *
+       * @endif
+       */
+      void disableLock();
+
+      /*!
+       * @if jp
+       *
+       * @brief 標準出力のバッファのフラッシュ
+       *
+       * @else
+       *
+       * @brief cout buffer flush
+       *
+       *
+       * @endif
+       */
+      void flush();
+
+      /*!
+       * @if jp
+       *
+       * @brief ログレベル有効チェック
+       *
+       * 指定されたログレベルが有効範囲かチェックし、有効・無効を返す。
+       *
+       * @param level ログレベル
+       *
+       * @return true: 有効, false: 無効
+       *
+       * @else
+       *
+       * @brief Log level effective check
+       *
+       * Check it whether an appointed log level is an effective range
+       * and return effective or invalidity.
+       *
+       * @param level Log level
+       *
+       * @return true: Valid, false: Invalid
+       *
+       * @endif
+       */
+      inline bool isValid(int level) const
+      {
+          return m_minLevel <= level && level <= m_logLevel;
+      }
+
+      /*!
+       * @if jp
+       *
+       * @brief ログロック取得
+       * ロックモードが設定されている場合、ログのロックを取得する。
+       *
+       * @else
+       *
+       * @brief Acquire log lock
+       * Acquire log lock when the lock mode is set.
+       *
+       * @endif
+       */
+      inline void lock()
+      {
+          if (m_lockEnable) m_mutex.lock();
+      }
+
+      /*!
+       * @if jp
+       *
+       * @brief ログロック解放
+       * ロックモードが設定されている場合に、ログのロックを解放する。
+       *
+       * @else
+       *
+       * @brief Release the log lock
+       * Release the log lock when the lock mode is set.
+       *
+       * @endif
+       */
+      inline void unlock()
+      {
+          if (m_lockEnable) m_mutex.unlock();
+      }
   protected:
-    /*!
-     * @if jp
-     *
-     * @brief デストラクタ
-     *
-     * デストラクタ。
-     *
-     * @else
-     *
-     * @brief Destructor
-     *
-     * Destructor
-     *
-     * @endif
-     */
-    ~log_stream() {}
-
-    /*!
-     * @if jp
-     *
-     * @brief デフォルトコンストラクタ
-     *
-     * デフォルトコンストラクタ
-     *
-     * @else
-     *
-     * @brief Default constructor
-     *
-     * Default constructor
-     *
-     * @endif
-     */
-    log_stream();
-
-    /*!
-     * @if jp
-     *
-     * @brief コピーコンストラクタ
-     *
-     * コピーコンストラクタ
-     *
-     * @param x log_stream オブジェクト
-     *
-     * @else
-     *
-     * @brief Copy Constructor
-     *
-     * Copy Constructor
-     *
-     * @param x log_stream object
-     *
-     * @endif
-     */
-    log_stream(const log_stream& x);
-
-    /*!
-     * @if jp
-     *
-     * @brief 代入演算子
-     *
-     * log_streamオブジェクトをコピーする。
-     *
-     * @param x log_streamオブジェクト
-     *
-     * @return 代入結果
-     *
-     * @else
-     *
-     * @brief Assignment operator
-     *
-     * Copy a log_stream object.
-     *
-     * @param x log_stream object.
-     *
-     * @return Assignment result.
-     *
-     * @endif
-     */
-    log_stream& operator=(const log_stream& x);
+      /*!
+       * @if jp
+       *
+       * @brief デストラクタ
+       *
+       * デストラクタ。
+       *
+       * @else
+       *
+       * @brief Destructor
+       *
+       * Destructor
+       *
+       * @endif
+       */
+      virtual ~LogStream() {};
+      LogStreamBuffer* ostream_type;
 
   private:
-    int m_minLevel, m_maxLevel;
-    int m_logLevel;
 
-    /*!
-     * @if jp
-     * @brief ダミーストリーム
-     * @else
-     * @brief Dummy log
-     * @endif
-     */
-    std::ofstream m_dummy;
+      /*!
+       * @if jp
+       *
+       * @brief コピーコンストラクタ
+       *
+       * コピーコンストラクタ
+       *
+       * @param x LogStream オブジェクト
+       *
+       * @else
+       *
+       * @brief Copy Constructor
+       *
+       * Copy Constructor
+       *
+       * @param x LogStream object
+       *
+       * @endif
+       */
+      LogStream(const LogStream& x);
+
+
+      /*!
+       * @if jp
+       *
+       * @brief 代入演算子
+       *
+       * LogStreamオブジェクトをコピーする。
+       *
+       * @param x LogStreamオブジェクト
+       *
+       * @return 代入結果
+       *
+       * @else
+       *
+       * @brief Assignment operator
+       *
+       * Copy a LogStream object.
+       *
+       * @param x LogStream object.
+       *
+       * @return Assignment result.
+       *
+       * @endif
+       */
+      LogStream& operator=(const LogStream& x);
+
+      
+      int m_minLevel, m_maxLevel;
+      int m_logLevel;
+
+      
   public:
-    /*!
-     * @if jp
-     * @brief ロック有効モード
-     * @else
-     * @brief Lock enable mode
-     * @endif
-     */
-    static bool m_lockEnable;
+      static bool m_lockEnable;
+      static Mutex m_mutex;
 
-    /*!
-     * @if jp
-     * @brief 排他制御オブジェクト
-     * @else
-     * @brief Mutual exclusion object
-     * @endif
-     */
-    static Mutex m_mutex;
   };
 
-  template <typename _CharT, typename _Traits >
-  bool log_stream<_CharT, _Traits >::m_lockEnable = true;
-
-  template <typename _CharT, typename _Traits >
-  coil::Mutex log_stream<_CharT, _Traits>::m_mutex("Mutex for Logger.");
-
-  typedef log_streambuf<char> LogStreamBuffer;
-  typedef log_stream<char> LogStream;
 
 };  // namespace coil
 #endif  // LOGGER_H

--- a/src/lib/coil/common/Properties.cpp
+++ b/src/lib/coil/common/Properties.cpp
@@ -843,4 +843,58 @@ namespace coil
   {
     return rhs._dump(lhs, rhs, 0);
   }
+
+
+  Properties::operator std::vector<std::string>() const
+  {
+      std::vector<std::string> out;
+
+      this->_dump(out, *this, 0);
+
+      return out;
+  }
+
+  void Properties::_dump(std::string& out, const Properties& curr, int index) const
+  {
+      if (index != 0) out += indent(index) + "- " + curr.name;
+      if (curr.leaf.empty())
+      {
+          if (curr.value.empty())
+          {
+              out += ": " + curr.default_value + "\n";
+          }
+          else
+          {
+              out += ": " + curr.value + "\n";
+          }
+          return;
+      }
+      if (index != 0) out += "\n";
+      for (size_t i(0), len(curr.leaf.size()); i < len; ++i)
+      {
+          _dump(out, *(curr.leaf[i]), index + 1);
+      }
+  }
+
+  void Properties::_dump(std::vector<std::string>& out, const Properties& curr, int index) const
+  {
+      if (index != 0) out.push_back(indent(index) + "- " + curr.name);
+      if (curr.leaf.empty())
+      {
+          if (curr.value.empty())
+          {
+              out.push_back(": " + curr.default_value);
+          }
+          else
+          {
+              out.push_back(": " + curr.value);
+          }
+          return;
+      }
+      if (index != 0)out.push_back("");
+      for (size_t i(0), len(curr.leaf.size()); i < len; ++i)
+      {
+          _dump(out, *(curr.leaf[i]), index + 1);
+      }
+  }
 };  // namespace coil

--- a/src/lib/coil/common/Properties.h
+++ b/src/lib/coil/common/Properties.h
@@ -1068,6 +1068,58 @@ namespace coil
      */
     Properties& operator<<(const Properties& prop);
 
+
+
+    /*!
+     * @if jp
+     * @brief Propertyをstd::vector<std::string>への型変換演算子
+     *
+     *
+     * @else
+     * @brief
+     *
+     *
+     * @endif
+     */
+    explicit operator std::vector<std::string>() const;
+    /*!
+     * @if jp
+     * @brief Propertyの内容を文字列に格納する
+     *
+     * @param out 文字列
+     * @param curr 対象のプロパティ
+     * @param index 現在のプロパティ階層
+     *
+     * @else
+     * @brief
+     *
+     * @param out 
+     * @param curr 
+     * @param index 
+     *
+     * @endif
+     */
+    void _dump(std::string& out, const Properties& curr, int index) const;
+
+    /*!
+     * @if jp
+     * @brief Propertyの内容を文字列のリストに格納する
+     *
+     * @param out 文字列のリスト
+     * @param curr 対象のプロパティ
+     * @param index 現在のプロパティ階層
+     *
+     * @else
+     * @brief
+     *
+     * @param out
+     * @param curr
+     * @param index
+     *
+     * @endif
+     */
+    void _dump(std::vector<std::string>& out, const Properties& curr, int index) const;
+
   protected:
     /*!
      * @if jp

--- a/src/lib/rtm/LogstreamBase.h
+++ b/src/lib/rtm/LogstreamBase.h
@@ -52,7 +52,7 @@ namespace RTC
    *
    * @endif
    */
-  typedef std::basic_streambuf<char> StreambufType;
+  typedef coil::LogStreamBuffer StreambufType;
   class LogstreamBase
   {
   public:

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -19,10 +19,401 @@
 #include <rtm/LogstreamBase.h>
 #include <rtm/LogstreamFile.h>
 #include <coil/stringutil.h>
+#include <rtm/Manager.h>
 
 namespace RTC
 {
   coil::vstring LogstreamFile::s_files;
+
+  /*!
+   * @if jp
+   *
+   * @brief ログメッセージのヘッダーの設定
+   *
+   * ログにログレベル、名前、時間、エスケープシケーンスを設定する。
+   *
+   * @param level レベル
+   * @param name 名前
+   * @param date 時間
+   * @param es_enable エスケープシケーンスの有無
+   *
+   *
+   * @else
+   *
+   * @brief
+   *
+   * @param level log level
+   * @param name log name
+   * @param date time
+   * @param es_enable enable escape sequence
+   *
+   *
+   * @endif
+   */
+  void FileStreamBase::header(int level, std::string name, std::string date, bool es_enable)
+  {
+      const char* color[] =
+      {
+        "\x1b[0m",          // SLILENT  (none)
+        "\x1b[0m\x1b[31m",  // FATAL    (red)
+        "\x1b[0m\x1b[35m",  // ERROR    (magenta)
+        "\x1b[0m\x1b[33m",  // WARN     (yellow)
+        "\x1b[0m\x1b[34m",  // INFO     (blue)
+        "\x1b[0m\x1b[32m",  // DEBUG    (green)
+        "\x1b[0m\x1b[36m",  // TRACE    (cyan)
+        "\x1b[0m\x1b[39m",  // VERBOSE  (default)
+        "\x1b[0m\x1b[37m"   // PARANOID (white)
+      };
+      if (es_enable)
+      {
+          *m_stream << color[level];
+      }
+      *m_stream << date << " " << Logger::getLevelString(level) << ": " << name << ": ";
+      if (es_enable)
+      {
+          *m_stream << "\x1b[0m";
+      }
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief 標準出力のバッファのフラッシュ
+   *
+   * @else
+   *
+   * @brief cout buffer flush
+   *
+   *
+   * @endif
+   */
+  void FileStreamBase::flush()
+  {
+      *m_stream << std::flush;
+  }
+
+    /*!
+  * @if jp
+  *
+  * @brief エスケープシーケンスの有効にする
+  *
+  *
+  * @else
+  *
+  * @brief
+  *
+  * 
+  *
+  *
+  * @endif
+  */
+  void FileStreamBase::enableEscapeSequence()
+  {
+	  m_esEnable = true;
+  }
+
+  /*!
+  * @if jp
+  *
+  * @brief エスケープシーケンスの無効にする
+  *
+  *
+  * @else
+  *
+  * @brief
+  *
+  * 
+  *
+  *
+  * @endif
+  */
+  void FileStreamBase::disableEscapeSequence()
+  {
+	  m_esEnable = false;
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief コンストラクタ
+   *
+   * コンストラクタ
+   *
+   *
+   * @else
+   *
+   * @brief Constructor
+   *
+   * Constructor
+   *
+   *
+   * @endif
+   */
+  StdoutStream::StdoutStream()
+  {
+      coil::Properties& prop(Manager::instance().getConfig());
+      coil::toBool(prop["logger.escape_sequence_enable"], "YES", "NO", false) ?
+          enableEscapeSequence() : disableEscapeSequence();
+
+      m_stream = new std::basic_ostream<char>(std::cout.rdbuf());
+  }
+
+
+  /*!
+   * @if jp
+   *
+   * @brief デストラクタ
+   *
+   * デストラクタ。
+   *
+   * @else
+   *
+   * @brief Destructor
+   *
+   * Destructor
+   *
+   * @endif
+   */
+  StdoutStream::~StdoutStream()
+  {
+      delete m_stream;
+  }
+
+
+  /*!
+   * @if jp
+   *
+   * @brief ログの出力
+   *
+   * 指定したメッセージのログを出力する
+   *
+   * @param level ログレベル
+   * @param name 名前
+   * @param date 時間
+   * @param mes メッセージ
+   *
+   *
+   * @else
+   *
+   * @brief log output
+   *
+   *
+   *
+   * @param level log level
+   * @param name log name
+   * @param date time
+   * @param mes message
+   *
+   * @endif
+   */
+  void StdoutStream::write(int level, const std::string &name, const std::string &date, const std::string &mes)
+  {
+      header(level, name, date, m_esEnable);
+      *m_stream << mes << std::endl;
+  }
+
+
+  /*!
+   * @if jp
+   *
+   * @brief コンストラクタ
+   *
+   * コンストラクタ
+   *
+   *
+   * @else
+   *
+   * @brief Constructor
+   *
+   * Constructor
+   *
+   *
+   * @endif
+   */
+  StderrStream::StderrStream()
+  {
+      coil::Properties& prop(Manager::instance().getConfig());
+      coil::toBool(prop["logger.escape_sequence_enable"], "YES", "NO", false) ?
+          enableEscapeSequence() : disableEscapeSequence();
+      m_stream = new std::basic_ostream<char>(std::cerr.rdbuf());
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief デストラクタ
+   *
+   * デストラクタ。
+   *
+   * @else
+   *
+   * @brief Destructor
+   *
+   * Destructor
+   *
+   * @endif
+   */
+  StderrStream::~StderrStream()
+  {
+      delete m_stream;
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief ログの出力
+   *
+   * 指定したメッセージのログを出力する
+   *
+   * @param level ログレベル
+   * @param name 名前
+   * @param date 時間
+   * @param mes メッセージ
+   *
+   *
+   * @else
+   *
+   * @brief log output
+   *
+   *
+   *
+   * @param level log level
+   * @param name log name
+   * @param date time
+   * @param mes message
+   *
+   * @endif
+   */
+  void StderrStream::write(int level, const std::string &name, const std::string &date, const std::string &mes)
+  {
+      header(level, name, date, m_esEnable);
+      *m_stream << mes << std::endl;
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief コンストラクタ
+   *
+   * コンストラクタ
+   *
+   * @param filename ファイル名
+   *
+   *
+   * @else
+   *
+   * @brief Constructor
+   *
+   * Constructor
+   *
+   * @param filename
+   *
+   *
+   * @endif
+   */
+  FileStream::FileStream(std::string filename)
+  {
+      coil::Properties& prop(Manager::instance().getConfig());
+      coil::toBool(prop["logger.escape_sequence_enable"], "YES", "NO", false) ?
+          enableEscapeSequence() : disableEscapeSequence();
+
+      m_fileout.open(filename, std::ios::out | std::ios::app);
+      m_stream = new std::basic_ostream<char>(&m_fileout);
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief デストラクタ
+   *
+   * デストラクタ。
+   *
+   * @else
+   *
+   * @brief Destructor
+   *
+   * Destructor
+   *
+   * @endif
+   */
+  FileStream::~FileStream()
+  {
+      delete m_stream;
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief ファイルを開くことに成功したかの確認
+   *
+   * @return 成功(True)
+   *
+   * @else
+   *
+   * @brief
+   *
+   *
+   *
+   * @endif
+   */
+  bool FileStream::is_open()
+  {
+      return m_fileout.is_open();
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief ファイルを閉じる
+   *
+   *
+   * @else
+   *
+   * @brief close file
+   *
+   *
+   *
+   * @endif
+   */
+  void FileStream::close()
+  {
+      if (m_fileout.is_open())
+      {
+          m_fileout.close();
+      }
+  }
+
+  /*!
+   * @if jp
+   *
+   * @brief ログの出力
+   *
+   * 指定したメッセージのログを出力する
+   *
+   * @param level ログレベル
+   * @param name 名前
+   * @param date 時間
+   * @param mes メッセージ
+   *
+   *
+   * @else
+   *
+   * @brief log output
+   *
+   *
+   *
+   * @param level log level
+   * @param name log name
+   * @param date time
+   * @param mes message
+   *
+   * @endif
+   */
+  void FileStream::write(int level, const std::string &name, const std::string &date, const std::string &mes)
+  {
+      header(level, name, date, m_esEnable);
+      *m_stream << mes << std::endl;
+  }
   
   LogstreamFile::LogstreamFile()
     : m_stdout(NULL), m_fileout(NULL)
@@ -55,27 +446,27 @@ namespace RTC
         if (fname == "stdout")
           {
             std::cout << "##### STDOUT!! #####" << std::endl;
-            m_stdout = std::cout.rdbuf();
+            m_stdout = new StdoutStream();
             return true;
           }
         else if (fname == "stderr")
           {
             std::cout << "##### STDOUT!! #####" << std::endl;
-            m_stdout = std::cerr.rdbuf();
+            m_stdout = new StderrStream();
             return true;
           }
         else
           {
             std::cout << "##### file #####" << std::endl;
-            m_fileout = new std::filebuf();
-            m_fileout->open(files[i].c_str(), std::ios::out | std::ios::app);
+            m_fileout = new FileStream(files[i]);
+            
             if (m_fileout->is_open()) { return true; }
           }
       }
     return false;
   }
 
-  StreambufType* LogstreamFile::getStreamBuffer()
+  coil::LogStreamBuffer* LogstreamFile::getStreamBuffer()
   {
     if (m_stdout != NULL)
       {
@@ -85,7 +476,7 @@ namespace RTC
       {
         return m_fileout;
       }
-    return std::cout.rdbuf();
+    return new StdoutStream();
   }
 
 };

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -50,7 +50,7 @@ namespace RTC
    *
    * @endif
    */
-  void FileStreamBase::header(int level, std::string name, std::string date, bool es_enable)
+  void FileStreamBase::header(int level, std::string &name, std::string &date, bool es_enable)
   {
       const char* color[] =
       {

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -50,7 +50,7 @@ namespace RTC
    *
    * @endif
    */
-  void FileStreamBase::header(int level, std::string &name, std::string &date, bool es_enable)
+  void FileStreamBase::header(int level, const std::string &name, const std::string &date, bool es_enable)
   {
       const char* color[] =
       {

--- a/src/lib/rtm/LogstreamFile.h
+++ b/src/lib/rtm/LogstreamFile.h
@@ -29,6 +29,416 @@ namespace RTC
   /*!
    * @if jp
    *
+   * @class FileStreamBase
+   * @brief ファイル出力のストリーミングバッファ基底クラス
+   *
+   * @else
+   *
+   * @class FileStreamBase
+   * @brief 
+   *
+   * @endif
+   */
+  class FileStreamBase : public coil::LogStreamBuffer
+  {
+  public:
+      /*!
+       * @if jp
+       *
+       * @brief コンストラクタ
+       *
+       * コンストラクタ
+       *
+       *
+       * @else
+       *
+       * @brief Constructor
+       *
+       * Constructor
+       *
+       *
+       * @endif
+       */
+      FileStreamBase(){};
+      /*!
+       * @if jp
+       *
+       * @brief デストラクタ
+       *
+       * デストラクタ。
+       *
+       * @else
+       *
+       * @brief Destructor
+       *
+       * Destructor
+       *
+       * @endif
+       */
+      virtual ~FileStreamBase() {};
+      /*!
+       * @if jp
+       *
+       * @brief ログメッセージのヘッダーの設定
+       *
+       * ログにログレベル、名前、時間、エスケープシケーンスを設定する。
+       *
+       * @param level レベル
+       * @param name 名前
+       * @param date 時間
+       * @param es_enable エスケープシケーンスの有無
+       *
+       *
+       * @else
+       *
+       * @brief 
+       *
+       * @param level log level
+       * @param name log name
+       * @param date time
+       * @param es_enable enable escape sequence
+       *
+       *
+       * @endif
+       */
+      void header(int level, std::string name, std::string date, bool es_enable = false);
+
+      /*!
+       * @if jp
+       *
+       * @brief 標準出力のバッファのフラッシュ
+       *
+       * @else
+       *
+       * @brief cout buffer flush
+       *
+       *
+       * @endif
+       */
+      virtual void flush();
+      /*!
+	   * @if jp
+	   *
+	   * @brief エスケープシーケンスを有効にする
+	   *
+	   * 
+	   *
+	   * @else
+	   *
+	   * @brief 
+	   * 
+	   * 
+	   *
+	   * 
+	   *
+	   * @endif
+	   */
+	  void enableEscapeSequence();
+	  /*!
+	   * @if jp
+	   *
+	   * @brief エスケープシーケンスを無効にする
+	   *
+	   *
+	   *
+	   * @else
+	   *
+	   * @brief
+	   *
+	   * 
+	   *
+	   *
+	   *
+	   * @endif
+	   */
+	  void disableEscapeSequence();
+      
+  protected:
+      std::basic_ostream<char> *m_stream;
+      bool m_esEnable;
+  };
+
+  /*!
+   * @if jp
+   *
+   * @class StdoutStream
+   * @brief 標準出力のストリーミングラッパークラス
+   *
+   * @else
+   *
+   * @class StdoutStream
+   * @brief 
+   *
+   * @endif
+   */
+  class StdoutStream : public FileStreamBase
+  {
+  public:
+      /*!
+       * @if jp
+       *
+       * @brief コンストラクタ
+       *
+       * コンストラクタ
+       *
+       *
+       * @else
+       *
+       * @brief Constructor
+       *
+       * Constructor
+       *
+       *
+       * @endif
+       */
+      StdoutStream();
+      /*!
+       * @if jp
+       *
+       * @brief デストラクタ
+       *
+       * デストラクタ。
+       *
+       * @else
+       *
+       * @brief Destructor
+       *
+       * Destructor
+       *
+       * @endif
+       */
+      virtual ~StdoutStream();
+
+      /*!
+       * @if jp
+       *
+       * @brief ログの出力
+       *
+       * 指定したメッセージのログを出力する
+       *
+       * @param level ログレベル
+       * @param name 名前
+       * @param date 時間
+       * @param mes メッセージ
+       *
+       *
+       * @else
+       *
+       * @brief log output
+       *
+       * 
+       *
+       * @param level log level
+       * @param name log name
+       * @param date time
+       * @param mes message
+       *
+       * @endif
+       */
+      virtual void write(int level, const std::string &name, const std::string &date, const std::string &mes);
+      
+  };
+
+  /*!
+   * @if jp
+   *
+   * @class StderrStream
+   * @brief 標準エラー出力のストリーミングラッパークラス
+   *
+   * @else
+   *
+   * @class StderrStream
+   * @brief 
+   *
+   * @endif
+   */
+  class StderrStream : public FileStreamBase
+  {
+  public:
+      /*!
+       * @if jp
+       *
+       * @brief コンストラクタ
+       *
+       * コンストラクタ
+       *
+       *
+       * @else
+       *
+       * @brief Constructor
+       *
+       * Constructor
+       *
+       *
+       * @endif
+       */
+      StderrStream();
+      /*!
+       * @if jp
+       *
+       * @brief デストラクタ
+       *
+       * デストラクタ。
+       *
+       * @else
+       *
+       * @brief Destructor
+       *
+       * Destructor
+       *
+       * @endif
+       */
+      virtual ~StderrStream();
+      /*!
+       * @if jp
+       *
+       * @brief ログの出力
+       *
+       * 指定したメッセージのログを出力する
+       *
+       * @param level ログレベル
+       * @param name 名前
+       * @param date 時間
+       * @param mes メッセージ
+       *
+       *
+       * @else
+       *
+       * @brief log output
+       *
+       *
+       *
+       * @param level log level
+       * @param name log name
+       * @param date time
+       * @param mes message
+       *
+       * @endif
+       */
+      virtual void write(int level, const std::string &name, const std::string &date, const std::string &mes);
+      
+
+  };
+
+  /*!
+   * @if jp
+   *
+   * @class FileStream
+   * @brief ファイル出力のストリーミングラッパークラス
+   *
+   * @else
+   *
+   * @class FileStream
+   * @brief
+   *
+   * @endif
+   */
+  class FileStream : public FileStreamBase
+  {
+  public:
+      /*!
+       * @if jp
+       *
+       * @brief コンストラクタ
+       *
+       * コンストラクタ
+       *
+       * @param filename ファイル名
+       *
+       *
+       * @else
+       *
+       * @brief Constructor
+       *
+       * Constructor
+       *
+       * @param filename
+       *
+       *
+       * @endif
+       */
+      FileStream(std::string filename);
+      /*!
+       * @if jp
+       *
+       * @brief デストラクタ
+       *
+       * デストラクタ。
+       *
+       * @else
+       *
+       * @brief Destructor
+       *
+       * Destructor
+       *
+       * @endif
+       */
+      virtual ~FileStream();
+      /*!
+       * @if jp
+       *
+       * @brief ファイルを開くことに成功したかの確認
+       *
+       * @return 成功(True)
+       *
+       * @else
+       *
+       * @brief 
+       *
+       * 
+       *
+       * @endif
+       */
+      bool is_open();
+      /*!
+       * @if jp
+       *
+       * @brief ファイルを閉じる
+       *
+       *
+       * @else
+       *
+       * @brief close file
+       *
+       *
+       *
+       * @endif
+       */
+      void close();
+      /*!
+       * @if jp
+       *
+       * @brief ログの出力
+       *
+       * 指定したメッセージのログを出力する
+       *
+       * @param level ログレベル
+       * @param name 名前
+       * @param date 時間
+       * @param mes メッセージ
+       *
+       *
+       * @else
+       *
+       * @brief log output
+       *
+       *
+       *
+       * @param level log level
+       * @param name log name
+       * @param date time
+       * @param mes message
+       *
+       * @endif
+       */
+      virtual void write(int level, const std::string &name, const std::string &date, const std::string &mes);
+      
+  private:
+      std::filebuf m_fileout;
+  };
+  /*!
+   * @if jp
+   *
    * @class PublisherBase
    *
    * @brief Publisher 基底クラス
@@ -122,13 +532,13 @@ namespace RTC
      *
      * @endif
      */
-    virtual StreambufType* getStreamBuffer();
+    virtual coil::LogStreamBuffer* getStreamBuffer();
 
   protected:
     static coil::vstring s_files;
     std::string m_fileName;
-    StreambufType* m_stdout;
-    std::filebuf* m_fileout;
+    FileStreamBase* m_stdout;
+    FileStream* m_fileout;
   };
 }; // namespace RTC
 

--- a/src/lib/rtm/LogstreamFile.h
+++ b/src/lib/rtm/LogstreamFile.h
@@ -101,7 +101,7 @@ namespace RTC
        *
        * @endif
        */
-      void header(int level, std::string &name, std::string &date, bool es_enable = false);
+      void header(int level, const std::string &name, const std::string &date, bool es_enable = false);
 
       /*!
        * @if jp

--- a/src/lib/rtm/LogstreamFile.h
+++ b/src/lib/rtm/LogstreamFile.h
@@ -101,7 +101,7 @@ namespace RTC
        *
        * @endif
        */
-      void header(int level, std::string name, std::string date, bool es_enable = false);
+      void header(int level, std::string &name, std::string &date, bool es_enable = false);
 
       /*!
        * @if jp
@@ -117,41 +117,41 @@ namespace RTC
        */
       virtual void flush();
       /*!
-	   * @if jp
-	   *
-	   * @brief エスケープシーケンスを有効にする
-	   *
-	   * 
-	   *
-	   * @else
-	   *
-	   * @brief 
-	   * 
-	   * 
-	   *
-	   * 
-	   *
-	   * @endif
-	   */
-	  void enableEscapeSequence();
-	  /*!
-	   * @if jp
-	   *
-	   * @brief エスケープシーケンスを無効にする
-	   *
-	   *
-	   *
-	   * @else
-	   *
-	   * @brief
-	   *
-	   * 
-	   *
-	   *
-	   *
-	   * @endif
-	   */
-	  void disableEscapeSequence();
+       * @if jp
+       *
+       * @brief エスケープシーケンスを有効にする
+       *
+       *
+       *
+       * @else
+       *
+       * @brief
+       *
+       *
+       *
+       *
+       *
+       * @endif
+       */
+      void enableEscapeSequence();
+      /*!
+       * @if jp
+       *
+       * @brief エスケープシーケンスを無効にする
+       *
+       *
+       *
+       * @else
+       *
+       * @brief
+       *
+       *
+       *
+       *
+       *
+       * @endif
+       */
+      void disableEscapeSequence();
       
   protected:
       std::basic_ostream<char> *m_stream;

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1467,8 +1467,6 @@ std::vector<coil::Properties> Manager::getLoadableModules()
     // Log stream mutex locking mode
     coil::toBool(m_config["logger.stream_lock"], "enable", "disable", false) ?
       rtclog.enableLock() : rtclog.disableLock();
-    coil::toBool(m_config["logger.escape_sequence_enable"], "YES", "NO", false) ?
-      rtclog.enableEscapeSequence() : rtclog.disableEscapeSequence();
 
     // File Logstream init
     initLogstreamFile();
@@ -2110,7 +2108,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             coil::Properties p(comps[i]->getInstanceName());
             p << comps[i]->getProperties();
             rtclog.lock();
-            rtclog.level(::RTC::Logger::RTL_PARANOID) << p;
+            rtclog.write(::RTC::Logger::RTL_PARANOID,  p);
             rtclog.unlock();
           }
         catch (...)

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -31,15 +31,15 @@ namespace RTC
 {
   const char* Logger::m_levelString[] =
     {
-      " SILENT: ",
-      " FATAL: ",
-      " ERROR: ",
-      " WARNING: ",
-      " INFO: ",
-      " DEBUG: ",
-      " TRACE: ",
-      " VERBOSE: ",
-      " PARANOID: "
+      "SILENT",
+      "FATAL",
+      "ERROR",
+      "WARNING",
+      "INFO",
+      "DEBUG",
+      "TRACE",
+      "VERBOSE",
+      "PARANOID"
     };
 
   Logger::Logger(const char* name)
@@ -48,7 +48,7 @@ namespace RTC
       m_name(name),
       m_dateFormat("%b %d %H:%M:%S.%Q"),
       m_clock(&coil::ClockManager::instance().getClock("system")),
-      m_msEnable(0), m_usEnable(0), m_esEnable(0)
+      m_msEnable(0), m_usEnable(0)
   {
     setLevel(Manager::instance().getLogLevel().c_str());
     coil::Properties& prop(Manager::instance().getConfig());
@@ -60,8 +60,7 @@ namespace RTC
       {
         setClockType(prop["logger.clock_type"]);
       }
-	coil::toBool(prop["logger.escape_sequence_enable"], "YES", "NO", false) ?
-		enableEscapeSequence() : disableEscapeSequence();
+	
   }
 
   Logger::Logger(LogStreamBuf* streambuf)
@@ -70,7 +69,7 @@ namespace RTC
       m_name("unknown"),
       m_dateFormat("%b %d %H:%M:%S.%Q"),
       m_clock(&coil::ClockManager::instance().getClock("system")),
-      m_msEnable(0), m_usEnable(0), m_esEnable(0)
+      m_msEnable(0), m_usEnable(0)
   {
     setDateFormat(m_dateFormat.c_str());
   }
@@ -121,37 +120,7 @@ namespace RTC
     m_name = name;
   }
 
-  /*!
-   * @if jp
-   * @brief メッセージのプリフィックス追加関数
-   * @else
-   * @brief Message prefix appender function
-   * @endif
-   */
-  void Logger::header(int level)
-    {
-	  if (m_esEnable)
-	    {
-		  const char* color[] =
-		  {
-			"\x1b[0m",          // SLILENT  (none)
-			"\x1b[0m\x1b[31m",  // FATAL    (red)
-			"\x1b[0m\x1b[35m",  // ERROR    (magenta)
-			"\x1b[0m\x1b[33m",  // WARN     (yellow)
-			"\x1b[0m\x1b[34m",  // INFO     (blue)
-			"\x1b[0m\x1b[32m",  // DEBUG    (green)
-			"\x1b[0m\x1b[36m",  // TRACE    (cyan)
-			"\x1b[0m\x1b[39m",  // VERBOSE  (default)
-			"\x1b[0m\x1b[37m"   // PARANOID (white)
-		  };
-		  *this << color[level];
-	    }
-      *this << getDate() + m_levelString[level] + m_name + ": ";
-	  if (m_esEnable)
-	    {
-		  *this << "\x1b[0m";
-	    }
-    }
+
 
   /*!
    * @if jp
@@ -224,44 +193,70 @@ namespace RTC
       return RTL_SILENT;
   }
 
-  /*!
-  * @if jp
-  *
-  * @brief エスケープシーケンスの有効にする
-  *
-  *
-  * @else
-  *
-  * @brief
-  *
-  * </pre>
-  *
-  *
-  * @endif
-  */
-  void Logger::enableEscapeSequence()
-  {
-	  m_esEnable = true;
-  }
+
 
   /*!
-  * @if jp
-  *
-  * @brief エスケープシーケンスの無効にする
-  *
-  *
-  * @else
-  *
-  * @brief
-  *
-  * </pre>
-  *
-  *
-  * @endif
-  */
-  void Logger::disableEscapeSequence()
+   * @if jp
+   *
+   * @brief ログの出力
+   *
+   * 指定したメッセージのログを出力する
+   *
+   * @param level ログレベル
+   * @param mes メッセージ
+   *
+   *
+   * @else
+   *
+   * @brief log output
+   *
+   * 
+   *
+   * @param level log level
+   * @param mes message
+   *
+   * @endif
+   */
+  void Logger::write(int level, const std::string &mes)
   {
-	  m_esEnable = false;
+      if (ostream_type)
+      {
+          std::string date = getDate();
+          ostream_type->write(level, m_name, date, mes);
+      }
+  }
+  /*!
+   * @if jp
+   *
+   * @brief ログの出力
+   *
+   * 指定したプロパティを文字列に変換してログに出力する
+   *
+   * @param level ログレベル
+   * @param prop プロパティ
+   *
+   *
+   * @else
+   *
+   * @brief log output
+   *
+   * 
+   *
+   * @param level log level
+   * @param prop properties
+   *
+   * @endif
+   */
+  void Logger::write(int level, coil::Properties &prop)
+  {
+      if (ostream_type)
+      {
+          std::vector<std::string> vec(prop);
+          for (std::vector<std::string>::iterator itr = vec.begin(); itr != vec.end(); ++itr)
+          {
+              ostream_type->write(level, m_name, getDate(), *itr);
+          }
+      }
   }
 
 };  // namespace RTC

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -247,7 +247,7 @@ namespace RTC
    *
    * @endif
    */
-  void Logger::write(int level, coil::Properties &prop)
+  void Logger::write(int level, const coil::Properties &prop)
   {
       if (ostream_type)
       {

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -27,6 +27,7 @@
 #include <coil/Mutex.h>
 #include <coil/Guard.h>
 #include <coil/stringutil.h>
+#include <coil/Properties.h>
 
 #include <string>
 
@@ -321,63 +322,84 @@ namespace RTC
      */
     void setName(const char* name);
 
-    /*!
-	 * @if jp
-	 *
-	 * @brief エスケープシーケンスを有効にする
-	 *
-	 * 
-	 *
-	 * @else
-	 *
-	 * @brief 
-	 * 
-	 * </pre>
-	 *
-	 * 
-	 *
-	 * @endif
-	 */
-	void enableEscapeSequence();
-	/*!
-	 * @if jp
-	 *
-	 * @brief エスケープシーケンスを無効にする
-	 *
-	 *
-	 *
-	 * @else
-	 *
-	 * @brief
-	 *
-	 * </pre>
-	 *
-	 *
-	 *
-	 * @endif
-	 */
-	void disableEscapeSequence();
 
-  protected:
     /*!
      * @if jp
      *
-     * @brief メッセージのプリフィックス追加関数
+     * @brief ログの出力
      *
-     * サブクラスにおいてこの関数をオーバーライドし、
-     * ログメッセージに適当なプリフィックスるを追加する。
+     * 指定したメッセージのログを出力する
+     *
+     * @param level ログレベル
+     * @param mes メッセージ
+     *
      *
      * @else
      *
-     * @brief Message prefix appender function
+     * @brief log output
      *
-     * Subclasses of this class should override this operation, and
-     * this function should be defined to append some prefix to the
-     * log messages.
+     *
+     *
+     * @param level log level
+     * @param mes message
      *
      * @endif
      */
-    virtual void header(int level);
+    virtual void write(int level, const std::string &mes);
+
+    /*!
+     * @if jp
+     *
+     * @brief ログの出力
+     *
+     * 指定したプロパティを文字列に変換してログに出力する
+     *
+     * @param level ログレベル
+     * @param prop プロパティ
+     *
+     *
+     * @else
+     *
+     * @brief log output
+     *
+     * 
+     *
+     * @param level log level
+     * @param prop properties
+     *
+     * @endif
+     */
+    void write(int level, coil::Properties &prop);
+
+    /*!
+     * @if jp
+     *
+     * @brief ログレベルを数値から文字列に変換
+     *
+     *
+     * @param level ログレベル
+     * 
+     * @return 文字列
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * 
+     *
+     * @param level log level
+     * 
+     * @return string
+     *
+     * @endif
+     */
+    static std::string getLevelString(int level)
+    {
+        return m_levelString[level];
+    }
+
+  protected:
+
 
     /*!
      * @if jp
@@ -424,7 +446,6 @@ namespace RTC
     static const char* m_levelString[];
     int m_msEnable;
     int m_usEnable;
-	bool m_esEnable;
   };
 
 
@@ -449,7 +470,7 @@ namespace RTC
     {                                                       \
       std::string str = ::coil::sprintf fmt;                \
       rtclog.lock();                                        \
-      rtclog.level(LV) << str << std::endl; \
+      rtclog.write(LV, str);                                \
       rtclog.unlock();                                      \
     }
 
@@ -457,7 +478,7 @@ namespace RTC
   if (rtclog.isValid(LV))                                   \
     {                                                       \
       rtclog.lock();                                        \
-      rtclog.level(LV) << str << std::endl;  \
+      rtclog.write(LV, str);                                \
       rtclog.unlock();                                      \
     }
 

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -369,7 +369,7 @@ namespace RTC
      *
      * @endif
      */
-    void write(int level, coil::Properties &prop);
+    void write(int level, const coil::Properties &prop);
 
     /*!
      * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#25


## Description of the Change

Fluent Bitロガーの出力をJSON形式でログメッセージ、ログレベル、名前、時間で分割するための変更を行いました。大幅な変更が加わっているため、入念なレビューをお願いします。

まず、Logger.hで定義されていたlog_streambuf、log_streamでは機能の実現が困難なため廃止しました。
変更後のクラス図を以下に掲載します。

![logger](https://user-images.githubusercontent.com/6216077/51812876-baa22b00-22f6-11e9-93d5-b617ee2fc423.png)




1. ログ出力関数

ログ出力関数はcoil::LogStreamBufferクラスのwrite関数に変更しました。

```CPP
void write(int level, const std::string &name, const std::string &date, const std::string &mes)
```

独自のロガーを実装する際はこのcoil::LogStreamBufferクラスを継承して作成します。
これに伴って、標準出力、標準エラー出力、ファイル出力をラッパーしたクラスStdoutStream、StderrStream、FileStreamを新たに定義しました。FluentBitロガーについてもcoil::LogStreamBufferクラスを継承することで、メッセージやログレベルなどをJSON形式に整形して出力できるようになりました。

2. Propertiesのログ出力
上記のwrite関数定義に伴い、Propertiesを標準出力するために、Propertiesを整形した文字列をstd::vector<std::string>に変換するため型変換演算子を定義した。
またRTC::LoggerにPropertiesを変換するためのwrite関数を定義した。
Propertiesをstd::vector<std::string>に変換後、順番にロガーに出力する。

```CPP
void write(int level, coil::Properties &prop);
```



## Verification 


Verify that the change has not introduced any regressions. 


- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
