### PR TITLE
コンポーネントオブザーバーでkindsの配列のサイズを取得する部分に間違いがあったため修正(1.2)

### DIFF
--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -136,7 +136,7 @@ namespace RTC
           "CONFIGURATION",
           "HEARTBEAT"
         };
-      return (size_t)kind < sizeof(kind)/sizeof(char*) ? kinds[kind] : "";
+      return (size_t)kind < sizeof(kinds)/sizeof(kinds[0]) ? kinds[kind] : "";
     }
 
     /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

この変更は1.2に関わる変更のため、最優先でマージをお願いします。

## Identify the Bug

以下の部分で配列のサイズを取得したいはずだが、なぜかそれとは無関係のStatusKindのサイズを取得しようとしているため修正した。

```CPP
          "CONFIGURATION",
          "HEARTBEAT"
        };
      return (size_t)kind < sizeof(kind)/sizeof(char*) ? kinds[kind] : "";
      return static_cast<size_t>(kind) < sizeof(kind)/sizeof(char*) ? kinds[kind] : "";
    }
```


## Description of the Change




## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
