### PR TITLE
[master]Deleted 'BuildRequires: python' from spec file. #40

### DIFF
--- a/packages/rpm/OpenRTM-aist.spec.in
+++ b/packages/rpm/OpenRTM-aist.spec.in
@@ -33,7 +33,6 @@ Buildroot:     %{_tmppath}/%{pkgname}-%{version}-%{release}-root
 Requires:      omniORB
 Requires:      omniORB-servers
 BuildRequires: omniORB-devel
-BuildRequires: python
 
 %description
 OpenRTM-aist is a reference implementation of RTC (Robotic Technology


### PR DESCRIPTION
close #40 
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #40

## Description of the Change

- OpenRTM-aist.spec.inの「BuildRequires: python」定義を削除した
- OpenRTM-aist-Pythonのspecファイルでも定義していないので、削除しても問題ないと判断した

## Verification 

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- masterブランチはcmakeでのビルドになったため、rpmパッケージ生成手順を見直す必要がある
- このため、rpmパッケージ作成動作は確認していない。この動作はsvn/RELENG_1_2ブランチで確認している
