### PR TITLE
Visual Studio 2012で未定義のアーキテクチャを削除

### DIFF
--- a/src/lib/coil/win32/coil/OS.h
+++ b/src/lib/coil/win32/coil/OS.h
@@ -303,6 +303,24 @@ namespace coil
           strcpy_s(cputype, sizeof(cputype), "NEUTRAL");
           strcpy_s(subtype, sizeof(subtype), "");
           break;
+#ifdef PROCESSOR_ARCHITECTURE_ARM64
+      case PROCESSOR_ARCHITECTURE_ARM64:
+          strcpy_s(cputype, sizeof(cputype), "ARM64");
+          strcpy_s(subtype, sizeof(subtype), "");
+          break;
+#endif
+#ifdef PROCESSOR_ARCHITECTURE_ARM32_ON_WIN64
+      case PROCESSOR_ARCHITECTURE_ARM32_ON_WIN64:
+          strcpy_s(cputype, sizeof(cputype), "ARM32_ON_WIN64");
+          strcpy_s(subtype, sizeof(subtype), "");
+          break;
+#endif
+#ifdef PROCESSOR_ARCHITECTURE_IA32_ON_ARM64
+      case PROCESSOR_ARCHITECTURE_IA32_ON_ARM64:
+          strcpy_s(cputype, sizeof(cputype), "IA32_ON_ARM64");
+          strcpy_s(subtype, sizeof(subtype), "");
+          break;
+#endif
       default:
         strcpy_s(cputype, sizeof(cputype), "Unknown");
         strcpy_s(subtype, sizeof(subtype), "Unknown");

--- a/src/lib/coil/win32/coil/OS.h
+++ b/src/lib/coil/win32/coil/OS.h
@@ -303,18 +303,6 @@ namespace coil
           strcpy_s(cputype, sizeof(cputype), "NEUTRAL");
           strcpy_s(subtype, sizeof(subtype), "");
           break;
-      case PROCESSOR_ARCHITECTURE_ARM64:
-          strcpy_s(cputype, sizeof(cputype), "ARM64");
-          strcpy_s(subtype, sizeof(subtype), "");
-          break;
-      case PROCESSOR_ARCHITECTURE_ARM32_ON_WIN64:
-          strcpy_s(cputype, sizeof(cputype), "ARM32_ON_WIN64");
-          strcpy_s(subtype, sizeof(subtype), "");
-          break;
-      case PROCESSOR_ARCHITECTURE_IA32_ON_ARM64:
-          strcpy_s(cputype, sizeof(cputype), "IA32_ON_ARM64");
-          strcpy_s(subtype, sizeof(subtype), "");
-          break;
       default:
         strcpy_s(cputype, sizeof(cputype), "Unknown");
         strcpy_s(subtype, sizeof(subtype), "Unknown");


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Visual Studio 2012では以下の定数が未定義のためエラーになる。

- PROCESSOR_ARCHITECTURE_ARM64
- PROCESSOR_ARCHITECTURE_ARM32_ON_WIN64
- PROCESSOR_ARCHITECTURE_IA32_ON_ARM64

## Description of the Change

そもそもこれらのアーキテクチャで動作することは現状はないと考えられるため削除する。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
