### PR TITLE
Use empty()

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2909,11 +2909,11 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 		  coil::Properties prop;
 		  NVUtil::copyToProperties(prop, prof->properties);
 		  if ((prop.hasKey("publish_topic") == nullptr ||
-			  prop["publish_topic"] == "") &&
+			  prop["publish_topic"].empty()) &&
 			  (prop.hasKey("subscribe_topic") == nullptr ||
-			  prop["subscribe_topic"] == "") &&
+			  prop["subscribe_topic"].empty()) &&
 			  (prop.hasKey("rendezvous_point") == nullptr ||
-			  prop["rendezvous_point"] == "")) {
+			  prop["rendezvous_point"].empty())) {
 			  continue;
 		  }
 
@@ -2955,11 +2955,11 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 		  coil::Properties prop;
 		  NVUtil::copyToProperties(prop, prof->properties);
 		  if ((prop.hasKey("publish_topic") == nullptr ||
-			  prop["publish_topic"] == "") &&
+			  prop["publish_topic"].empty()) &&
 			  (prop.hasKey("subscribe_topic") == nullptr ||
-			  prop["subscribe_topic"] == "") &&
+			  prop["subscribe_topic"].empty()) &&
 			  (prop.hasKey("rendezvous_point") == nullptr ||
-			  prop["rendezvous_point"] == "")) {
+			  prop["rendezvous_point"].empty())) {
 			  continue;
 		  }
 


### PR DESCRIPTION
## Description of the Change
処理が高速な empty() をコンテナサイズ取得の代わりに使用する。
(#67 の副産物)

## Verification 
ビルド確認のみ

- [X] Did you succesed the build?  
- [X] No warnings for the build?  
- [ ] Have you passed the unit tests?  
