### PR TITLE
LogstreamFile.cppで定義したログレベルの文字列の定義をSystemLogger.cppに移動させる #74

### DIFF
--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -52,36 +52,13 @@ namespace RTC
    */
   void FileStreamBase::header(int level, const std::string &name, const std::string &date, bool es_enable)
   {
-      const char* color[] =
-      {
-        "\x1b[0m",          // SLILENT  (none)
-        "\x1b[0m\x1b[31m",  // FATAL    (red)
-        "\x1b[0m\x1b[35m",  // ERROR    (magenta)
-        "\x1b[0m\x1b[33m",  // WARN     (yellow)
-        "\x1b[0m\x1b[34m",  // INFO     (blue)
-        "\x1b[0m\x1b[32m",  // DEBUG    (green)
-        "\x1b[0m\x1b[36m",  // TRACE    (cyan)
-        "\x1b[0m\x1b[39m",  // VERBOSE  (default)
-        "\x1b[0m\x1b[37m"   // PARANOID (white)
-      };
 
-      const char* level_str[] =
-      {
-        " SILENT: ",
-        " FATAL: ",
-        " ERROR: ",
-        " WARNING: ",
-        " INFO: ",
-        " DEBUG: ",
-        " TRACE: ",
-        " VERBOSE: ",
-        " PARANOID: "
-      };
+
       if (es_enable)
       {
-          *m_stream << color[level];
+          *m_stream << Logger::getLevelColor(level);
       }
-      *m_stream << date << level_str[level] << name << ": ";
+      *m_stream << date << Logger::getLevelOutputString(level) << name << ": ";
       if (es_enable)
       {
           *m_stream << "\x1b[0m";

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -42,6 +42,32 @@ namespace RTC
       "PARANOID"
     };
 
+  const char* Logger::m_levelOutputString[] =
+    {
+      " SILENT: ",
+      " FATAL: ",
+      " ERROR: ",
+      " WARNING: ",
+      " INFO: ",
+      " DEBUG: ",
+      " TRACE: ",
+      " VERBOSE: ",
+      " PARANOID: "
+    };
+
+  const char* Logger::m_levelColor[] =
+    {
+      "\x1b[0m",          // SLILENT  (none)
+      "\x1b[0m\x1b[31m",  // FATAL    (red)
+      "\x1b[0m\x1b[35m",  // ERROR    (magenta)
+      "\x1b[0m\x1b[33m",  // WARN     (yellow)
+      "\x1b[0m\x1b[34m",  // INFO     (blue)
+      "\x1b[0m\x1b[32m",  // DEBUG    (green)
+      "\x1b[0m\x1b[36m",  // TRACE    (cyan)
+      "\x1b[0m\x1b[39m",  // VERBOSE  (default)
+      "\x1b[0m\x1b[37m"   // PARANOID (white)
+    };
+
   Logger::Logger(const char* name)
     : ::coil::LogStream(&(Manager::instance().getLogStreamBuf()),
                         RTL_SILENT, RTL_PARANOID, RTL_SILENT),

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -398,6 +398,62 @@ namespace RTC
         return m_levelString[level];
     }
 
+    /*!
+     * @if jp
+     *
+     * @brief ログレベルを対応した出力用の文字列に変換
+     *
+     *
+     * @param level ログレベル
+     *
+     * @return 文字列
+     *
+     * @else
+     *
+     * @brief
+     *
+     *
+     *
+     * @param level log level
+     *
+     * @return string
+     *
+     * @endif
+     */
+    static std::string getLevelOutputString(int level)
+    {
+        return m_levelOutputString[level];
+    }
+
+
+    /*!
+     * @if jp
+     *
+     * @brief ログレベルを対応したエスケープシケーンスに変換
+     *
+     *
+     * @param level ログレベル
+     *
+     * @return 文字列
+     *
+     * @else
+     *
+     * @brief
+     *
+     *
+     *
+     * @param level log level
+     *
+     * @return string
+     *
+     * @endif
+     */
+    static std::string getLevelColor(int level)
+    {
+        return m_levelColor[level];
+    }
+    
+
   protected:
 
 
@@ -444,6 +500,8 @@ namespace RTC
     std::string m_dateFormat;
     coil::IClock* m_clock;
     static const char* m_levelString[];
+    static const char* m_levelOutputString[];
+    static const char* m_levelColor[];
     int m_msEnable;
     int m_usEnable;
   };


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#74 


## Description of the Change

ログレベルの標準出力、ファイル出力用の文字列、エスケープシーケンスの定義をLoggerクラスに移動した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
