### PR TITLE
ビルド時に`rtm-config: not found`を表示させないようにする

### DIFF
--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -22,10 +22,17 @@ from __future__ import print_function
 import os
 import sys
 import getopt
+import subprocess
 
-libdir_path = os.popen("rtm-config --libdir", "r").read().split("\n")
-pyhelper_path = libdir_path[0] + "/py_helper"
-sys.path.append(pyhelper_path)
+if os.name != "nt":
+	cmd = "rtm-config --libdir"
+	p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	p.wait()
+	libdir_path = p.stdout.readlines()
+	pyhelper_path = libdir_path[0].replace("\n","")
+	if pyhelper_path:
+		pyhelper_path = pyhelper_path + "/py_helper"
+		sys.path.append(pyhelper_path)
 
 import skel_wrapper
 

--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -30,6 +30,9 @@ if os.name != "nt":
 		p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		p.wait()
 		libdir_path = p.stdout.readlines()
+		if sys.version_info[0] == 3:
+			libdir_path[0] = libdir_path[0].decode()
+
 		pyhelper_path = libdir_path[0].replace("\n","")
 		if pyhelper_path:
 			pyhelper_path = pyhelper_path + "/py_helper"

--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -26,13 +26,16 @@ import subprocess
 
 if os.name != "nt":
 	cmd = "rtm-config --libdir"
-	p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	p.wait()
-	libdir_path = p.stdout.readlines()
-	pyhelper_path = libdir_path[0].replace("\n","")
-	if pyhelper_path:
-		pyhelper_path = pyhelper_path + "/py_helper"
-		sys.path.append(pyhelper_path)
+	try:
+		p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		p.wait()
+		libdir_path = p.stdout.readlines()
+		pyhelper_path = libdir_path[0].replace("\n","")
+		if pyhelper_path:
+			pyhelper_path = pyhelper_path + "/py_helper"
+			sys.path.append(pyhelper_path)
+	except:
+		pass
 
 import skel_wrapper
 
@@ -167,5 +170,3 @@ def main():
 
 if __name__ == "__main__":
 	main()
-
-		


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#61


## Description of the Change

rtm-skelwrapperで`rtm-config --libdir`の標準エラー出力を表示しないようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
