### PR TITLE
コンポーネントオブザーバーのバグ修正

### DIFF
--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -625,7 +625,7 @@ namespace RTC
       }
     if (m_ecaction.ecDetached != NULL)
       {
-        m_rtobj->removeExecutionContextActionListener(EC_ATTACHED,
+        m_rtobj->removeExecutionContextActionListener(EC_DETACHED,
                                                       m_ecaction.ecDetached);
       }
     if (m_ecaction.ecRatechanged != NULL)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#182


## Description of the Change

そもそも複合コンポーネントのバグではありませんでした。

コンポーネントオブザーバーのRTCにアタッチしたリスナを削除する際の処理に問題があったため発生していました。

[2018年4月5日のコミット](https://github.com/OpenRTM/OpenRTM-aist/commit/ded7d3a559c1c0cebb01c44cddcc2a3f1ef1ebb5#diff-96fd1197581fd4414efb5528e4c10686)以前には発生していなかったようですが、これ以前にはまともな複合コンポーネントの終了処理ができておらず、子コンポーネントとECのデタッチをしなかったため偶然問題が発生しなかったようです。



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
