### PR TITLE
#28の変更によりUbuntu 16.04(gcc 5.4.0)でビルドに失敗する、警告が発生する問題の修正

### DIFF
--- a/src/lib/coil/common/Properties.h
+++ b/src/lib/coil/common/Properties.h
@@ -1081,7 +1081,7 @@ namespace coil
      *
      * @endif
      */
-    explicit operator std::vector<std::string>() const;
+    operator std::vector<std::string>() const;
     /*!
      * @if jp
      * @brief Propertyの内容を文字列に格納する

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -317,7 +317,7 @@ namespace RTC
       coil::toBool(prop["logger.escape_sequence_enable"], "YES", "NO", false) ?
           enableEscapeSequence() : disableEscapeSequence();
 
-      m_fileout.open(filename, std::ios::out | std::ios::app);
+      m_fileout.open(filename.c_str(), std::ios::out | std::ios::app);
       m_stream = new std::basic_ostream<char>(&m_fileout);
   }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
#37


## Description of the Change

以下のエラーが発生した部分について修正した。

```
LogstreamFile.cpp:320:61: error: no matching function for call to ‘std::basic_filebuf<char>::open(std::__cxx11::string&, std::_Ios_Openmode)’      m_fileout.open(filename, std::ios::out | std::ios::app);
```

またexplicit指定子についてgcc 5.4.0で警告が発生していたが、削除しても問題なかったため削除した。

```
warning: explicit conversion operators only available with -std=c++11 or -std=gnu++11
```


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
