### PR TITLE
仕様変更に伴うComponentObserverConsumerのエラーの修正

### DIFF
--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -430,7 +430,7 @@ namespace RTC
       virtual ~DataPortAction() {}
 
       virtual ReturnCode operator()(ConnectorInfo& info,
-                                    cdrMemoryStream& data)
+                                    ByteData& data)
       {
         coil::TimeValue curr = coil::gettimeofday();
         coil::TimeValue intvl = curr - m_last;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#104 

## Description of the Change

operator()の引数が変わったため修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
