### PR TITLE
rtm_skelwrapperの自動生成するコードで定数名先頭にアンダーバーが付かないように修正

### DIFF
--- a/utils/rtm-skelwrapper/skel_wrapper.py
+++ b/utils/rtm-skelwrapper/skel_wrapper.py
@@ -246,9 +246,21 @@ class skel_wrapper:
 
 		skel_h_guard = dirname + self.data["skel_h"].replace(".","_")
 		skel_h_guard = skel_h_guard.replace("/","_")
+		count = 0
+		for i in range(len(skel_h_guard)):
+			if skel_h_guard[i] != "_":
+				count = i
+				break
+		skel_h_guard = skel_h_guard[count:]
 		skel_h_guard = skel_h_guard.upper()
 		stub_h_guard = dirname + self.data["stub_h"].replace(".","_")
 		stub_h_guard = stub_h_guard.replace("/","_")
+		count = 0
+		for i in range(len(stub_h_guard)):
+			if stub_h_guard[i] != "_":
+				count = i
+				break
+		stub_h_guard = stub_h_guard[count:]
 		stub_h_guard = stub_h_guard.upper()
 		self.data["skel_h_inc_guard"] = skel_h_guard
 		self.data["stub_h_inc_guard"] = stub_h_guard

--- a/utils/rtm-skelwrapper/skel_wrapper.py
+++ b/utils/rtm-skelwrapper/skel_wrapper.py
@@ -234,7 +234,9 @@ class skel_wrapper:
 			sys.stderr.write("Invalid IDL file name specified.\n")
 			sys.exit(1)
 			
-		dirname  = os.path.dirname(basename) + "/"
+		dirname  = os.path.dirname(basename)
+		if dirname:
+			dirname += "/"
 		basename = os.path.basename(basename)
 		self.data["basename"] = basename
 		self.data["skel_h"]   = basename + skel_suffix + ".h"


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

rtm_skelwrapperの自動生成するコードで定数名の先頭にアンダーバーが付く場合に警告が出る場合があった。


```CPP
#ifndef _BASICDATATYPESKEL_H
#define _BASICDATATYPESKEL_H
```


## Description of the Change

先頭にアンダーバーが付かないように修正した。



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
