### PR TITLE
Support debian 8 docker build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
 
 env:
   - TARGET_DIST=ubuntu TARGET_VER=1604
+  - TARGET_DIST=debian TARGET_VER=8
 
 #branches:
 #  only:

--- a/build/debian_8/Dockerfile
+++ b/build/debian_8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM debian:8
 
 RUN apt-get update\
  && apt-get install -y --no-install-recommends\


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Description of the Change
#67 のために､古い gcc を使用する debian 8 の自動ビルドを行う｡

## Verification 

- [X] Did you succesed the build?  
- [X] No warnings for the build?  
- [X] Have you passed the unit tests?   ビルド通過を確認済み｡
