### PR TITLE
Fix redundant-member-init

### DIFF
--- a/examples/Throughput/Throughput.cpp
+++ b/examples/Throughput/Throughput.cpp
@@ -87,8 +87,7 @@ Throughput::Throughput(RTC::Manager* manager)
     m_inFloatIn("in", m_inFloat),   m_outFloatOut("out", m_outFloat),
     m_inDoubleIn("in", m_inDouble), m_outDoubleOut("out", m_outDouble),
 
-    // Other private members
-    m_fs(),
+    
     m_datasize(1),
     m_record(m_maxsample),
     m_sendcount(0),

--- a/src/lib/coil/common/PeriodicTask.h
+++ b/src/lib/coil/common/PeriodicTask.h
@@ -413,7 +413,7 @@ namespace coil
      */
     struct suspend_t
     {
-      explicit suspend_t(bool sus) : suspend(sus), mutex(), cond(mutex) {}
+      explicit suspend_t(bool sus) : suspend(sus),  cond(mutex) {}
       bool suspend;
       coil::Mutex mutex;
       coil::Condition<coil::Mutex> cond;

--- a/src/lib/rtm/CorbaPort.h
+++ b/src/lib/rtm/CorbaPort.h
@@ -1225,8 +1225,8 @@ namespace RTC
                           PortableServer::RefCountServantBase* servant)
         : m_typeName(type_name),
           m_instanceName(instance_name),
-          m_servant(servant),
-          m_ior()
+          m_servant(servant)
+          
       {
 #ifndef ORB_IS_RTORB
 #ifdef ORB_IS_OMNIORB

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -103,7 +103,7 @@ namespace RTC
    */
   Manager::Manager()
     : m_initProc(nullptr), m_namingManager(nullptr), m_timer(nullptr),
-      m_logStreamBuf(), rtclog(&m_logStreamBuf),
+       rtclog(&m_logStreamBuf),
       m_runner(nullptr), m_terminator(nullptr)
   {
     new coil::SignalAction((coil::SignalHandler) handler, SIGINT);
@@ -118,7 +118,7 @@ namespace RTC
    */
   Manager::Manager(const Manager& manager)
     : m_initProc(nullptr), m_namingManager(nullptr), m_timer(nullptr),
-      m_logStreamBuf(), rtclog(&m_logStreamBuf),
+       rtclog(&m_logStreamBuf),
       m_runner(nullptr), m_terminator(nullptr)
   {
     new coil::SignalAction((coil::SignalHandler) handler, SIGINT);

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -48,7 +48,7 @@ namespace RTC_exp
    */
   MultilayerCompositeEC::
   MultilayerCompositeEC()
-  : PeriodicExecutionContext(), m_ownersm(nullptr)
+  :  m_ownersm(nullptr)
   {
     RTC_TRACE(("MultilayerCompositeEC()"));
   }

--- a/src/lib/rtm/SimulatorExecutionContext.cpp
+++ b/src/lib/rtm/SimulatorExecutionContext.cpp
@@ -35,7 +35,7 @@ namespace RTC
    * @endif
    */
   SimulatorExecutionContext::SimulatorExecutionContext()
-		: RTC::OpenHRPExecutionContext()
+		 
   {
 	  
 	  


### PR DESCRIPTION
## Identify the Bug
自動で呼ばれるデフォルトコンストラクターの呼び出しコードがあり、冗長。
(#67 の副産物)

## Description of the Change
不要な初期なコードを削除する。

## Verification 
ビルド確認のみ。

- [X] Did you succesed the build?  
- [X] No warnings for the build?  
- [ ] Have you passed the unit tests?  
