### PR TITLE
inet_ntoaがNULLを返した場合に落ちる可能性がある問題の修正

### DIFF
--- a/src/lib/coil/posix/coil/Routing.cpp
+++ b/src/lib/coil/posix/coil/Routing.cpp
@@ -19,7 +19,7 @@
 
 #include <cstdio>
 #include <netdb.h>       // gethostbyname
-#include <arpa/inet.h>   // inet_ntoa
+#include <arpa/inet.h>   // inet_ntop
 #include <netinet/in.h>  // sockaddr_in
 #include <sys/wait.h>
 
@@ -62,8 +62,11 @@ namespace coil
 
     hostent = gethostbyname(dest_addr.c_str());
     addr.sin_addr.s_addr = **(unsigned int **)(hostent->h_addr_list);
-    dest_addr = inet_ntoa(addr.sin_addr);
-
+    char src[48];
+    if(inet_ntop(AF_INET, addr.sin_addr, src, size_of(src)) != nullptr)
+    {
+            dest_addr = src;
+    }
 #if defined(COIL_OS_FREEBSD) || defined(COIL_OS_DARWIN) \
                              || defined(COIL_OS_CYGWIN) \
                              || defined(COIL_OS_QNX)

--- a/src/lib/coil/posix/coil/Routing.cpp
+++ b/src/lib/coil/posix/coil/Routing.cpp
@@ -63,7 +63,7 @@ namespace coil
     hostent = gethostbyname(dest_addr.c_str());
     addr.sin_addr.s_addr = **(unsigned int **)(hostent->h_addr_list);
     char src[48];
-    if(inet_ntop(AF_INET, addr.sin_addr, src, size_of(src)) != nullptr)
+    if(inet_ntop(AF_INET, addr.sin_addr, src, sizeof(src)) != nullptr)
     {
             dest_addr = src;
     }

--- a/src/lib/coil/posix/coil/Routing.cpp
+++ b/src/lib/coil/posix/coil/Routing.cpp
@@ -63,7 +63,7 @@ namespace coil
     hostent = gethostbyname(dest_addr.c_str());
     addr.sin_addr.s_addr = **(unsigned int **)(hostent->h_addr_list);
     char src[48];
-    if(inet_ntop(AF_INET, addr.sin_addr, src, sizeof(src)) != nullptr)
+    if(inet_ntop(AF_INET, &addr.sin_addr, src, sizeof(src)) != nullptr)
     {
             dest_addr = src;
     }

--- a/src/lib/coil/posix/coil/Routing.cpp
+++ b/src/lib/coil/posix/coil/Routing.cpp
@@ -67,6 +67,10 @@ namespace coil
     {
             dest_addr = src;
     }
+    else
+    {
+            return false;
+    }
 #if defined(COIL_OS_FREEBSD) || defined(COIL_OS_DARWIN) \
                              || defined(COIL_OS_CYGWIN) \
                              || defined(COIL_OS_QNX)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#206 


## Description of the Change

inet_ntoaをinet_ntopに変更。
inet_ntopがnullptrを返す場合はreturn falseして終了するようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
