### PR TITLE
posix/OS.hの#if文の修正 #82

### DIFF
--- a/src/lib/coil/posix/coil/OS.h
+++ b/src/lib/coil/posix/coil/OS.h
@@ -249,7 +249,7 @@ namespace coil
       optarg = ::optarg;
       optind = ::optind;
       optopt = ::optopt;
-#if __QNX__
+#ifdef __QNX__
       if (optind_last < m_argc)
         {
           ++optind_last;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#82 


## Description of the Change

ifではなくifdefの間違いのため修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
