### PR TITLE
Use 'override' keyword instead of 'virtual'

### DIFF
--- a/examples/Analyzer/Analyzer.h
+++ b/examples/Analyzer/Analyzer.h
@@ -71,7 +71,7 @@ class Analyzer
   /*!
    * @brief destructor
    */
-  ~Analyzer();
+  ~Analyzer() override;
 
   // <rtc-template block="public_attribute">
   
@@ -90,7 +90,7 @@ class Analyzer
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onInitialize();
+   RTC::ReturnCode_t onInitialize() override;
 
   /***
    *
@@ -140,7 +140,7 @@ class Analyzer
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id);
+   RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
 
   /***
    *
@@ -153,7 +153,7 @@ class Analyzer
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id);
+   RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
 
   /***
    *
@@ -166,7 +166,7 @@ class Analyzer
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+   RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   /***
    *
@@ -338,10 +338,10 @@ class DataListener
 	USE_CONNLISTENER_STATUS;
 public:
 	DataListener(Analyzer *comp);
-	virtual ~DataListener();
+	~DataListener() override;
 
-	virtual ReturnCode operator()(ConnectorInfo&  /*info*/,
-		TimedOctetSeq& data)
+	ReturnCode operator()(ConnectorInfo&  /*info*/,
+		TimedOctetSeq& data) override
 	{
 		m_comp->writeData(data);
 		return NO_CHANGE;

--- a/examples/Analyzer/Analyzer_test.h
+++ b/examples/Analyzer/Analyzer_test.h
@@ -60,7 +60,7 @@ class Analyzer_test
   /*!
    * @brief destructor
    */
-  ~Analyzer_test();
+  ~Analyzer_test() override;
 
   // <rtc-template block="public_attribute">
   
@@ -79,7 +79,7 @@ class Analyzer_test
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onInitialize();
+   RTC::ReturnCode_t onInitialize() override;
 
   /***
    *
@@ -155,7 +155,7 @@ class Analyzer_test
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+   RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   /***
    *

--- a/examples/Composite/Controller.h
+++ b/examples/Composite/Controller.h
@@ -30,11 +30,11 @@ class Controller  : public RTC::DataFlowComponentBase
 {
  public:
   Controller(RTC::Manager* manager);
-  ~Controller();
+  ~Controller() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
- virtual RTC::ReturnCode_t onInitialize();
+ RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -58,7 +58,7 @@ class Controller  : public RTC::DataFlowComponentBase
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/Composite/Motor.h
+++ b/examples/Composite/Motor.h
@@ -30,11 +30,11 @@ class Motor  : public RTC::DataFlowComponentBase
 {
  public:
   Motor(RTC::Manager* manager);
-  ~Motor();
+  ~Motor() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
- virtual RTC::ReturnCode_t onInitialize();
+ RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -58,7 +58,7 @@ class Motor  : public RTC::DataFlowComponentBase
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/Composite/Sensor.h
+++ b/examples/Composite/Sensor.h
@@ -30,11 +30,11 @@ class Sensor  : public RTC::DataFlowComponentBase
 {
  public:
   Sensor(RTC::Manager* manager);
-  ~Sensor();
+  ~Sensor() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
- virtual RTC::ReturnCode_t onInitialize();
+ RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -58,7 +58,7 @@ class Sensor  : public RTC::DataFlowComponentBase
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/ConfigSample/ConfigSample.h
+++ b/examples/ConfigSample/ConfigSample.h
@@ -34,11 +34,11 @@ class ConfigSample
 {
  public:
   ConfigSample(RTC::Manager* manager);
-  ~ConfigSample();
+  ~ConfigSample() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
- virtual RTC::ReturnCode_t onInitialize();
+ RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -62,7 +62,7 @@ class ConfigSample
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/ExtTrigger/ConsoleIn.h
+++ b/examples/ExtTrigger/ConsoleIn.h
@@ -34,11 +34,11 @@ class ConsoleIn
 {
  public:
   ConsoleIn(RTC::Manager* manager);
-  ~ConsoleIn();
+  ~ConsoleIn() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -62,7 +62,7 @@ class ConsoleIn
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/ExtTrigger/ConsoleOut.h
+++ b/examples/ExtTrigger/ConsoleOut.h
@@ -34,11 +34,11 @@ class ConsoleOut
 {
  public:
   ConsoleOut(RTC::Manager* manager);
-  ~ConsoleOut();
+  ~ConsoleOut() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -62,7 +62,7 @@ class ConsoleOut
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/SeqIO/SeqIn.h
+++ b/examples/SeqIO/SeqIn.h
@@ -38,7 +38,7 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(const char* name) : m_name(name) {}
-  virtual ~DataListener()
+  ~DataListener() override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -47,8 +47,8 @@ public:
       }
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info,
-                          TimedLong& data)
+  ReturnCode operator()(ConnectorInfo& info,
+                          TimedLong& data) override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -75,7 +75,7 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(const char* name) : m_name(name) {}
-  virtual ~ConnListener()
+  ~ConnListener() override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -84,7 +84,7 @@ public:
       }
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info)
+  ReturnCode operator()(ConnectorInfo& info) override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -109,11 +109,11 @@ class SeqIn
 {
  public:
   SeqIn(RTC::Manager* manager);
-  ~SeqIn();
+  ~SeqIn() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -137,7 +137,7 @@ class SeqIn
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/SeqIO/SeqOut.h
+++ b/examples/SeqIO/SeqOut.h
@@ -38,7 +38,7 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(const char* name) : m_name(name) {}
-  virtual ~DataListener()
+  ~DataListener() override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -47,8 +47,8 @@ public:
       }
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info,
-                                TimedLong& data)
+  ReturnCode operator()(ConnectorInfo& info,
+                                TimedLong& data) override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -75,7 +75,7 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(const char* name) : m_name(name) {}
-  virtual ~ConnListener()
+  ~ConnListener() override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -84,7 +84,7 @@ public:
       }
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info)
+  ReturnCode operator()(ConnectorInfo& info) override
   {
     // Connector Listener Dump check
     if(g_Listener_dump_enabled)
@@ -109,11 +109,11 @@ class SeqOut
 {
  public:
   SeqOut(RTC::Manager* manager);
-  ~SeqOut();
+  ~SeqOut() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -137,7 +137,7 @@ class SeqOut
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/SimpleIO/ConsoleIn.h
+++ b/examples/SimpleIO/ConsoleIn.h
@@ -38,13 +38,13 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(const char* name) : m_name(name) {}
-  virtual ~DataListener()
+  ~DataListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info,
-                                TimedLong& data)
+  ReturnCode operator()(ConnectorInfo& info,
+                                TimedLong& data) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Data Listener: " << m_name       << std::endl;
@@ -67,12 +67,12 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(const char* name) : m_name(name) {}
-  virtual ~ConnListener()
+  ~ConnListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info)
+  ReturnCode operator()(ConnectorInfo& info) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Connector Listener: " << m_name       << std::endl;
@@ -93,11 +93,11 @@ class ConsoleIn
 {
  public:
   ConsoleIn(RTC::Manager* manager);
-  ~ConsoleIn();
+  ~ConsoleIn() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -121,7 +121,7 @@ class ConsoleIn
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/SimpleIO/ConsoleOut.h
+++ b/examples/SimpleIO/ConsoleOut.h
@@ -37,13 +37,13 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(const char* name) : m_name(name) {}
-  virtual ~DataListener()
+  ~DataListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info,
-                                TimedLong& data)
+  ReturnCode operator()(ConnectorInfo& info,
+                                TimedLong& data) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Data Listener: " << m_name << "(OutPort)"  << std::endl;
@@ -65,12 +65,12 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(const char* name) : m_name(name) {}
-  virtual ~ConnListener()
+  ~ConnListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info)
+  ReturnCode operator()(ConnectorInfo& info) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Connector Listener: " << m_name       << std::endl;
@@ -91,11 +91,11 @@ class ConsoleOut
 {
  public:
   ConsoleOut(RTC::Manager* manager);
-  ~ConsoleOut();
+  ~ConsoleOut() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -119,7 +119,7 @@ class ConsoleOut
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/SimpleService/MyServiceConsumer.h
+++ b/examples/SimpleService/MyServiceConsumer.h
@@ -38,11 +38,11 @@ class MyServiceConsumer
 {
  public:
   MyServiceConsumer(RTC::Manager* manager);
-  ~MyServiceConsumer();
+  ~MyServiceConsumer() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -66,7 +66,7 @@ class MyServiceConsumer
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/SimpleService/MyServiceProvider.h
+++ b/examples/SimpleService/MyServiceProvider.h
@@ -35,11 +35,11 @@ class MyServiceProvider
 {
  public:
   MyServiceProvider(RTC::Manager* manager);
-  ~MyServiceProvider();
+  ~MyServiceProvider() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()

--- a/examples/SimpleService/MyServiceSVC_impl.h
+++ b/examples/SimpleService/MyServiceSVC_impl.h
@@ -25,19 +25,19 @@ class MyServiceSVC_impl
  public:
    // standard constructor
    MyServiceSVC_impl();
-   virtual ~MyServiceSVC_impl();
+   ~MyServiceSVC_impl() override;
 
    // attributes and operations
    char* echo(const char* msg)
-     throw (CORBA::SystemException);
+     throw (CORBA::SystemException) override;
   SimpleService::EchoList* get_echo_history()
-     throw (CORBA::SystemException);
+     throw (CORBA::SystemException) override;
    void set_value(CORBA::Float value)
-     throw (CORBA::SystemException);
+     throw (CORBA::SystemException) override;
    CORBA::Float get_value()
-     throw (CORBA::SystemException);
+     throw (CORBA::SystemException) override;
   SimpleService::ValueList* get_value_history()
-     throw (CORBA::SystemException);
+     throw (CORBA::SystemException) override;
 
 private:
   CORBA::Float m_value;

--- a/examples/StaticFsm/Display.h
+++ b/examples/StaticFsm/Display.h
@@ -49,8 +49,8 @@ public:
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info,
-                                TimedLong& data)
+  ReturnCode operator()(ConnectorInfo& info,
+                        TimedLong& data) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Data Listener: " << m_name       << std::endl;
@@ -78,7 +78,7 @@ public:
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info)
+  ReturnCode operator()(ConnectorInfo& info) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Connector Listener: " << m_name       << std::endl;
@@ -102,8 +102,8 @@ class Display
   ~Display();
 
   // The initialize action (on CREATED->ALIVE transition)
-  // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  // formaer rtc_init_entry()
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -127,7 +127,7 @@ class Display
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/StaticFsm/Inputbutton.h
+++ b/examples/StaticFsm/Inputbutton.h
@@ -43,8 +43,8 @@ public:
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info,
-                                TimedLong& data)
+  ReturnCode operator()(ConnectorInfo& info,
+                        TimedLong& data) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Data Listener: " << m_name       << std::endl;
@@ -72,7 +72,7 @@ public:
     std::cout << "dtor of " << m_name << std::endl;
   }
 
-  virtual ReturnCode operator()(ConnectorInfo& info)
+  ReturnCode operator()(ConnectorInfo& info) override
   {
     std::cout << "------------------------------"   << std::endl;
     std::cout << "Connector Listener: " << m_name       << std::endl;
@@ -96,8 +96,8 @@ class Inputbutton
   ~Inputbutton();
 
   // The initialize action (on CREATED->ALIVE transition)
-  // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  // formaer rtc_init_entry()
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -121,7 +121,7 @@ class Inputbutton
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/StaticFsm/Microwave.h
+++ b/examples/StaticFsm/Microwave.h
@@ -37,11 +37,11 @@ class Microwave
 {
  public:
   Microwave(RTC::Manager* manager);
-  ~Microwave();
+  ~Microwave() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry() 
-  virtual RTC::ReturnCode_t onInitialize();
+  RTC::ReturnCode_t onInitialize() override;
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
@@ -65,7 +65,7 @@ class Microwave
 
   // The execution action that is invoked periodically
   // former rtc_active_do()
-  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+  RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   // The aborting action when main logic error occurred.
   // former rtc_aborting_entry()

--- a/examples/StaticFsm/MicrowaveFsm.h
+++ b/examples/StaticFsm/MicrowaveFsm.h
@@ -66,7 +66,7 @@ namespace MicrowaveFsm
     // Machine's event protocol
     virtual void open() {}
     virtual void close() {}
-    virtual void minute(RTC::TimedLong time) {}
+    virtual void minute(RTC::TimedLong /* time */) {}
 //    {
 //      std::cout << "Top::minute()" << std::endl;
 //      for (size_t i(0); i < (size_t)time.data; ++i)
@@ -79,9 +79,9 @@ namespace MicrowaveFsm
     virtual void tick() {}		// Minute has passed
 
   private:
-    virtual RTC::ReturnCode_t onInit();
-    virtual RTC::ReturnCode_t onEntry();
-    virtual RTC::ReturnCode_t onExit();
+    RTC::ReturnCode_t onInit() override;
+    RTC::ReturnCode_t onEntry() override;
+    RTC::ReturnCode_t onExit() override;
   };
 
   //============================================================
@@ -91,11 +91,11 @@ namespace MicrowaveFsm
     FSM_STATE(Disabled);
 
     // Event handler
-    virtual void close();
+    void close() override;
 
   private:
-    virtual RTC::ReturnCode_t onEntry();
-    virtual RTC::ReturnCode_t onExit();
+    RTC::ReturnCode_t onEntry() override;
+    RTC::ReturnCode_t onExit() override;
   };
 
   //============================================================
@@ -108,11 +108,11 @@ namespace MicrowaveFsm
     DEEPHISTORY();
 
     // Event handler
-    void open();
-    void stop();
+    void open() override;
+    void stop() override;
 
   private:
-    virtual RTC::ReturnCode_t onInit();
+    RTC::ReturnCode_t onInit() override;
   };
 
   //============================================================
@@ -121,10 +121,10 @@ namespace MicrowaveFsm
   {
     FSM_STATE(Idle);
 
-    void minute(RTC::TimedLong time);
+    void minute(RTC::TimedLong time) override;
 
   private:
-    virtual RTC::ReturnCode_t onEntry();
+    RTC::ReturnCode_t onEntry() override;
   };
 
   //============================================================
@@ -133,13 +133,13 @@ namespace MicrowaveFsm
   {
     FSM_STATE(Programmed);
 
-    void minute(RTC::TimedLong time);
-    void start();
+    void minute(RTC::TimedLong time) override;
+    void start() override;
 
   private:
-    virtual RTC::ReturnCode_t onEntry();
-    virtual RTC::ReturnCode_t onInit();
-    virtual RTC::ReturnCode_t onExit();
+    RTC::ReturnCode_t onEntry() override;
+    RTC::ReturnCode_t onInit() override;
+    RTC::ReturnCode_t onExit() override;
   };
 
   //============================================================
@@ -148,11 +148,11 @@ namespace MicrowaveFsm
   {
     FSM_STATE(Cooking);
 
-    void tick();
+    void tick() override;
 
   private:
-    virtual RTC::ReturnCode_t onEntry();
-    virtual RTC::ReturnCode_t onExit();
+    RTC::ReturnCode_t onEntry() override;
+    RTC::ReturnCode_t onExit() override;
   };
 } // namespace MicrowaveFsm
 

--- a/examples/Throughput/Throughput.h
+++ b/examples/Throughput/Throughput.h
@@ -116,7 +116,7 @@ class Throughput
   /*!
    * @brief destructor
    */
-  ~Throughput();
+  ~Throughput() override;
 
   // <rtc-template block="public_attribute">
   
@@ -135,7 +135,7 @@ class Throughput
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onInitialize();
+   RTC::ReturnCode_t onInitialize() override;
 
   /***
    *
@@ -185,7 +185,7 @@ class Throughput
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id);
+   RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id) override;
 
   /***
    *
@@ -198,7 +198,7 @@ class Throughput
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id);
+   RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id) override;
 
   /***
    *
@@ -211,7 +211,7 @@ class Throughput
    * 
    * 
    */
-   virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+   RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id) override;
 
   /***
    *
@@ -434,9 +434,9 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(Throughput *comp) : m_comp(comp)  {};
-  virtual ~DataListener() {};
-  virtual ReturnCode operator()(ConnectorInfo&  /*info*/,
-                          DataType& data)
+  ~DataListener() override {};
+  ReturnCode operator()(ConnectorInfo&  /*info*/,
+                          DataType& data) override
   {
     m_comp->receiveData(data.tm, data.data.length());
 	return RTC::ConnectorListenerStatus::NO_CHANGE;;
@@ -450,8 +450,8 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(Throughput *comp) : m_comp(comp) {}
-  virtual ~ConnListener() {}
-  virtual ReturnCode operator()(ConnectorInfo& info)
+  ~ConnListener() override {}
+  ReturnCode operator()(ConnectorInfo& info) override
   {
 // Connector Listener: ON_CONNECT
 // Profile::name:      ConsoleIn0.out_ConsoleOut0.in

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
@@ -98,7 +98,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~LogicalTimeTriggeredEC();
+    ~LogicalTimeTriggeredEC() override;
 
     /*!
      * @if jp
@@ -113,7 +113,7 @@ namespace RTC
      *
      * @endif
      */
-    void init(coil::Properties& props);
+    void init(coil::Properties& props) override;
 
     /*!
      * @if jp
@@ -139,7 +139,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual int open(void *args);
+    int open(void *args) override;
 
     /*!
      * @if jp
@@ -161,7 +161,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual int svc();
+    int svc() override;
 
     /*!
      * @if jp
@@ -190,7 +190,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual int close(unsigned long flags);
+    int close(unsigned long flags) override;
 
     //============================================================
     // LogicalTimeTriggeredECService
@@ -208,10 +208,10 @@ namespace RTC
      *
      * @endif
      */
-    virtual void tick(::CORBA::ULong sec, ::CORBA::ULong usec)
-      throw (CORBA::SystemException);
-    virtual void get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec)
-      throw (CORBA::SystemException);
+    void tick(::CORBA::ULong sec, ::CORBA::ULong usec)
+      throw (CORBA::SystemException) override;
+    void get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec)
+      throw (CORBA::SystemException) override;
 
     //============================================================
     // ExecutionContextService
@@ -240,8 +240,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Boolean is_running()
-      throw (CORBA::SystemException);
+    CORBA::Boolean is_running()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -270,8 +270,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t start()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t start()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -299,8 +299,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t stop()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -322,8 +322,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Double get_rate()
-      throw (CORBA::SystemException);
+    CORBA::Double get_rate()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -354,8 +354,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -390,9 +390,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
     
     /*!
      * @if jp
@@ -426,9 +426,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -461,9 +461,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -491,9 +491,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::LifeCycleState
+    RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -514,8 +514,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException);
+    RTC::ExecutionKind get_kind()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -548,8 +548,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -581,9 +581,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -604,8 +604,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException);
+    RTC::ExecutionContextProfile* get_profile()
+      throw (CORBA::SystemException) override;
 
   protected:
     /*!
@@ -615,22 +615,22 @@ namespace RTC
     /*!
      * @brief onStarted() template function
      */
-    virtual RTC::ReturnCode_t onStarted();
+    RTC::ReturnCode_t onStarted() override;
     /*!
      * @brief onWaitingActivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingDeactivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingReset() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count) override;
 
   private:
     bool threadRunning()

--- a/src/ext/ec/rtpreempt/RTPreemptEC.h
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.h
@@ -176,7 +176,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual ~RTPreemptEC();
+    ~RTPreemptEC() override;
 
     /*!
      * @if jp
@@ -191,7 +191,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    void init(coil::Properties& props);
+    void init(coil::Properties& props) override;
 
     /*!
      * @if jp
@@ -217,7 +217,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual int open(void *args);
+    int open(void *args) override;
 
     /*!
      * @if jp
@@ -238,7 +238,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual int svc();
+    int svc() override;
 
     /*!
      * @if jp
@@ -267,7 +267,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual int close(unsigned long flags);
+    int close(unsigned long flags) override;
 
     //============================================================
     // ExecutionContext
@@ -296,8 +296,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual CORBA::Boolean is_running()
-      throw (CORBA::SystemException);
+    CORBA::Boolean is_running()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -326,8 +326,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t start()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t start()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -355,8 +355,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t stop()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -378,8 +378,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual CORBA::Double get_rate()
-      throw (CORBA::SystemException);
+    CORBA::Double get_rate()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -410,8 +410,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -446,9 +446,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -482,9 +482,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -517,9 +517,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -547,9 +547,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::LifeCycleState
+    RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -570,8 +570,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException);
+    RTC::ExecutionKind get_kind()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -604,9 +604,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -637,9 +637,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -660,49 +660,49 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException);
+    RTC::ExecutionContextProfile* get_profile()
+      throw (CORBA::SystemException) override;
 
   protected:
     /*!
      * @brief onStarted() template function
      */
-    virtual RTC::ReturnCode_t onStarted();
+    RTC::ReturnCode_t onStarted() override;
     /*!
      * @brief onStopping() template function
      */
-    virtual RTC::ReturnCode_t onStopping();
+    RTC::ReturnCode_t onStopping() override;
     /*!
      * @brief onWaitingActivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onActivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onActivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onActivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingDeactivated() template function
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     onWaitingDeactivated(RTC_impl::RTObjectStateMachine* comp,
-                         long int count);
+                         long int count) override;
     /*!
      * @brief onDeactivated() template function
      */
-    virtual RTC::ReturnCode_t 
-    onDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t 
+    onDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingReset() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onReset() template function
      */
-    virtual RTC::ReturnCode_t 
-    onReset(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t 
+    onReset(RTC_impl::RTObjectStateMachine* comp, long int count) override;
 
     bool threadRunning()
     {

--- a/src/ext/local_service/nameservice_file/FileNameservice.h
+++ b/src/ext/local_service/nameservice_file/FileNameservice.h
@@ -60,7 +60,7 @@ namespace RTM
        * @brief FileNameService dtor
        * @endif
        */
-      virtual ~FileNameservice();
+      ~FileNameservice() override;
       
       /*!
        * @if jp
@@ -78,8 +78,8 @@ namespace RTM
        *
        * @endif
        */
-      virtual bool
-      init(const ::coil::Properties& props);
+      bool
+      init(const ::coil::Properties& props) override;
       
       /*!
        * @if jp
@@ -97,8 +97,8 @@ namespace RTM
        *
        * @endif
        */
-      virtual bool
-      reinit(const ::coil::Properties& props);
+      bool
+      reinit(const ::coil::Properties& props) override;
       
       /*!
        * @if jp
@@ -117,7 +117,7 @@ namespace RTM
        *
        * @endif
        */
-      virtual const LocalServiceProfile& getProfile() const;
+      const LocalServiceProfile& getProfile() const override;
       
       /*!
        * @if jp
@@ -132,7 +132,7 @@ namespace RTM
        *
        * @endif
        */
-      virtual void finalize();
+      void finalize() override;
       
       /*!
        * @if jp
@@ -246,7 +246,7 @@ namespace RTM
        * @brief Destructor
        * @endif
        */
-      virtual ~NamingAction();
+      ~NamingAction() override;
 
       /*!
        * @if jp
@@ -257,8 +257,8 @@ namespace RTM
        * TODO: Documentation
        * @endif
        */
-      virtual void preBind(RTC::RTObject_impl* rtobj,
-                           coil::vstring& name);
+      void preBind(RTC::RTObject_impl* rtobj,
+                           coil::vstring& name) override;
       /*!
        * @if jp
        * @brief postBind コールバック関数
@@ -268,8 +268,8 @@ namespace RTM
        * TODO: Documentation
        * @endif
        */
-      virtual void postBind(RTC::RTObject_impl* rtobj,
-                            coil::vstring& name);
+      void postBind(RTC::RTObject_impl* rtobj,
+                            coil::vstring& name) override;
       
       /*!
        * @if jp
@@ -280,8 +280,8 @@ namespace RTM
        * TODO: Documentation
        * @endif
        */
-      virtual void preUnbind(RTC::RTObject_impl* rtobj,
-                             coil::vstring& name);
+      void preUnbind(RTC::RTObject_impl* rtobj,
+                             coil::vstring& name) override;
       
       /*!
        * @if jp
@@ -292,8 +292,8 @@ namespace RTM
        * TODO: Documentation
        * @endif
        */
-      virtual void postUnbind(RTC::RTObject_impl* rtobj,
-                              coil::vstring& name);
+      void postUnbind(RTC::RTObject_impl* rtobj,
+                              coil::vstring& name) override;
     private:
       RTM::LocalService::FileNameservice& m_fns;
     };

--- a/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.h
+++ b/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.h
@@ -57,7 +57,7 @@ namespace RTC
      * @brief dtor
      * @endif
      */
-    virtual ~ExtendedFsmServiceProvider();
+    ~ExtendedFsmServiceProvider() override;
 
     /*!
      * @if jp
@@ -66,8 +66,8 @@ namespace RTC
      * @brief Initialization
      * @endif
      */
-    virtual bool init(RTObject_impl& rtobj,
-                      const SDOPackage::ServiceProfile& profile);
+    bool init(RTObject_impl& rtobj,
+                      const SDOPackage::ServiceProfile& profile) override;
 
     /*!
      * @if jp
@@ -76,7 +76,7 @@ namespace RTC
      * @brief Re-initialization
      * @endif
      */
-    virtual bool reinit(const SDOPackage::ServiceProfile& profile);
+    bool reinit(const SDOPackage::ServiceProfile& profile) override;
 
     /*!
      * @if jp
@@ -85,7 +85,7 @@ namespace RTC
      * @brief getting ServiceProfile
      * @endif
      */
-    virtual const SDOPackage::ServiceProfile& getProfile() const;
+    const SDOPackage::ServiceProfile& getProfile() const override;
     
     /*!
      * @if jp
@@ -94,7 +94,7 @@ namespace RTC
      * @brief Finalization
      * @endif
      */
-    virtual void finalize();
+    void finalize() override;
 
     //============================================================
     // CORBA operations
@@ -123,7 +123,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual char* get_current_state();
+    char* get_current_state() override;
     /*!
      * @if jp
      * @brief FSMの構造を設定する
@@ -157,8 +157,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    set_fsm_structure(const ::RTC::FsmStructure& fsm_structure);
+    ReturnCode_t
+    set_fsm_structure(const ::RTC::FsmStructure& fsm_structure) override;
     /*!
      * @if jp
      * @brief FSMの構造を取得する
@@ -196,8 +196,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    get_fsm_structure(::RTC::FsmStructure_out fsm_structure);
+    ReturnCode_t
+    get_fsm_structure(::RTC::FsmStructure_out fsm_structure) override;
 
     
 

--- a/src/ext/sdo/logger/LoggerConsumer.h
+++ b/src/ext/sdo/logger/LoggerConsumer.h
@@ -57,7 +57,7 @@ namespace RTC
      * @brief dtor
      * @endif
      */
-    virtual ~LoggerConsumer();
+    ~LoggerConsumer() override;
 
     /*!
      * @if jp
@@ -66,8 +66,8 @@ namespace RTC
      * @brief Initialization
      * @endif
      */
-    virtual bool init(RTObject_impl& rtobj,
-                      const SDOPackage::ServiceProfile& profile);
+    bool init(RTObject_impl& rtobj,
+                      const SDOPackage::ServiceProfile& profile) override;
 
     /*!
      * @if jp
@@ -76,7 +76,7 @@ namespace RTC
      * @brief Re-initialization
      * @endif
      */
-    virtual bool reinit(const SDOPackage::ServiceProfile& profile);
+    bool reinit(const SDOPackage::ServiceProfile& profile) override;
 
     /*!
      * @if jp
@@ -85,7 +85,7 @@ namespace RTC
      * @brief getting ServiceProfile
      * @endif
      */
-    virtual const SDOPackage::ServiceProfile& getProfile() const;
+    const SDOPackage::ServiceProfile& getProfile() const override;
     
     /*!
      * @if jp
@@ -94,7 +94,7 @@ namespace RTC
      * @brief Finalization
      * @endif
      */
-    virtual void finalize();
+    void finalize() override;
 
   protected:
 

--- a/src/lib/coil/common/Async.h
+++ b/src/lib/coil/common/Async.h
@@ -75,7 +75,7 @@ namespace coil
      *
      * @endif
      */
-    virtual ~Async() {}
+    ~Async() override {}
 
     /*!
      * @if jp
@@ -177,7 +177,7 @@ namespace coil
      *
      * @endif
      */
-    virtual ~Async_t()
+    ~Async_t() override
     {
     }
 
@@ -200,7 +200,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int svc()
+    int svc() override
     {
       m_func(m_obj);
       {
@@ -226,7 +226,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void finalize()
+    void finalize() override
     {
       Task::finalize();
       if (m_autodelete) delete this;
@@ -247,7 +247,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void invoke()
+    void invoke() override
     {
       activate();
     }
@@ -271,7 +271,7 @@ namespace coil
      *
      * @endif
      */
-    virtual bool finished()
+    bool finished() override
     {
       coil::Guard<Mutex> guard(m_mutex);
       return m_finished;
@@ -345,7 +345,7 @@ namespace coil
      *
      * @endif
      */
-    virtual ~Async_ref_t()
+    ~Async_ref_t() override
     {
     }
 
@@ -368,7 +368,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int svc()
+    int svc() override
     {
       m_func(m_obj);
       m_finished = true;
@@ -390,7 +390,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void invoke()
+    void invoke() override
     {
       activate();
     }
@@ -414,7 +414,7 @@ namespace coil
      *
      * @endif
      */
-    virtual bool finished()
+    bool finished() override
     {
       return m_finished;
     }
@@ -434,7 +434,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void finalize()
+    void finalize() override
     {
       Task::finalize();
       if (m_autodelete) delete this;

--- a/src/lib/coil/common/ClockManager.h
+++ b/src/lib/coil/common/ClockManager.h
@@ -93,9 +93,9 @@ namespace coil
     : public IClock
   {
   public:
-    virtual ~SystemClock();
-    virtual coil::TimeValue gettime() const;
-    virtual bool settime(coil::TimeValue clocktime);
+    ~SystemClock() override;
+    coil::TimeValue gettime() const override;
+    bool settime(coil::TimeValue clocktime) override;
   };
 
   /*!
@@ -118,9 +118,9 @@ namespace coil
   {
   public:
     LogicalClock();
-    virtual ~LogicalClock();
-    virtual coil::TimeValue gettime() const;
-    virtual bool settime(coil::TimeValue clocktime);
+    ~LogicalClock() override;
+    coil::TimeValue gettime() const override;
+    bool settime(coil::TimeValue clocktime) override;
   private:
     coil::TimeValue m_currentTime;
     mutable coil::Mutex m_currentTimeMutex;
@@ -146,9 +146,9 @@ namespace coil
   {
   public:
     AdjustedClock();
-    virtual ~AdjustedClock();
-    virtual coil::TimeValue gettime() const;
-    virtual bool settime(coil::TimeValue clocktime);
+    ~AdjustedClock() override;
+    coil::TimeValue gettime() const override;
+    bool settime(coil::TimeValue clocktime) override;
   private:
     coil::TimeValue m_offset;
     mutable coil::Mutex m_offsetMutex;

--- a/src/lib/coil/common/Listener.h
+++ b/src/lib/coil/common/Listener.h
@@ -136,7 +136,7 @@ public:
    *
    * @endif
    */
-  virtual ~ListenerObject()
+  ~ListenerObject() override
   {
   }
 
@@ -153,7 +153,7 @@ public:
    *
    * @endif
    */
-  virtual void invoke()
+  void invoke() override
   {
     (m_obj->*m_cbf)();
   }
@@ -222,7 +222,7 @@ public:
    *
    * @endif
    */
-  virtual ~ListenerFunc() {}
+  ~ListenerFunc() override {}
 
   /*!
    * @if jp
@@ -237,7 +237,7 @@ public:
    *
    * @endif
    */
-  virtual void invoke()
+  void invoke() override
   {
     (*m_cbf)();
   }

--- a/src/lib/coil/common/PeriodicTask.h
+++ b/src/lib/coil/common/PeriodicTask.h
@@ -96,7 +96,7 @@ namespace coil
      *
      * @endif
      */
-    virtual ~PeriodicTask();
+    ~PeriodicTask() override;
 
     /*!
      * @if jp
@@ -120,7 +120,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void activate();
+    void activate() override;
 
     /*!
      * @if jp
@@ -135,7 +135,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void finalize();
+    void finalize() override;
 
     /*!
      * @if jp
@@ -150,7 +150,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int suspend();
+    int suspend() override;
 
     /*!
      * @if jp
@@ -165,7 +165,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int resume();
+    int resume() override;
 
     /*!
      * @if jp
@@ -180,7 +180,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void signal();
+    void signal() override;
 
     /*!
      * @if jp
@@ -195,7 +195,7 @@ namespace coil
      *
      * @endif
      */
-    virtual bool setTask(TaskFuncBase* func, bool delete_in_dtor = true);
+    bool setTask(TaskFuncBase* func, bool delete_in_dtor = true) override;
 
     /*!
      * @if jp
@@ -233,7 +233,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void setPeriod(double period);
+    void setPeriod(double period) override;
 
     /*!
      * @if jp
@@ -248,7 +248,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void setPeriod(TimeValue& period);
+    void setPeriod(TimeValue& period) override;
 
     /*!
      * @if jp
@@ -257,7 +257,7 @@ namespace coil
      * @brief Validate a Task execute time measurement
      * @endif
      */
-    virtual void executionMeasure(bool value);
+    void executionMeasure(bool value) override;
 
     /*!
      * @if jp
@@ -266,7 +266,7 @@ namespace coil
      * @brief Task execute time measurement period
      * @endif
      */
-    virtual void executionMeasureCount(int n);
+    void executionMeasureCount(int n) override;
 
     /*!
      * @if jp
@@ -275,7 +275,7 @@ namespace coil
      * @brief Validate a Task period time measurement
      * @endif
      */
-    virtual void periodicMeasure(bool value);
+    void periodicMeasure(bool value) override;
 
     /*!
      * @if jp
@@ -284,7 +284,7 @@ namespace coil
      * @brief Task period time measurement count
      * @endif
      */
-    virtual void periodicMeasureCount(int n);
+    void periodicMeasureCount(int n) override;
 
     /*!
      * @if jp
@@ -293,7 +293,7 @@ namespace coil
      * @brief Get a result in task execute time measurement
      * @endif
      */
-    virtual TimeMeasure::Statistics getExecStat();
+    TimeMeasure::Statistics getExecStat() override;
 
     /*!
      * @if jp
@@ -302,7 +302,7 @@ namespace coil
      * @brief Get a result in task period time measurement
      * @endif
      */
-    virtual TimeMeasure::Statistics getPeriodStat();
+    TimeMeasure::Statistics getPeriodStat() override;
 
   protected:
     /*!
@@ -312,7 +312,7 @@ namespace coil
      * @brief Thread execution for PeriodicTask
      * @endif
      */
-    virtual int svc();
+    int svc() override;
 
     /*!
      * @if jp

--- a/src/lib/coil/common/PeriodicTaskBase.h
+++ b/src/lib/coil/common/PeriodicTaskBase.h
@@ -136,7 +136,7 @@ namespace coil
      *
      * @endif
      */
-    virtual ~TaskFunc() {}
+    ~TaskFunc() override {}
 
     /*!
      * @if jp
@@ -153,7 +153,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int operator()()
+    int operator()() override
     {
       return (m_obj->*m_func)();
     }
@@ -209,7 +209,7 @@ namespace coil
      *
      * @endif
      */
-    virtual ~PeriodicTaskBase() {}
+    ~PeriodicTaskBase() override {}
 
     /*!
      * @if jp
@@ -226,7 +226,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void activate() = 0;
+    void activate() override = 0;
 
     /*!
      * @if jp
@@ -243,7 +243,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void finalize() = 0;
+    void finalize() override = 0;
 
     /*!
      * @if jp
@@ -260,7 +260,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int suspend() = 0;
+    int suspend() override = 0;
 
     /*!
      * @if jp
@@ -277,7 +277,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int resume() = 0;
+    int resume() override = 0;
 
     /*!
      * @if jp

--- a/src/lib/coil/common/Timer.h
+++ b/src/lib/coil/common/Timer.h
@@ -88,7 +88,7 @@ namespace coil
      *
      * @endif
      */
-    virtual ~Timer();
+    ~Timer() override;
 
     //============================================================
     // ACE_Task
@@ -116,7 +116,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int open(void *args);
+    int open(void *args) override;
 
     /*!
      * @if jp
@@ -137,7 +137,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int svc();
+    int svc() override;
 
     //============================================================
     // public functions

--- a/src/lib/rtm/ByteDataStreamBase.h
+++ b/src/lib/rtm/ByteDataStreamBase.h
@@ -235,7 +235,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~ByteDataStream()
+    ~ByteDataStream() override
     {
     }
 

--- a/src/lib/rtm/CORBA_CdrMemoryStream.h
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.h
@@ -448,7 +448,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual ~CORBA_CdrSerializer()
+        ~CORBA_CdrSerializer() override
         {
         }
 
@@ -465,7 +465,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual void init(const coil::Properties& prop)
+        void init(const coil::Properties& prop) override
         {
         };
         /*!
@@ -484,7 +484,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual void writeData(const unsigned char* buffer, unsigned long length)
+        void writeData(const unsigned char* buffer, unsigned long length) override
         {
             m_cdr.writeCdrData(buffer, length);
         };
@@ -505,7 +505,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual void readData(unsigned char* buffer, unsigned long length) const
+        void readData(unsigned char* buffer, unsigned long length) const override
         {
             m_cdr.readCdrData(buffer, length);
         };
@@ -523,7 +523,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual unsigned long getDataLength() const
+        unsigned long getDataLength() const override
         {
             return m_cdr.getCdrDataLength();
         };
@@ -543,7 +543,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual bool serialize(const DataType& data)
+        bool serialize(const DataType& data) override
         {
             return m_cdr.serializeCDR(data);
         };
@@ -561,7 +561,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual bool deserialize(DataType& data)
+        bool deserialize(DataType& data) override
         {
             return m_cdr.deserializeCDR(data);
         };
@@ -618,7 +618,7 @@ namespace RTC
          *
          * @endif
          */
-        virtual void isLittleEndian(bool little_endian)
+        void isLittleEndian(bool little_endian) override
         {
             m_cdr.setEndian(little_endian);
         }

--- a/src/lib/rtm/ConfigAdmin.h
+++ b/src/lib/rtm/ConfigAdmin.h
@@ -399,7 +399,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~Config() {}
+    ~Config() override {}
 
     /*!
      * @if jp
@@ -424,7 +424,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool update(const char* val)
+    bool update(const char* val) override
     {
       if (string_value == val) { return true; }
       string_value = val;

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -520,7 +520,7 @@ namespace RTC
      * @brief Destructor
      * @endif
      */
-    virtual ~ConnectorDataListenerT() {}
+    ~ConnectorDataListenerT() override {}
 
     /*!
      * @if jp
@@ -545,8 +545,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode operator()(ConnectorInfo& info,
-                                  ByteData& cdrdata)
+    ReturnCode operator()(ConnectorInfo& info,
+                                  ByteData& cdrdata) override
     {
       DataType data;
       std::string marshaling_type = info.properties.getProperty("marshaling_type", "corba");

--- a/src/lib/rtm/CorbaConsumer.h
+++ b/src/lib/rtm/CorbaConsumer.h
@@ -427,7 +427,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~CorbaConsumer()
+    ~CorbaConsumer() override
     {
       releaseObject();
     };
@@ -460,7 +460,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool setObject(CORBA::Object_ptr obj)
+    bool setObject(CORBA::Object_ptr obj) override
     {
       if (!CorbaConsumerBase::setObject(obj))
         {
@@ -555,7 +555,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void releaseObject()
+    void releaseObject() override
     {
       CorbaConsumerBase::releaseObject();
       m_var = ObjectType::_nil();

--- a/src/lib/rtm/CorbaPort.h
+++ b/src/lib/rtm/CorbaPort.h
@@ -663,7 +663,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~CorbaPort();
+    ~CorbaPort() override;
 
     /*!
      * @if jp
@@ -861,8 +861,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    publishInterfaces(ConnectorProfile& connector_profile);
+    ReturnCode_t
+    publishInterfaces(ConnectorProfile& connector_profile) override;
 
     /*!
      * @if jp
@@ -996,8 +996,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    subscribeInterfaces(const ConnectorProfile& connector_profile);
+    ReturnCode_t
+    subscribeInterfaces(const ConnectorProfile& connector_profile) override;
 
     /*!
      * @if jp
@@ -1020,8 +1020,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void
-    unsubscribeInterfaces(const ConnectorProfile& connector_profile);
+    void
+    unsubscribeInterfaces(const ConnectorProfile& connector_profile) override;
 
     //============================================================
     // Local operations
@@ -1042,7 +1042,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void activateInterfaces();
+    void activateInterfaces() override;
 
     /*!
      * @if jp
@@ -1060,7 +1060,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void deactivateInterfaces();
+    void deactivateInterfaces() override;
 
   protected:
     /*!

--- a/src/lib/rtm/DataFlowComponentBase.h
+++ b/src/lib/rtm/DataFlowComponentBase.h
@@ -102,7 +102,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~DataFlowComponentBase();
+    ~DataFlowComponentBase() override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/DirectInPortBase.h
+++ b/src/lib/rtm/DirectInPortBase.h
@@ -76,7 +76,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-    virtual ~DirectInPortBase(){};
+    ~DirectInPortBase() override{};
 
 
 

--- a/src/lib/rtm/DirectOutPortBase.h
+++ b/src/lib/rtm/DirectOutPortBase.h
@@ -76,7 +76,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual ~DirectOutPortBase()
+	~DirectOutPortBase() override
 	{
 	}
 	/*!

--- a/src/lib/rtm/ECFactory.h
+++ b/src/lib/rtm/ECFactory.h
@@ -264,7 +264,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ECFactoryCXX();
+    ~ECFactoryCXX() override;
 
     /*!
      * @if jp
@@ -285,7 +285,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual const char* name();
+    const char* name() override;
 
     /*!
      * @if jp
@@ -306,7 +306,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ExecutionContextBase* create();
+    ExecutionContextBase* create() override;
 
     /*!
      * @if jp
@@ -327,7 +327,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void destroy(ExecutionContextBase* ec);
+    void destroy(ExecutionContextBase* ec) override;
 
   protected:
     /*!

--- a/src/lib/rtm/EventBase.h
+++ b/src/lib/rtm/EventBase.h
@@ -52,8 +52,8 @@ namespace RTC
           m_eb(eb)
       {
       };
-      virtual ~Event0() {};
-      virtual void operator()()
+      ~Event0() override {};
+      void operator()() override
       {
           m_eb->run();
       };
@@ -69,8 +69,8 @@ namespace RTC
           m_eb(eb), m_data(data)
       {
       };
-      virtual ~Event1() {};
-      virtual void operator()()
+      ~Event1() override {};
+      void operator()() override
       {
           m_eb->run(m_data);
       };

--- a/src/lib/rtm/EventPort.h
+++ b/src/lib/rtm/EventPort.h
@@ -55,10 +55,10 @@ namespace RTC
                  RingBuffer<EventBase*> &buffer)
       : m_fsm(fsm), m_eventName(event_name), m_handler(handler), m_buffer(buffer) {}
 
-    virtual ~EventBinder0() {}
+    ~EventBinder0() override {}
 
-    virtual ReturnCode operator()(ConnectorInfo& info,
-                                  ByteData&  /*data*/)
+    ReturnCode operator()(ConnectorInfo& info,
+                                  ByteData&  /*data*/) override
     {
       if (info.properties["fsm_event_name"] == m_eventName ||
           info.name == m_eventName)
@@ -71,7 +71,7 @@ namespace RTC
       return NO_CHANGE;
     }
 
-    virtual void run()
+    void run() override
     {
         
         m_fsm.dispatch(Macho::Event(m_handler));
@@ -96,9 +96,9 @@ namespace RTC
                  RingBuffer<EventBase*> &buffer)
       : m_fsm(fsm), m_eventName(event_name), m_handler(handler), m_buffer(buffer) {}
 
-    virtual ~EventBinder1() {}
+    ~EventBinder1() override {}
 
-    virtual ReturnCode operator()(ConnectorInfo& info, P0& data)
+    ReturnCode operator()(ConnectorInfo& info, P0& data) override
     {
       if (info.properties["fsm_event_name"] == m_eventName ||
           info.name == m_eventName)
@@ -111,7 +111,7 @@ namespace RTC
       return NO_CHANGE;
     }
 
-    virtual void run(P0& data)
+    void run(P0& data) override
     {
         m_fsm.dispatch(Macho::Event(m_handler, data));
     }
@@ -129,11 +129,11 @@ namespace RTC
   public:
       EventConnListener(RingBuffer<EventBase*>&buffer, CdrBufferBase* m_thebuffer) :
           m_buffer(buffer), m_thebuffer(m_thebuffer) {}
-      virtual ~EventConnListener()
+      ~EventConnListener() override
       {
       }
 
-      virtual ReturnCode operator()(ConnectorInfo& info)
+      ReturnCode operator()(ConnectorInfo& info) override
       {
           coil::Properties prop;
           prop["write.full_policy"] = "do_nothing";
@@ -282,7 +282,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~EventInPort(){};
+    ~EventInPort() override{};
 
     /*!
      * @if jp
@@ -308,7 +308,7 @@ namespace RTC
       return m_name.c_str();
     }
 
-    virtual void init(coil::Properties& prop)
+    void init(coil::Properties& prop) override
     {
         InPortBase::init(prop);
         this->addConnectorListener
@@ -332,7 +332,7 @@ namespace RTC
         (ON_RECEIVED,
          new EventBinder0<FsmType, TOP, R>(m_fsm, name, handler, m_buffer));
     }
-    virtual bool read(std::string  /*name*/="") { return true; }
+    bool read(std::string  /*name*/="") override { return true; }
   private:
     /*!
      * @if jp

--- a/src/lib/rtm/ExtTrigExecutionContext.h
+++ b/src/lib/rtm/ExtTrigExecutionContext.h
@@ -92,7 +92,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~ExtTrigExecutionContext();
+    ~ExtTrigExecutionContext() override;
 
     /*!
      * @if jp
@@ -118,7 +118,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual int open(void *args);
+    int open(void *args) override;
 
     /*!
      * @if jp
@@ -140,7 +140,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual int svc();
+    int svc() override;
 
     /*!
      * @if jp
@@ -169,7 +169,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual int close(unsigned long flags);
+    int close(unsigned long flags) override;
 
     //============================================================
     // ExtTrigExecutionContextService
@@ -187,8 +187,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void tick()
-      throw (CORBA::SystemException);
+    void tick()
+      throw (CORBA::SystemException) override;
 
     //============================================================
     // ExecutionContextService
@@ -217,8 +217,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Boolean is_running()
-      throw (CORBA::SystemException);
+    CORBA::Boolean is_running()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -247,8 +247,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t start()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t start()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -276,8 +276,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t stop()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -299,8 +299,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Double get_rate()
-      throw (CORBA::SystemException);
+    CORBA::Double get_rate()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -331,8 +331,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -367,9 +367,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -403,9 +403,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -438,9 +438,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -468,9 +468,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::LifeCycleState
+    RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -491,8 +491,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException);
+    RTC::ExecutionKind get_kind()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -525,8 +525,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -558,9 +558,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -581,40 +581,40 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException);
+    RTC::ExecutionContextProfile* get_profile()
+      throw (CORBA::SystemException) override;
 
   protected:
     /*!
      * @brief onStarted() template function
      */
-    virtual RTC::ReturnCode_t onStarted();
+    RTC::ReturnCode_t onStarted() override;
     // template virtual functions adding/removing component
     /*!
      * @brief onAddedComponent() template function
      */
-     virtual RTC::ReturnCode_t
-     onAddedComponent(RTC::LightweightRTObject_ptr rtobj);
+     RTC::ReturnCode_t
+     onAddedComponent(RTC::LightweightRTObject_ptr rtobj) override;
     /*!
      * @brief onRemovedComponent() template function
      */
-    virtual RTC::ReturnCode_t
-    onRemovedComponent(RTC::LightweightRTObject_ptr rtobj);
+    RTC::ReturnCode_t
+    onRemovedComponent(RTC::LightweightRTObject_ptr rtobj) override;
     /*!
      * @brief onWaitingActivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingDeactivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingReset() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count) override;
 
   private:
     bool threadRunning()

--- a/src/lib/rtm/Factory.h
+++ b/src/lib/rtm/Factory.h
@@ -344,7 +344,7 @@ namespace RTC
                RtcDeleteFunc delete_func,
                RTM::NumberingPolicyBase* policy = new RTM::ProcessUniquePolicy());
 
-    virtual ~FactoryCXX()
+    ~FactoryCXX() override
     {
       delete m_policy;
     }
@@ -372,7 +372,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTObject_impl* create(Manager* mgr);
+    RTObject_impl* create(Manager* mgr) override;
 
     /*!
      * @if jp
@@ -393,7 +393,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void destroy(RTObject_impl* comp);
+    void destroy(RTObject_impl* comp) override;
 
   protected:
     /*!

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -183,7 +183,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPort() {}
+    ~InPort() override {}
 
     /*!
      * @if jp
@@ -297,7 +297,7 @@ namespace RTC
         RTC_DEBUG(("isNew() = false, no readable data"));
         return false;
     }
-    virtual bool isNew()
+    bool isNew() override
     {
       RTC_TRACE(("isNew()"));
 
@@ -419,7 +419,7 @@ namespace RTC
         RTC_DEBUG(("isEmpty() = false, no readable data"));
         return false;
     }
-    virtual bool isEmpty()
+    bool isEmpty() override
     {
       RTC_TRACE(("isEmpty()"));
       if (m_directNewData == true) { return false; }
@@ -529,7 +529,7 @@ namespace RTC
      *
      * @endif
      */
-    bool read(std::string name="")
+    bool read(std::string name="") override
     {
       RTC_TRACE(("DataType read()"));
 

--- a/src/lib/rtm/InPortBase.h
+++ b/src/lib/rtm/InPortBase.h
@@ -113,7 +113,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortBase();
+    ~InPortBase() override;
 
     /*!
      * @if jp
@@ -356,7 +356,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void activateInterfaces();
+    void activateInterfaces() override;
 
     /*!
      * @if jp
@@ -374,7 +374,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void deactivateInterfaces();
+    void deactivateInterfaces() override;
 
     /*!
      * @if jp
@@ -601,9 +601,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
+    ReturnCode_t
     connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -623,8 +623,8 @@ namespace RTC
      * @endif
      */
     virtual ConnectorListeners& getListeners();
-    virtual ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-		throw (CORBA::SystemException);
+    ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
+		throw (CORBA::SystemException) override;
 
   protected:
     /*!
@@ -655,8 +655,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    publishInterfaces(ConnectorProfile& cprof);
+    ReturnCode_t
+    publishInterfaces(ConnectorProfile& cprof) override;
 
     /*!
      * @if jp
@@ -685,8 +685,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    subscribeInterfaces(const ConnectorProfile& cprof);
+    ReturnCode_t
+    subscribeInterfaces(const ConnectorProfile& cprof) override;
 
     /*!
      * @if jp
@@ -709,8 +709,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void
-    unsubscribeInterfaces(const ConnectorProfile& connector_profile);
+    void
+    unsubscribeInterfaces(const ConnectorProfile& connector_profile) override;
 
 
     /*!

--- a/src/lib/rtm/InPortConnector.h
+++ b/src/lib/rtm/InPortConnector.h
@@ -80,7 +80,7 @@ namespace RTC
      * @brief Destructor
      * @endif
      */
-    virtual ~InPortConnector();
+    ~InPortConnector() override;
 
    /*!
      * @if jp
@@ -99,7 +99,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual const ConnectorInfo& profile();
+    const ConnectorInfo& profile() override;
 
     /*!
      * @if jp
@@ -118,7 +118,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual const char* id();
+    const char* id() override;
 
     /*!
      * @if jp
@@ -137,7 +137,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual const char* name();
+    const char* name() override;
 
     /*!
      * @if jp
@@ -156,7 +156,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode disconnect() = 0;
+    ReturnCode disconnect() override = 0;
 
     /*!
      * @if jp
@@ -175,7 +175,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual CdrBufferBase* getBuffer();
+    CdrBufferBase* getBuffer() override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.h
@@ -92,7 +92,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortCorbaCdrConsumer();
+    ~InPortCorbaCdrConsumer() override;
 
     /*!
      * @if jp
@@ -121,7 +121,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -155,7 +155,7 @@ namespace RTC
      *
      * @endif
      */
-	virtual ReturnCode put(ByteData& data);
+	ReturnCode put(ByteData& data) override;
 
     /*!
      * @if jp
@@ -180,7 +180,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void publishInterfaceProfile(SDOPackage::NVList& properties);
+    void publishInterfaceProfile(SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -204,7 +204,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -223,7 +223,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -92,7 +92,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortCorbaCdrProvider();
+    ~InPortCorbaCdrProvider() override;
 
     /*!
      * @if jp
@@ -121,7 +121,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -148,7 +148,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(BufferBase<ByteData>* buffer);
+    void setBuffer(BufferBase<ByteData>* buffer) override;
 
     /*!
      * @if jp
@@ -198,8 +198,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -225,7 +225,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setConnector(InPortConnector* connector);
+    void setConnector(InPortConnector* connector) override;
 
     /*!
      * @if jp
@@ -244,8 +244,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::OpenRTM::PortStatus put(const ::OpenRTM::CdrData& data)
-      throw (CORBA::SystemException);
+    ::OpenRTM::PortStatus put(const ::OpenRTM::CdrData& data)
+      throw (CORBA::SystemException) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortDSConsumer.h
+++ b/src/lib/rtm/InPortDSConsumer.h
@@ -90,7 +90,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortDSConsumer();
+    ~InPortDSConsumer() override;
 
     /*!
      * @if jp
@@ -119,7 +119,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -153,7 +153,7 @@ namespace RTC
      *
      * @endif
      */
-	virtual ReturnCode put(ByteData& data);
+	ReturnCode put(ByteData& data) override;
 
     /*!
      * @if jp
@@ -178,7 +178,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void publishInterfaceProfile(SDOPackage::NVList& properties);
+    void publishInterfaceProfile(SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -202,7 +202,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -221,7 +221,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -90,7 +90,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortDSProvider();
+    ~InPortDSProvider() override;
 
     /*!
      * @if jp
@@ -119,7 +119,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -146,7 +146,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(BufferBase<ByteData>* buffer);
+    void setBuffer(BufferBase<ByteData>* buffer) override;
 
     /*!
      * @if jp
@@ -196,8 +196,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -223,7 +223,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setConnector(InPortConnector* connector);
+    void setConnector(InPortConnector* connector) override;
 
     /*!
      * @if jp
@@ -242,8 +242,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::RTC::PortStatus push(const ::RTC::OctetSeq& data)
-      throw (CORBA::SystemException);
+    ::RTC::PortStatus push(const ::RTC::OctetSeq& data)
+      throw (CORBA::SystemException) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortDirectConsumer.h
+++ b/src/lib/rtm/InPortDirectConsumer.h
@@ -91,7 +91,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortDirectConsumer();
+    ~InPortDirectConsumer() override;
 
     /*!
      * @if jp
@@ -120,7 +120,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -154,7 +154,7 @@ namespace RTC
      *
      * @endif
      */
-	virtual ReturnCode put(ByteData& data);
+	ReturnCode put(ByteData& data) override;
 
     /*!
      * @if jp
@@ -179,7 +179,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void publishInterfaceProfile(SDOPackage::NVList& properties);
+    void publishInterfaceProfile(SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -203,7 +203,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -222,7 +222,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
 
   private:
     mutable Logger rtclog;

--- a/src/lib/rtm/InPortDirectProvider.h
+++ b/src/lib/rtm/InPortDirectProvider.h
@@ -88,7 +88,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortDirectProvider();
+    ~InPortDirectProvider() override;
 
     /*!
      * @if jp
@@ -117,7 +117,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -144,7 +144,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(BufferBase<ByteData>* buffer);
+    void setBuffer(BufferBase<ByteData>* buffer) override;
 
     /*!
      * @if jp
@@ -194,8 +194,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -221,7 +221,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setConnector(InPortConnector* connector);
+    void setConnector(InPortConnector* connector) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortPullConnector.h
+++ b/src/lib/rtm/InPortPullConnector.h
@@ -150,7 +150,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortPullConnector();
+    ~InPortPullConnector() override;
 
     /*!
      * @if jp
@@ -183,7 +183,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode read(ByteDataStreamBase* data);
+    ReturnCode read(ByteDataStreamBase* data) override;
 
     /*!
      * @if jp
@@ -198,7 +198,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode disconnect();
+    ReturnCode disconnect() override;
 
     /*!
      * @if jp
@@ -214,7 +214,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void activate() {}  // do nothing
+    void activate() override {}  // do nothing
 
     /*!
      * @if jp
@@ -230,7 +230,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void deactivate() {}  // do nothing
+    void deactivate() override {}  // do nothing
 
   protected:
     /*!

--- a/src/lib/rtm/InPortPushConnector.h
+++ b/src/lib/rtm/InPortPushConnector.h
@@ -144,7 +144,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortPushConnector();
+    ~InPortPushConnector() override;
 
     /*!
      * @if jp
@@ -178,7 +178,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode read(ByteDataStreamBase* data);
+    ReturnCode read(ByteDataStreamBase* data) override;
 
     /*!
      * @if jp
@@ -199,7 +199,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode disconnect();
+    ReturnCode disconnect() override;
 
     /*!
      * @if jp
@@ -215,7 +215,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void activate() {}  // do nothing
+    void activate() override {}  // do nothing
 
     /*!
      * @if jp
@@ -231,7 +231,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void deactivate() {}  // do nothing
+    void deactivate() override {}  // do nothing
 
   protected:
     /*!
@@ -255,7 +255,7 @@ namespace RTC
      */
     virtual CdrBufferBase* createBuffer(ConnectorInfo& info);
 
-    virtual BufferStatus::Enum write(ByteData &cdr);
+    BufferStatus::Enum write(ByteData &cdr) override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortSHMConsumer.h
+++ b/src/lib/rtm/InPortSHMConsumer.h
@@ -91,7 +91,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortSHMConsumer();
+    ~InPortSHMConsumer() override;
 
     /*!
      * @if jp
@@ -111,7 +111,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
     /*!
      * @if jp
      * @brief 接続先へのデータ送信
@@ -130,7 +130,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual InPortConsumer::ReturnCode put(ByteData& data);
+    InPortConsumer::ReturnCode put(ByteData& data) override;
     /*!
      * @if jp
      * @brief 
@@ -147,10 +147,10 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool setObject(CORBA::Object_ptr obj);
-	virtual void publishInterfaceProfile(SDOPackage::NVList& properties);
-	virtual bool subscribeInterface(const SDOPackage::NVList& properties);
-	virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+    bool setObject(CORBA::Object_ptr obj) override;
+	void publishInterfaceProfile(SDOPackage::NVList& properties) override;
+	bool subscribeInterface(const SDOPackage::NVList& properties) override;
+	void unsubscribeInterface(const SDOPackage::NVList& properties) override;
   
 private:
 	bool subscribeFromIor(const SDOPackage::NVList& properties);

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -86,7 +86,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortSHMProvider();
+    ~InPortSHMProvider() override;
 
     /*!
      * @if jp
@@ -104,7 +104,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -121,7 +121,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(BufferBase<ByteData>* buffer);
+    void setBuffer(BufferBase<ByteData>* buffer) override;
 
     /*!
      * @if jp
@@ -143,8 +143,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 	/*!
 	* @if jp
 	* @brief Connectorを設定する。
@@ -162,7 +162,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual void setConnector(InPortConnector* connector);
+	void setConnector(InPortConnector* connector) override;
 
     /*!
      * @if jp
@@ -181,8 +181,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::OpenRTM::PortStatus put()
-      throw (CORBA::SystemException);
+    ::OpenRTM::PortStatus put()
+      throw (CORBA::SystemException) override;
     
   private:
 

--- a/src/lib/rtm/LogstreamFile.h
+++ b/src/lib/rtm/LogstreamFile.h
@@ -75,7 +75,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual ~FileStreamBase() {};
+      ~FileStreamBase() override {};
       /*!
        * @if jp
        *
@@ -115,7 +115,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual void flush();
+      void flush() override;
       /*!
        * @if jp
        *
@@ -179,7 +179,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual void write(int level, const std::string &name, const std::string &date, const std::string &mes);
+      void write(int level, const std::string &name, const std::string &date, const std::string &mes) override;
       
   protected:
       std::basic_ostream<char> *m_stream;
@@ -235,7 +235,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual ~StdoutStream();
+      ~StdoutStream() override;
 
       
       
@@ -290,7 +290,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual ~StderrStream();
+      ~StderrStream() override;
       
       
 
@@ -349,7 +349,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual ~FileStream();
+      ~FileStream() override;
       /*!
        * @if jp
        *
@@ -438,7 +438,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~LogstreamFile();
+    ~LogstreamFile() override;
 
     /*!
      * @if jp
@@ -461,7 +461,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool init(const coil::Properties& prop);
+    bool init(const coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -482,7 +482,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual coil::LogStreamBuffer* getStreamBuffer();
+    coil::LogStreamBuffer* getStreamBuffer() override;
 
   protected:
     static coil::vstring s_files;

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -2305,7 +2305,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual int open(void * /*args*/)
+      int open(void * /*args*/) override
       {
         activate();
         return 0;
@@ -2328,7 +2328,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual int svc()
+      int svc() override
       {
         m_pORB->run();
 //        Manager::instance().shutdown();
@@ -2356,7 +2356,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual int close(unsigned long  /*flags*/)
+      int close(unsigned long  /*flags*/) override
       {
         return 0;
       }
@@ -2457,7 +2457,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual int open(void * /*args*/)
+      int open(void * /*args*/) override
       {
         activate();
         return 0;
@@ -2480,7 +2480,7 @@ namespace RTC
        *
        * @endif
        */
-      virtual int svc()
+      int svc() override
       {
         coil::sleep(m_waittime);
         Manager::instance().shutdown();

--- a/src/lib/rtm/ManagerActionListener.h
+++ b/src/lib/rtm/ManagerActionListener.h
@@ -130,7 +130,7 @@ namespace RTM
     : public ::RTM::util::ListenerHolder<ManagerActionListener>
   {
   public:
-    virtual ~ManagerActionListenerHolder();
+    ~ManagerActionListenerHolder() override;
 
     /*!
      * @if jp
@@ -272,7 +272,7 @@ namespace RTM
      * @brief Destructor
      * @endif
      */
-    virtual ~ModuleActionListenerHolder();
+    ~ModuleActionListenerHolder() override;
 
     /*!
      * @if jp
@@ -457,7 +457,7 @@ namespace RTM
      * @brief Destructor
      * @endif
      */
-    virtual ~RtcLifecycleActionListenerHolder();
+    ~RtcLifecycleActionListenerHolder() override;
 
 
     /*!
@@ -641,7 +641,7 @@ namespace RTM
      * @brief Destructor
      * @endif
      */
-    virtual ~NamingActionListenerHolder();
+    ~NamingActionListenerHolder() override;
 
     /*!
      * @if jp
@@ -853,7 +853,7 @@ namespace RTM
      * @brief Destructor
      * @endif
      */
-    virtual ~LocalServiceActionListenerHolder();
+    ~LocalServiceActionListenerHolder() override;
 
     // registration instance of service to svc admin
     /*!

--- a/src/lib/rtm/ManagerServant.h
+++ b/src/lib/rtm/ManagerServant.h
@@ -93,7 +93,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual ~ManagerServant();
+    ~ManagerServant() override;
 
     /*!
      * @if jp
@@ -119,7 +119,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t load_module(const char* pathname, const char* initfunc);
+    RTC::ReturnCode_t load_module(const char* pathname, const char* initfunc) override;
 
     /*!
      * @if jp
@@ -140,7 +140,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t unload_module(const char* pathname);
+    RTC::ReturnCode_t unload_module(const char* pathname) override;
 
     /*!
      * @if jp
@@ -159,7 +159,7 @@ namespace RTM
      *
      * @endif
      */
-    RTM::ModuleProfileList* get_loadable_modules();
+    RTM::ModuleProfileList* get_loadable_modules() override;
 
     /*!
      * @if jp
@@ -178,7 +178,7 @@ namespace RTM
      *
      * @endif
      */
-    RTM::ModuleProfileList* get_loaded_modules();
+    RTM::ModuleProfileList* get_loaded_modules() override;
 
     // component 関連
     /*!
@@ -200,7 +200,7 @@ namespace RTM
      *
      * @endif
      */
-    RTM::ModuleProfileList* get_factory_profiles();
+    RTM::ModuleProfileList* get_factory_profiles() override;
 
     /*!
      * @if jp
@@ -220,7 +220,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::RTObject_ptr create_component(const char* module_name);
+    RTC::RTObject_ptr create_component(const char* module_name) override;
 
     /*!
      * @if jp
@@ -240,7 +240,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t delete_component(const char* instance_name);
+    RTC::ReturnCode_t delete_component(const char* instance_name) override;
 
     /*!
      * @if jp
@@ -259,7 +259,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::RTCList* get_components();
+    RTC::RTCList* get_components() override;
 
     /*!
      * @if jp
@@ -280,7 +280,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ComponentProfileList* get_component_profiles();
+    RTC::ComponentProfileList* get_component_profiles() override;
 
     // manager 基本
     /*!
@@ -300,7 +300,7 @@ namespace RTM
      *
      * @endif
      */
-    RTM::ManagerProfile* get_profile();
+    RTM::ManagerProfile* get_profile() override;
 
     /*!
      * @if jp
@@ -319,7 +319,7 @@ namespace RTM
      *
      * @endif
      */
-    RTM::NVList* get_configuration();
+    RTM::NVList* get_configuration() override;
 
     /*!
      * @if jp
@@ -342,7 +342,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t set_configuration(const char* name, const char* value);
+    RTC::ReturnCode_t set_configuration(const char* name, const char* value) override;
 
     /*!
      * @if jp
@@ -363,7 +363,7 @@ namespace RTM
      *
      * @endif
      */
-    ::CORBA::Boolean is_master();
+    ::CORBA::Boolean is_master() override;
 
     /*!
      * @if jp
@@ -386,7 +386,7 @@ namespace RTM
      *
      * @endif
      */
-    RTM::ManagerList* get_master_managers();
+    RTM::ManagerList* get_master_managers() override;
 
     /*!
      * @if jp
@@ -411,7 +411,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t add_master_manager(RTM::Manager_ptr mgr);
+    RTC::ReturnCode_t add_master_manager(RTM::Manager_ptr mgr) override;
 
     /*!
      * @if jp
@@ -432,7 +432,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t remove_master_manager(RTM::Manager_ptr mgr);
+    RTC::ReturnCode_t remove_master_manager(RTM::Manager_ptr mgr) override;
 
     /*!
      * @if jp
@@ -455,7 +455,7 @@ namespace RTM
      *
      * @endif
      */
-    RTM::ManagerList* get_slave_managers();
+    RTM::ManagerList* get_slave_managers() override;
 
     /*!
      * @if jp
@@ -476,7 +476,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t add_slave_manager(RTM::Manager_ptr mgr);
+    RTC::ReturnCode_t add_slave_manager(RTM::Manager_ptr mgr) override;
 
     /*!
      * @if jp
@@ -497,7 +497,7 @@ namespace RTM
      *
      * @endif
      */
-    RTC::ReturnCode_t remove_slave_manager(RTM::Manager_ptr mgr);
+    RTC::ReturnCode_t remove_slave_manager(RTM::Manager_ptr mgr) override;
 
     /*!
      * @if jp
@@ -508,7 +508,7 @@ namespace RTM
      * @return ReturnCode_t
      * @endif
      */
-    RTC::ReturnCode_t fork();
+    RTC::ReturnCode_t fork() override;
     /*!
      * @if jp
      * @brief shutdownする
@@ -518,7 +518,7 @@ namespace RTM
      * @return ReturnCode_t
      * @endif
      */
-    RTC::ReturnCode_t shutdown();
+    RTC::ReturnCode_t shutdown() override;
     /*!
      * @if jp
      * @brief 再起動する。
@@ -528,7 +528,7 @@ namespace RTM
      * @return ReturnCode_t
      * @endif
      */
-    RTC::ReturnCode_t restart();
+    RTC::ReturnCode_t restart() override;
 
      /*!
      * @if jp
@@ -545,7 +545,7 @@ namespace RTM
      *
      * @endig
      */
-    RTC::RTCList* get_components_by_name(const char* name);
+    RTC::RTCList* get_components_by_name(const char* name) override;
 
     /*!
      * @if jp
@@ -556,7 +556,7 @@ namespace RTM
      * @return RTC reference
      * @endif
      */
-    CORBA::Object_ptr get_service(const char* name);
+    CORBA::Object_ptr get_service(const char* name) override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/MultilayerCompositeEC.h
+++ b/src/lib/rtm/MultilayerCompositeEC.h
@@ -89,7 +89,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual ~MultilayerCompositeEC();
+    ~MultilayerCompositeEC() override;
 
     /*!
      * @if jp
@@ -104,7 +104,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual  void init(coil::Properties& props);
+     void init(coil::Properties& props) override;
 
 
     /*!
@@ -126,7 +126,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual int svc();
+    int svc() override;
 
     /*!
      * @if jp
@@ -141,7 +141,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t bindComponent(RTC::RTObject_impl* rtc);
+    RTC::ReturnCode_t bindComponent(RTC::RTObject_impl* rtc) override;
 
 
     virtual RTC_impl::RTObjectStateMachine* findComponent(RTC::LightweightRTObject_ptr comp);

--- a/src/lib/rtm/NamingManager.h
+++ b/src/lib/rtm/NamingManager.h
@@ -284,7 +284,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~NamingOnCorba() {}
+    ~NamingOnCorba() override {}
 
     /*!
      * @if jp
@@ -309,8 +309,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void bindObject(const char* name, const RTObject_impl* rtobj);
-    virtual void bindObject(const char* name, const PortBase* port);
+    void bindObject(const char* name, const RTObject_impl* rtobj) override;
+    void bindObject(const char* name, const PortBase* port) override;
 
     /*!
      * @if jp
@@ -329,7 +329,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void bindObject(const char* name, const RTM::ManagerServant* mgr);
+    void bindObject(const char* name, const RTM::ManagerServant* mgr) override;
 
     /*!
      * @if jp
@@ -350,7 +350,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unbindObject(const char* name);
+    void unbindObject(const char* name) override;
 
     /*!
      * @if jp
@@ -367,7 +367,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool isAlive();
+    bool isAlive() override;
 	/*!
 	 * @if jp
 	 *
@@ -406,7 +406,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual RTC::RTCList string_to_component(std::string name);
+	RTC::RTCList string_to_component(std::string name) override;
     CorbaNaming& getCorbaNaming() { return m_cosnaming; }
 
   private:
@@ -474,7 +474,7 @@ namespace RTC
      *
      * @endif
      */
-	 virtual ~NamingOnManager(){};
+	 ~NamingOnManager() override{};
     
     /*!
      * @if jp
@@ -499,8 +499,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void bindObject(const char* name, const RTObject_impl* rtobj);
-    virtual void bindObject(const char* name, const PortBase* port);
+    void bindObject(const char* name, const RTObject_impl* rtobj) override;
+    void bindObject(const char* name, const PortBase* port) override;
 
     /*!
      * @if jp
@@ -519,7 +519,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void bindObject(const char* name, const RTM::ManagerServant* mgr);
+    void bindObject(const char* name, const RTM::ManagerServant* mgr) override;
 
     /*!
      * @if jp
@@ -540,7 +540,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unbindObject(const char* name);
+    void unbindObject(const char* name) override;
 
     /*!
      * @if jp
@@ -557,7 +557,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool isAlive();
+    bool isAlive() override;
 	/*!
 	* @if jp
 	*
@@ -576,7 +576,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	RTC::RTCList string_to_component(std::string name);
+	RTC::RTCList string_to_component(std::string name) override;
 	/*!
 	* @if jp
 	*

--- a/src/lib/rtm/NamingServiceNumberingPolicy.h
+++ b/src/lib/rtm/NamingServiceNumberingPolicy.h
@@ -78,7 +78,7 @@ namespace RTM
      *
      * @endif
      */
-	  virtual ~NamingServiceNumberingPolicy(){};
+	  ~NamingServiceNumberingPolicy() override{};
     
     /*!
      * @if jp
@@ -105,7 +105,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual std::string onCreate(void* obj);
+    std::string onCreate(void* obj) override;
     
     /*!
      * @if jp
@@ -128,7 +128,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual void onDelete(void* obj);
+    void onDelete(void* obj) override;
 
 
     

--- a/src/lib/rtm/NodeNumberingPolicy.h
+++ b/src/lib/rtm/NodeNumberingPolicy.h
@@ -79,7 +79,7 @@ namespace RTM
      *
      * @endif
      */
-	  virtual ~NodeNumberingPolicy(){};
+	  ~NodeNumberingPolicy() override{};
     
     /*!
      * @if jp
@@ -106,7 +106,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual std::string onCreate(void* obj);
+    std::string onCreate(void* obj) override;
     
     /*!
      * @if jp
@@ -129,7 +129,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual void onDelete(void* obj);
+    void onDelete(void* obj) override;
     
   protected:
 	  /*!

--- a/src/lib/rtm/NumberingPolicy.h
+++ b/src/lib/rtm/NumberingPolicy.h
@@ -81,7 +81,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual ~ProcessUniquePolicy(){};
+    ~ProcessUniquePolicy() override{};
     
     /*!
      * @if jp
@@ -108,7 +108,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual std::string onCreate(void* obj);
+    std::string onCreate(void* obj) override;
     
     /*!
      * @if jp
@@ -131,7 +131,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual void onDelete(void* obj);
+    void onDelete(void* obj) override;
     
   protected:
     /*!

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -72,7 +72,7 @@ namespace RTC
      * @brief Destructor
      * @endif
      */
-    virtual ~OpenHRPExecutionContext();
+    ~OpenHRPExecutionContext() override;
 
 
     //============================================================
@@ -91,8 +91,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void tick()
-      throw (CORBA::SystemException);
+    void tick()
+      throw (CORBA::SystemException) override;
 
     //============================================================
     // ExecutionContextService
@@ -121,8 +121,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Boolean is_running()
-      throw (CORBA::SystemException);
+    CORBA::Boolean is_running()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -151,8 +151,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t start()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t start()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -180,8 +180,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t stop()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -203,8 +203,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Double get_rate()
-      throw (CORBA::SystemException);
+    CORBA::Double get_rate()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -235,8 +235,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -271,9 +271,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -307,9 +307,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -342,9 +342,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -372,9 +372,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::LifeCycleState
+    RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -395,8 +395,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException);
+    RTC::ExecutionKind get_kind()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -429,8 +429,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -462,9 +462,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -485,20 +485,20 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException);
+    RTC::ExecutionContextProfile* get_profile()
+      throw (CORBA::SystemException) override;
   protected:
     // template virtual functions adding/removing component	
     /*!
     * @brief onAddedComponent() template function
     */
-    virtual RTC::ReturnCode_t
-		onAddedComponent(RTC::LightweightRTObject_ptr rtobj);
+    RTC::ReturnCode_t
+		onAddedComponent(RTC::LightweightRTObject_ptr rtobj) override;
     /*!
     * @brief onRemovedComponent() template function
     */
-    virtual RTC::ReturnCode_t
-		onRemovedComponent(RTC::LightweightRTObject_ptr rtobj);
+    RTC::ReturnCode_t
+		onRemovedComponent(RTC::LightweightRTObject_ptr rtobj) override;
     /*!
      * @brief Mutex to gurad tick() reenter.
      */

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -172,7 +172,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPort()
+    ~OutPort() override
     {
     }
 
@@ -316,7 +316,7 @@ namespace RTC
      *
      * @endif
      */
-    bool write()
+    bool write() override
     {
       return write(m_value);
     }
@@ -512,17 +512,17 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual void read(DataType& data)
+	void read(DataType& data) override
 	{
 		Guard guard(m_valueMutex);
 		m_directNewData = false;
 		data = m_directValue;
 	}
-	virtual bool isEmpty()
+	bool isEmpty() override
 	{
 		return !m_directNewData;
 	}
-	virtual bool isNew()
+	bool isNew() override
 	{
 		return m_directNewData;
 	}

--- a/src/lib/rtm/OutPortBase.h
+++ b/src/lib/rtm/OutPortBase.h
@@ -274,7 +274,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortBase();
+    ~OutPortBase() override;
 
     /*!
      * @if jp
@@ -528,7 +528,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void activateInterfaces();
+    void activateInterfaces() override;
 
     /*!
      * @if jp
@@ -546,7 +546,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void deactivateInterfaces();
+    void deactivateInterfaces() override;
 
 
     /*!
@@ -774,9 +774,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
+    ReturnCode_t
     connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
 	/*!
 	* @if jp
@@ -861,8 +861,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    publishInterfaces(ConnectorProfile& cprof);
+    ReturnCode_t
+    publishInterfaces(ConnectorProfile& cprof) override;
 
     /*! @if jp
      *
@@ -902,8 +902,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t
-    subscribeInterfaces(const ConnectorProfile& cprof);
+    ReturnCode_t
+    subscribeInterfaces(const ConnectorProfile& cprof) override;
 
     /*!
      * @if jp
@@ -936,8 +936,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void
-    unsubscribeInterfaces(const ConnectorProfile& connector_profile);
+    void
+    unsubscribeInterfaces(const ConnectorProfile& connector_profile) override;
 
     /*!
      * @if jp
@@ -1034,8 +1034,8 @@ namespace RTC
                                       coil::Properties& prop,
                                       OutPortProvider* provider);
 
-    virtual ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-		throw (CORBA::SystemException);
+    ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
+		throw (CORBA::SystemException) override;
 
 
   protected:

--- a/src/lib/rtm/OutPortConnector.h
+++ b/src/lib/rtm/OutPortConnector.h
@@ -75,7 +75,7 @@ namespace RTC
      * @brief Destructor
      * @endif
      */
-    virtual ~OutPortConnector();
+    ~OutPortConnector() override;
    /*!
      * @if jp
      * @brief Profile 取得
@@ -89,7 +89,7 @@ namespace RTC
      *
      * @endif
      */
-    const ConnectorInfo& profile();
+    const ConnectorInfo& profile() override;
 
     /*!
      * @if jp
@@ -104,7 +104,7 @@ namespace RTC
      *
      * @endif
      */
-    const char* id();
+    const char* id() override;
 
     /*!
      * @if jp
@@ -119,7 +119,7 @@ namespace RTC
      *
      * @endif
      */
-    const char* name();
+    const char* name() override;
 
     /*!
      * @if jp
@@ -134,7 +134,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode disconnect() = 0;
+    ReturnCode disconnect() override = 0;
 
     /*!
      * @if jp
@@ -149,7 +149,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual CdrBufferBase* getBuffer() = 0;
+    CdrBufferBase* getBuffer() override = 0;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.h
@@ -87,7 +87,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortCorbaCdrConsumer();
+    ~OutPortCorbaCdrConsumer() override;
 
     /*!
      * @if jp
@@ -116,7 +116,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -143,7 +143,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -189,8 +189,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -213,7 +213,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode get(ByteData& data);
+    ReturnCode get(ByteData& data) override;
 
     /*!
      * @if jp
@@ -237,7 +237,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -256,7 +256,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
 
   private:
     /*!

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -92,7 +92,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortCorbaCdrProvider();
+    ~OutPortCorbaCdrProvider() override;
 
     /*!
      * @if jp
@@ -121,7 +121,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -148,7 +148,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -194,8 +194,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -221,7 +221,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setConnector(OutPortConnector* connector);
+    void setConnector(OutPortConnector* connector) override;
 
     /*!
      * @if jp
@@ -240,8 +240,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::OpenRTM::PortStatus get(::OpenRTM::CdrData_out data)
-      throw (CORBA::SystemException);
+    ::OpenRTM::PortStatus get(::OpenRTM::CdrData_out data)
+      throw (CORBA::SystemException) override;
 
 
   private:

--- a/src/lib/rtm/OutPortDSConsumer.h
+++ b/src/lib/rtm/OutPortDSConsumer.h
@@ -85,7 +85,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortDSConsumer();
+    ~OutPortDSConsumer() override;
 
     /*!
      * @if jp
@@ -114,7 +114,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -141,7 +141,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -187,8 +187,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -211,7 +211,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode get(ByteData& data);
+    ReturnCode get(ByteData& data) override;
 
     /*!
      * @if jp
@@ -235,7 +235,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
 
     /*!
      * @if jp
@@ -254,7 +254,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
 
   private:
     /*!

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -90,7 +90,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortDSProvider();
+    ~OutPortDSProvider() override;
 
     /*!
      * @if jp
@@ -119,7 +119,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -146,7 +146,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -192,8 +192,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -219,7 +219,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setConnector(OutPortConnector* connector);
+    void setConnector(OutPortConnector* connector) override;
 
     /*!
      * @if jp
@@ -238,8 +238,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::RTC::PortStatus pull(::RTC::OctetSeq_out data)
-      throw (CORBA::SystemException);
+    ::RTC::PortStatus pull(::RTC::OctetSeq_out data)
+      throw (CORBA::SystemException) override;
 
 
   private:

--- a/src/lib/rtm/OutPortDirectConsumer.h
+++ b/src/lib/rtm/OutPortDirectConsumer.h
@@ -86,7 +86,7 @@ namespace RTC
      *
      * @endif
      */
-	virtual ~OutPortDirectConsumer();
+	~OutPortDirectConsumer() override;
 
     /*!
      * @if jp
@@ -115,7 +115,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -142,7 +142,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -188,8 +188,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -212,7 +212,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode get(ByteData& data);
+    ReturnCode get(ByteData& data) override;
 
     /*!
      * @if jp
@@ -236,7 +236,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
     
     /*!
      * @if jp
@@ -255,7 +255,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
     
 private:
 	mutable Logger rtclog;

--- a/src/lib/rtm/OutPortDirectProvider.h
+++ b/src/lib/rtm/OutPortDirectProvider.h
@@ -84,7 +84,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortDirectProvider();
+    ~OutPortDirectProvider() override;
 
     /*!
      * @if jp
@@ -113,7 +113,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -140,7 +140,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -186,8 +186,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -213,7 +213,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setConnector(OutPortConnector* connector);
+    void setConnector(OutPortConnector* connector) override;
 
     
   private:

--- a/src/lib/rtm/OutPortPullConnector.h
+++ b/src/lib/rtm/OutPortPullConnector.h
@@ -145,7 +145,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortPullConnector();
+    ~OutPortPullConnector() override;
 
     /*!
      * @if jp
@@ -163,9 +163,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode write(ByteDataStreamBase* data);
+    ReturnCode write(ByteDataStreamBase* data) override;
 
-    virtual CdrBufferBase::ReturnCode read(ByteData &data);
+    CdrBufferBase::ReturnCode read(ByteData &data) override;
 
     /*!
      * @if jp
@@ -182,7 +182,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode disconnect();
+    ReturnCode disconnect() override;
 
     /*!
      * @if jp
@@ -197,7 +197,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual CdrBufferBase* getBuffer();
+    CdrBufferBase* getBuffer() override;
 
     /*!
      * @if jp
@@ -213,7 +213,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void activate() {}  // do nothing
+    void activate() override {}  // do nothing
 
     /*!
      * @if jp
@@ -229,7 +229,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void deactivate() {}  // do nothing
+    void deactivate() override {}  // do nothing
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortPushConnector.h
+++ b/src/lib/rtm/OutPortPushConnector.h
@@ -148,7 +148,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortPushConnector();
+    ~OutPortPushConnector() override;
 
     /*!
      * @if jp
@@ -189,7 +189,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode write(RTC::ByteDataStreamBase* data);
+    ReturnCode write(RTC::ByteDataStreamBase* data) override;
 
     /*!
      * @if jp
@@ -206,7 +206,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode disconnect();
+    ReturnCode disconnect() override;
 
     /*!
      * @if jp
@@ -222,7 +222,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void activate();
+    void activate() override;
 
     /*!
      * @if jp
@@ -238,7 +238,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void deactivate();
+    void deactivate() override;
 
     /*!
      * @if jp
@@ -253,7 +253,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual CdrBufferBase* getBuffer();
+    CdrBufferBase* getBuffer() override;
 
   protected:
     /*!

--- a/src/lib/rtm/OutPortSHMConsumer.h
+++ b/src/lib/rtm/OutPortSHMConsumer.h
@@ -84,7 +84,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortSHMConsumer(); 
+    ~OutPortSHMConsumer() override; 
 
     /*!
      * @if jp
@@ -104,7 +104,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -123,7 +123,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -144,8 +144,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -168,7 +168,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode get(ByteData& data);
+    ReturnCode get(ByteData& data) override;
 
     /*!
      * @if jp
@@ -192,7 +192,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool subscribeInterface(const SDOPackage::NVList& properties);
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
     
     /*!
      * @if jp
@@ -211,8 +211,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void unsubscribeInterface(const SDOPackage::NVList& properties);
-    virtual bool setObject(CORBA::Object_ptr obj);
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
+    bool setObject(CORBA::Object_ptr obj) override;
     
   private:
     /*!

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -85,7 +85,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortSHMProvider();
+    ~OutPortSHMProvider() override;
 
     /*!
      * @if jp
@@ -105,7 +105,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(coil::Properties& prop);
+    void init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -124,7 +124,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setBuffer(CdrBufferBase* buffer);
+    void setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -145,8 +145,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setListener(ConnectorInfo& info,
-                             ConnectorListeners* listeners);
+    void setListener(ConnectorInfo& info,
+                             ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -165,7 +165,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void setConnector(OutPortConnector* connector);
+    void setConnector(OutPortConnector* connector) override;
 
     /*!
      * @if jp
@@ -184,8 +184,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::OpenRTM::PortStatus get()
-      throw (CORBA::SystemException);
+    ::OpenRTM::PortStatus get()
+      throw (CORBA::SystemException) override;
 
     
   private:

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -595,8 +595,8 @@ namespace RTC
   public:
     explicit setCallback(::SDOPackage::PeriodicECOrganization* org)
            : m_org(org) {}
-    virtual ~setCallback() {}
-    virtual void operator()(const coil::Properties&  /*config_set*/)
+    ~setCallback() override {}
+    void operator()(const coil::Properties&  /*config_set*/) override
     {
       m_org->updateDelegatedPorts();
     }
@@ -611,8 +611,8 @@ namespace RTC
   public:
     explicit addCallback(::SDOPackage::PeriodicECOrganization* org)
            : m_org(org) {}
-    virtual ~addCallback() {}
-    virtual void operator()(const coil::Properties&  /*config_set*/)
+    ~addCallback() override {}
+    void operator()(const coil::Properties&  /*config_set*/) override
     {
       m_org->updateDelegatedPorts();
     }

--- a/src/lib/rtm/PeriodicECSharedComposite.h
+++ b/src/lib/rtm/PeriodicECSharedComposite.h
@@ -104,7 +104,7 @@ namespace SDOPackage
      *
      * @endif
      */
-    virtual ~PeriodicECOrganization();
+    ~PeriodicECOrganization() override;
 
     /*!
      * @if jp
@@ -128,9 +128,9 @@ namespace SDOPackage
      *
      * @endif
      */
-    virtual ::CORBA::Boolean add_members(const SDOList& sdo_list)
+    ::CORBA::Boolean add_members(const SDOList& sdo_list)
       throw (::CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -155,9 +155,9 @@ namespace SDOPackage
      *
      * @endif
      */
-    virtual ::CORBA::Boolean set_members(const SDOList& sdo_list)
+    ::CORBA::Boolean set_members(const SDOList& sdo_list)
       throw (::CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -180,9 +180,9 @@ namespace SDOPackage
      *
      * @endif
      */
-    virtual ::CORBA::Boolean remove_member(const char* id)
+    ::CORBA::Boolean remove_member(const char* id)
       throw (::CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -504,7 +504,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PeriodicECSharedComposite();
+    ~PeriodicECSharedComposite() override;
 
     /*!
      * @if jp
@@ -521,7 +521,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t onInitialize();
+    ReturnCode_t onInitialize() override;
     /*!
      * @if jp
      *
@@ -553,7 +553,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t onActivated(RTC::UniqueId exec_handle);
+    ReturnCode_t onActivated(RTC::UniqueId exec_handle) override;
     void activateChildComp(RTC::RTObject_var rtobj);
     /*!
      * @if jp
@@ -586,7 +586,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t onDeactivated(RTC::UniqueId exec_handle);
+    ReturnCode_t onDeactivated(RTC::UniqueId exec_handle) override;
 
     /*!
      * @if jp
@@ -618,7 +618,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t onReset(RTC::UniqueId exec_handle);
+    ReturnCode_t onReset(RTC::UniqueId exec_handle) override;
     /*!
      * @if jp
      *
@@ -643,10 +643,10 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t onFinalize();
+    ReturnCode_t onFinalize() override;
 
-    virtual ReturnCode_t exit()
-      throw (CORBA::SystemException);
+    ReturnCode_t exit()
+      throw (CORBA::SystemException) override;
 
   protected:
     /*!

--- a/src/lib/rtm/PeriodicExecutionContext.h
+++ b/src/lib/rtm/PeriodicExecutionContext.h
@@ -99,7 +99,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual ~PeriodicExecutionContext();
+    ~PeriodicExecutionContext() override;
 
     /*!
      * @if jp
@@ -114,7 +114,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual  void init(coil::Properties& props);
+     void init(coil::Properties& props) override;
 
     /*!
      * @if jp
@@ -140,7 +140,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual int open(void *args);
+    int open(void *args) override;
 
     /*!
      * @if jp
@@ -161,7 +161,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual int svc();
+    int svc() override;
 
     /*!
      * @if jp
@@ -190,7 +190,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual int close(unsigned long flags);
+    int close(unsigned long flags) override;
 
     //============================================================
     // ExecutionContext
@@ -219,8 +219,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual CORBA::Boolean is_running()
-      throw (CORBA::SystemException);
+    CORBA::Boolean is_running()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -249,8 +249,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t start()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t start()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -278,8 +278,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t stop()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -301,8 +301,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual CORBA::Double get_rate()
-      throw (CORBA::SystemException);
+    CORBA::Double get_rate()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -333,8 +333,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -369,9 +369,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -405,9 +405,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -440,9 +440,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -470,9 +470,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::LifeCycleState
+    RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -493,8 +493,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException);
+    RTC::ExecutionKind get_kind()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -527,8 +527,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -560,9 +560,9 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -583,8 +583,8 @@ namespace RTC_exp
      *
      * @endif
      */
-    virtual RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException);
+    RTC::ExecutionContextProfile* get_profile()
+      throw (CORBA::SystemException) override;
 
   protected:
     template <class T>
@@ -602,53 +602,53 @@ namespace RTC_exp
     /*!
      * @brief onStarted() template function
      */
-    virtual RTC::ReturnCode_t onStarted();
+    RTC::ReturnCode_t onStarted() override;
     /*!
      * @brief onStopping() template function
      */
-    virtual RTC::ReturnCode_t onStopping();
+    RTC::ReturnCode_t onStopping() override;
     // template virtual functions adding/removing component
     /*!
      * @brief onAddedComponent() template function
      */
-     virtual RTC::ReturnCode_t
-     onAddedComponent(RTC::LightweightRTObject_ptr rtobj);
+     RTC::ReturnCode_t
+     onAddedComponent(RTC::LightweightRTObject_ptr rtobj) override;
     /*!
      * @brief onRemovedComponent() template function
      */
-    virtual RTC::ReturnCode_t
-    onRemovedComponent(RTC::LightweightRTObject_ptr rtobj);
+    RTC::ReturnCode_t
+    onRemovedComponent(RTC::LightweightRTObject_ptr rtobj) override;
 
     /*!
      * @brief onWaitingActivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingActivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onActivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onActivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onActivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingDeactivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onDeactivated() template function
      */
-    virtual RTC::ReturnCode_t
-    onDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onDeactivated(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onWaitingReset() template function
      */
-    virtual RTC::ReturnCode_t
-    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onWaitingReset(RTC_impl::RTObjectStateMachine* comp, long int count) override;
     /*!
      * @brief onReset() template function
      */
-    virtual RTC::ReturnCode_t
-    onReset(RTC_impl::RTObjectStateMachine* comp, long int count);
+    RTC::ReturnCode_t
+    onReset(RTC_impl::RTObjectStateMachine* comp, long int count) override;
 
     /*!
      * @brief setting CPU affinity from given properties

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -180,7 +180,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PortBase();
+    ~PortBase() override;
 
     /*!
      * @if jp
@@ -233,8 +233,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual PortProfile* get_port_profile()
-      throw (CORBA::SystemException);
+    PortProfile* get_port_profile()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -315,8 +315,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ConnectorProfileList* get_connector_profiles()
-      throw (CORBA::SystemException);
+    ConnectorProfileList* get_connector_profiles()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -357,8 +357,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ConnectorProfile* get_connector_profile(const char* connector_id)
-      throw (CORBA::SystemException);
+    ConnectorProfile* get_connector_profile(const char* connector_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -517,8 +517,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException);
+    ReturnCode_t connect(ConnectorProfile& connector_profile)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -635,8 +635,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException);
+    ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -703,8 +703,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t disconnect(const char* connector_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t disconnect(const char* connector_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -794,8 +794,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t notify_disconnect(const char* connector_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t notify_disconnect(const char* connector_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -816,8 +816,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t disconnect_all()
-      throw (CORBA::SystemException);
+    ReturnCode_t disconnect_all()
+      throw (CORBA::SystemException) override;
 
     //============================================================
     // Local operations

--- a/src/lib/rtm/PublisherFlush.h
+++ b/src/lib/rtm/PublisherFlush.h
@@ -92,7 +92,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PublisherFlush();
+    ~PublisherFlush() override;
 
     /*!
      * @if jp
@@ -118,7 +118,7 @@ namespace RTC
      *                    INVALID_ARGS Properties with invalid values.
      * @endif
      */
-    virtual ReturnCode init(coil::Properties& prop);
+    ReturnCode init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -145,7 +145,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode setConsumer(InPortConsumer* consumer);
+    ReturnCode setConsumer(InPortConsumer* consumer) override;
 
     /*!
      * @if jp
@@ -168,7 +168,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode setBuffer(CdrBufferBase* buffer);
+    ReturnCode setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -203,9 +203,9 @@ namespace RTC
      *         INVALID_ARGS Invalid arguments
      * @endif
      */
-    virtual ::RTC::DataPortStatus::Enum
+    ::RTC::DataPortStatus::Enum
     setListener(ConnectorInfo& info,
-                RTC::ConnectorListeners* listeners);
+                RTC::ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -265,9 +265,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode write(ByteDataStreamBase* data,
+    ReturnCode write(ByteDataStreamBase* data,
                              unsigned long sec,
-                             unsigned long usec);
+                             unsigned long usec) override;
     /*!
      * @if jp
      *
@@ -295,7 +295,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool isActive();
+    bool isActive() override;
 
     /*!
      * @if jp
@@ -322,7 +322,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode activate();
+    ReturnCode activate() override;
 
     /*!
      * @if jp
@@ -349,7 +349,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode deactivate();
+    ReturnCode deactivate() override;
 
   protected:
     /*!

--- a/src/lib/rtm/PublisherNew.h
+++ b/src/lib/rtm/PublisherNew.h
@@ -104,7 +104,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PublisherNew();
+    ~PublisherNew() override;
 
     /*!
      * @if jp
@@ -157,7 +157,7 @@ namespace RTC
      *                    INVALID_ARGS Properties with invalid values.
      * @endif
      */
-    virtual ReturnCode init(coil::Properties& prop);
+    ReturnCode init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -184,7 +184,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode setConsumer(InPortConsumer* consumer);
+    ReturnCode setConsumer(InPortConsumer* consumer) override;
 
     /*!
      * @if jp
@@ -211,7 +211,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode setBuffer(CdrBufferBase* buffer);
+    ReturnCode setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -246,8 +246,8 @@ namespace RTC
      *         INVALID_ARGS Invalid arguments
      * @endif
      */
-    virtual ReturnCode setListener(ConnectorInfo& info,
-                                   ConnectorListeners* listeners);
+    ReturnCode setListener(ConnectorInfo& info,
+                                   ConnectorListeners* listeners) override;
 
     /*!
      * @if jp
@@ -324,9 +324,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode write(ByteDataStreamBase* data,
+    ReturnCode write(ByteDataStreamBase* data,
                              unsigned long sec,
-                             unsigned long usec);
+                             unsigned long usec) override;
 
     /*!
      * @if jp
@@ -355,7 +355,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool isActive();
+    bool isActive() override;
 
     /*!
      * @if jp
@@ -382,7 +382,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode activate();
+    ReturnCode activate() override;
 
     /*!
      * @if jp
@@ -409,7 +409,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode deactivate();
+    ReturnCode deactivate() override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/PublisherPeriodic.h
+++ b/src/lib/rtm/PublisherPeriodic.h
@@ -94,7 +94,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PublisherPeriodic();
+    ~PublisherPeriodic() override;
 
     /*!
      * @if jp
@@ -157,7 +157,7 @@ namespace RTC
      *                    INVALID_ARGS Properties with invalid values.
      * @endif
      */
-    virtual ReturnCode init(coil::Properties& prop);
+    ReturnCode init(coil::Properties& prop) override;
 
     /*!
      * @if jp
@@ -184,7 +184,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode setConsumer(InPortConsumer* consumer);
+    ReturnCode setConsumer(InPortConsumer* consumer) override;
 
     /*!
      * @if jp
@@ -211,7 +211,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode setBuffer(CdrBufferBase* buffer);
+    ReturnCode setBuffer(CdrBufferBase* buffer) override;
 
     /*!
      * @if jp
@@ -246,8 +246,8 @@ namespace RTC
      *         INVALID_ARGS Invalid arguments
      * @endif
      */
-    virtual ReturnCode setListener(ConnectorInfo& info,
-                                   ConnectorListeners* listeners);
+    ReturnCode setListener(ConnectorInfo& info,
+                                   ConnectorListeners* listeners) override;
     /*!
      * @if jp
      * @brief データを書き込む
@@ -323,9 +323,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode write(ByteDataStreamBase* data,
+    ReturnCode write(ByteDataStreamBase* data,
                              unsigned long sec,
-                             unsigned long usec);
+                             unsigned long usec) override;
     /*!
      * @if jp
      *
@@ -353,7 +353,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool isActive();
+    bool isActive() override;
 
     /*!
      * @if jp
@@ -380,7 +380,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode activate();
+    ReturnCode activate() override;
 
     /*!
      * @if jp
@@ -407,7 +407,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode deactivate();
+    ReturnCode deactivate() override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -148,7 +148,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~RTObject_impl();
+    ~RTObject_impl() override;
 
   protected:
     //============================================================
@@ -617,8 +617,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t initialize()
-      throw (CORBA::SystemException);
+    ReturnCode_t initialize()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -665,8 +665,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t finalize()
-      throw (CORBA::SystemException);
+    ReturnCode_t finalize()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -711,8 +711,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t exit()
-      throw (CORBA::SystemException);
+    ReturnCode_t exit()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -747,8 +747,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Boolean is_alive(ExecutionContext_ptr exec_context)
-      throw (CORBA::SystemException);
+    CORBA::Boolean is_alive(ExecutionContext_ptr exec_context)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -777,8 +777,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ExecutionContext_ptr get_context(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ExecutionContext_ptr get_context(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -798,8 +798,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ExecutionContextList* get_owned_contexts()
-      throw (CORBA::SystemException);
+    ExecutionContextList* get_owned_contexts()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -819,8 +819,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ExecutionContextList* get_participating_contexts()
-      throw (CORBA::SystemException);
+    ExecutionContextList* get_participating_contexts()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -836,9 +836,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual ExecutionContextHandle_t
+    ExecutionContextHandle_t
     get_context_handle(ExecutionContext_ptr cxt)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -871,7 +871,7 @@ namespace RTC
      * @endif
      */
     UniqueId attach_context(ExecutionContext_ptr exec_context)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     UniqueId bindContext(ExecutionContext_ptr exec_context);
 
@@ -917,7 +917,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t detach_context(UniqueId ec_id)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
     //============================================================
     // RTC::RTObject
@@ -941,8 +941,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ComponentProfile* get_component_profile()
-      throw (CORBA::SystemException);
+    ComponentProfile* get_component_profile()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -963,8 +963,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual PortServiceList* get_ports()
-      throw (CORBA::SystemException);
+    PortServiceList* get_ports()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1018,8 +1018,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_initialize()
-      throw (CORBA::SystemException);
+    ReturnCode_t on_initialize()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1045,8 +1045,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_finalize()
-      throw (CORBA::SystemException);
+    ReturnCode_t on_finalize()
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1076,8 +1076,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_startup(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_startup(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1107,8 +1107,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_shutdown(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_shutdown(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1136,8 +1136,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_activated(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_activated(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1166,8 +1166,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_deactivated(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_deactivated(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1201,8 +1201,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_aborting(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_aborting(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1247,8 +1247,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_error(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_error(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1284,8 +1284,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_reset(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_reset(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     //============================================================
     // RTC::DataFlowComponentAction
@@ -1332,8 +1332,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_execute(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_execute(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1378,8 +1378,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_state_update(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_state_update(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     /*!
      * @if jp
@@ -1417,8 +1417,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode_t on_rate_changed(UniqueId ec_id)
-      throw (CORBA::SystemException);
+    ReturnCode_t on_rate_changed(UniqueId ec_id)
+      throw (CORBA::SystemException) override;
 
     //============================================================
     // SDOPackage::SdoSystemElement
@@ -1460,9 +1460,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual SDOPackage::OrganizationList* get_owned_organizations()
+    SDOPackage::OrganizationList* get_owned_organizations()
       throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError);
+             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
 
     //============================================================
     // SDOPackage::SDO
@@ -1500,9 +1500,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual char* get_sdo_id()
+    char* get_sdo_id()
       throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError);
+             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1537,9 +1537,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual char* get_sdo_type()
+    char* get_sdo_type()
       throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError);
+             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1577,9 +1577,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual SDOPackage::DeviceProfile* get_device_profile()
+    SDOPackage::DeviceProfile* get_device_profile()
       throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError);
+             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1617,9 +1617,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual SDOPackage::ServiceProfileList* get_service_profiles()
+    SDOPackage::ServiceProfileList* get_service_profiles()
       throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError);
+             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1662,10 +1662,10 @@ namespace RTC
      *
      * @endif
      */
-    virtual SDOPackage::ServiceProfile* get_service_profile(const char* id)
+    SDOPackage::ServiceProfile* get_service_profile(const char* id)
       throw (CORBA::SystemException,
              SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-             SDOPackage::InternalError);
+             SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1714,10 +1714,10 @@ namespace RTC
      *
      * @endif
      */
-    virtual SDOPackage::SDOService_ptr get_sdo_service(const char* id)
+    SDOPackage::SDOService_ptr get_sdo_service(const char* id)
       throw (CORBA::SystemException,
              SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-             SDOPackage::InternalError);
+             SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1763,10 +1763,10 @@ namespace RTC
      *                          completely due to some internal error.
      * @endif
      */
-    virtual SDOPackage::Configuration_ptr get_configuration()
+    SDOPackage::Configuration_ptr get_configuration()
       throw (CORBA::SystemException,
              SDOPackage::InterfaceNotImplemented, SDOPackage::NotAvailable,
-             SDOPackage::InternalError);
+             SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1811,10 +1811,10 @@ namespace RTC
      *                          completely due to some internal error.
      * @endif
      */
-    virtual SDOPackage::Monitoring_ptr get_monitoring()
+    SDOPackage::Monitoring_ptr get_monitoring()
       throw (CORBA::SystemException,
              SDOPackage::InterfaceNotImplemented, SDOPackage::NotAvailable,
-             SDOPackage::InternalError);
+             SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1851,9 +1851,9 @@ namespace RTC
      *                          completely due to some internal error.
      * @endif
      */
-    virtual SDOPackage::OrganizationList* get_organizations()
+    SDOPackage::OrganizationList* get_organizations()
       throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError);
+             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1886,9 +1886,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual SDOPackage::NVList* get_status_list()
+    SDOPackage::NVList* get_status_list()
       throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError);
+             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
 
     /*!
      * @if jp
@@ -1926,10 +1926,10 @@ namespace RTC
      *
      * @endif
      */
-    virtual CORBA::Any* get_status(const char* name)
+    CORBA::Any* get_status(const char* name)
       throw (CORBA::SystemException,
              SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-             SDOPackage::InternalError);
+             SDOPackage::InternalError) override;
 
     //============================================================
     // Local interfaces
@@ -3494,7 +3494,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        void operator()(UniqueId ec_id)
+        void operator()(UniqueId ec_id) override
         {
           (m_obj.*m_memfunc)(ec_id);
         }
@@ -3628,7 +3628,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        void operator()(UniqueId ec_id, ReturnCode_t ret)
+        void operator()(UniqueId ec_id, ReturnCode_t ret) override
         {
           (m_obj.*m_memfunc)(ec_id, ret);
         }
@@ -3741,7 +3741,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        void operator()(const RTC::PortProfile& pprofile)
+        void operator()(const RTC::PortProfile& pprofile) override
         {
           (m_obj.*m_memfunc)(pprofile);
         }
@@ -3853,7 +3853,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        void operator()(UniqueId ec_id)
+        void operator()(UniqueId ec_id) override
         {
           (m_obj.*m_memfunc)(ec_id);
         }
@@ -3966,7 +3966,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        void operator()(const char* portname, ConnectorProfile& cprofile)
+        void operator()(const char* portname, ConnectorProfile& cprofile) override
         {
           (m_obj.*m_memfunc)(portname, cprofile);
         }
@@ -4087,7 +4087,7 @@ namespace RTC
         }
         void operator()(const char* portname,
                         ConnectorProfile& cprofile,
-                        ReturnCode_t ret)
+                        ReturnCode_t ret) override
         {
           (m_obj.*m_memfunc)(portname, cprofile, ret);
         }
@@ -4181,7 +4181,7 @@ namespace RTC
         {
         }
         void operator()(const char* config_set_name,
-                        const char* config_param_name)
+                        const char* config_param_name) override
         {
           (m_obj.*m_memfunc)(config_set_name, config_param_name);
         }
@@ -4273,7 +4273,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        virtual void operator()(const coil::Properties& config_set)
+        void operator()(const coil::Properties& config_set) override
         {
           (m_obj.*m_memfunc)(config_set);
         }
@@ -4365,7 +4365,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        virtual void operator()(const char* config_set_name)
+        void operator()(const char* config_set_name) override
         {
           (m_obj.*m_memfunc)(config_set_name);
         }
@@ -4503,7 +4503,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        void operator()(const char* state)
+        void operator()(const char* state) override
         {
           (m_obj.*m_memfunc)(state);
         }
@@ -4635,7 +4635,7 @@ namespace RTC
           : m_obj(obj), m_memfunc(memfunc)
         {
         }
-        void operator()(const char* state, ReturnCode_t ret)
+        void operator()(const char* state, ReturnCode_t ret) override
         {
           (m_obj.*m_memfunc)(state, ret);
         }
@@ -5498,7 +5498,7 @@ namespace RTC
             m_sdoservice = sdoservice;
             m_id = id;
           }
-        virtual int svc()
+        int svc() override
           {
             m_sdoservice->removeSdoServiceConsumer(m_id.c_str());
             return 0;

--- a/src/lib/rtm/RingBuffer.h
+++ b/src/lib/rtm/RingBuffer.h
@@ -142,7 +142,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~RingBuffer()
+    ~RingBuffer() override
     {
     }
 
@@ -185,7 +185,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void init(const coil::Properties& prop)
+    void init(const coil::Properties& prop) override
     {
       initLength(prop);
       initWritePolicy(prop);
@@ -212,7 +212,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual size_t length() const
+    size_t length() const override
     {
       Guard guard(m_posmutex);
       return m_length;
@@ -240,7 +240,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode length(size_t n)
+    ReturnCode length(size_t n) override
     {
       m_buffer.resize(n);
       m_length = n;
@@ -270,7 +270,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode reset()
+    ReturnCode reset() override
     {
       Guard guard(m_posmutex);
       m_fillcount = 0;
@@ -303,7 +303,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual DataType* wptr(long int n = 0)
+    DataType* wptr(long int n = 0) override
     {
       Guard guard(m_posmutex);
       return &m_buffer[(m_wpos + n + m_length) % m_length];
@@ -333,7 +333,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode advanceWptr(long int n = 1, bool unlock_enable = true)
+    ReturnCode advanceWptr(long int n = 1, bool unlock_enable = true) override
     {
       bool empty_ = false;
       bool lock_ = (unlock_enable && n > 0);
@@ -404,7 +404,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode put(const DataType& value)
+    ReturnCode put(const DataType& value) override
     {
       Guard guard(m_posmutex);
       m_buffer[m_wpos] = value;
@@ -452,8 +452,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode write(const DataType& value,
-                             long int sec = -1, long int nsec = 0)
+    ReturnCode write(const DataType& value,
+                             long int sec = -1, long int nsec = 0) override
     {
       {
       Guard guard(m_full.mutex);
@@ -527,7 +527,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual size_t writable() const
+    size_t writable() const override
     {
       Guard guard(m_posmutex);
       return m_length - m_fillcount;
@@ -552,7 +552,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool full() const
+    bool full() const override
     {
       Guard guard(m_posmutex);
       return m_length == m_fillcount;
@@ -579,7 +579,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual DataType* rptr(long int n = 0)
+    DataType* rptr(long int n = 0) override
     {
       Guard guard(m_posmutex);
       return &(m_buffer[(m_rpos + n + m_length) % m_length]);
@@ -607,7 +607,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode advanceRptr(long int n = 1, bool unlock_enable = true)
+    ReturnCode advanceRptr(long int n = 1, bool unlock_enable = true) override
     {
       bool full_ = false;
       bool lock_ = (unlock_enable && n > 0);
@@ -674,7 +674,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode get(DataType& value)
+    ReturnCode get(DataType& value) override
     {
       Guard gaurd(m_posmutex);
       value = m_buffer[m_rpos];
@@ -699,7 +699,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual DataType& get()
+    DataType& get() override
     {
       Guard gaurd(m_posmutex);
       return m_buffer[m_rpos];
@@ -747,8 +747,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ReturnCode read(DataType& value,
-                            long int sec = -1, long int nsec = 0)
+    ReturnCode read(DataType& value,
+                            long int sec = -1, long int nsec = 0) override
     {
       {
       Guard gaurd(m_empty.mutex);
@@ -829,7 +829,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual size_t readable() const
+    size_t readable() const override
     {
       Guard guard(m_posmutex);
       return m_fillcount;
@@ -854,7 +854,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual bool empty() const
+    bool empty() const override
     {
       Guard guard(m_posmutex);
       return m_fillcount == 0;

--- a/src/lib/rtm/SdoConfiguration.h
+++ b/src/lib/rtm/SdoConfiguration.h
@@ -195,7 +195,7 @@ namespace SDOPackage
 
      * @endif
      */
-    virtual ~Configuration_impl();
+    ~Configuration_impl() override;
 
     //============================================================
     //
@@ -242,9 +242,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean set_device_profile(const DeviceProfile& dProfile)
+    CORBA::Boolean set_device_profile(const DeviceProfile& dProfile)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -291,9 +291,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean add_service_profile(const ServiceProfile& sProfile)
+    CORBA::Boolean add_service_profile(const ServiceProfile& sProfile)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -330,9 +330,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean add_organization(Organization_ptr org)
+    CORBA::Boolean add_organization(Organization_ptr org)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -376,9 +376,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean remove_service_profile(const char* id)
+    CORBA::Boolean remove_service_profile(const char* id)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -419,9 +419,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean remove_organization(const char* organization_id)
+    CORBA::Boolean remove_organization(const char* organization_id)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -455,9 +455,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual ParameterList* get_configuration_parameters()
+    ParameterList* get_configuration_parameters()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -489,9 +489,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual NVList* get_configuration_parameter_values()
+    NVList* get_configuration_parameter_values()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -533,9 +533,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Any* get_configuration_parameter_value(const char* name)
+    CORBA::Any* get_configuration_parameter_value(const char* name)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -579,10 +579,10 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean set_configuration_parameter(const char* name,
+    CORBA::Boolean set_configuration_parameter(const char* name,
                                                        const CORBA::Any& value)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -618,9 +618,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual ConfigurationSetList* get_configuration_sets()
+    ConfigurationSetList* get_configuration_sets()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -662,9 +662,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual ConfigurationSet* get_configuration_set(const char* config_id)
+    ConfigurationSet* get_configuration_set(const char* config_id)
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -714,9 +714,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual ConfigurationSet* get_active_configuration_set()
+    ConfigurationSet* get_active_configuration_set()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -759,10 +759,10 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean
+    CORBA::Boolean
     add_configuration_set(const ConfigurationSet& configuration_set)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -815,10 +815,10 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean
+    CORBA::Boolean
     set_configuration_set_values(const ConfigurationSet& configuration_set)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -858,9 +858,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean remove_configuration_set(const char* config_id)
+    CORBA::Boolean remove_configuration_set(const char* config_id)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -912,9 +912,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean activate_configuration_set(const char* config_id)
+    CORBA::Boolean activate_configuration_set(const char* config_id)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     // end of CORBA interface definition
     //============================================================

--- a/src/lib/rtm/SdoOrganization.h
+++ b/src/lib/rtm/SdoOrganization.h
@@ -115,7 +115,7 @@ namespace SDOPackage
      *
      * @endif
      */
-    virtual ~Organization_impl();
+    ~Organization_impl() override;
 
     //============================================================
     //
@@ -151,9 +151,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual char* get_organization_id()
+    char* get_organization_id()
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -197,10 +197,10 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean
+    CORBA::Boolean
     add_organization_property(const OrganizationProperty& organization_property)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -234,9 +234,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual OrganizationProperty* get_organization_property()
+    OrganizationProperty* get_organization_property()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -277,9 +277,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Any* get_organization_property_value(const char* name)
+    CORBA::Any* get_organization_property_value(const char* name)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -325,10 +325,10 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean
+    CORBA::Boolean
     set_organization_property_value(const char* name, const CORBA::Any& value)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -370,9 +370,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean remove_organization_property(const char* name)
+    CORBA::Boolean remove_organization_property(const char* name)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -411,9 +411,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean add_members(const SDOList& sdo_list)
+    CORBA::Boolean add_members(const SDOList& sdo_list)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -447,9 +447,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual SDOList* get_members()
+    SDOList* get_members()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -494,9 +494,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean set_members(const SDOList& sdos)
+    CORBA::Boolean set_members(const SDOList& sdos)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -534,9 +534,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean remove_member(const char* id)
+    CORBA::Boolean remove_member(const char* id)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -568,9 +568,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual SDOSystemElement_ptr get_owner()
+    SDOSystemElement_ptr get_owner()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -613,9 +613,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean set_owner(SDOSystemElement_ptr sdo)
+    CORBA::Boolean set_owner(SDOSystemElement_ptr sdo)
       throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError);
+             InvalidParameter, NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -652,9 +652,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual DependencyType get_dependency()
+    DependencyType get_dependency()
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     /*!
      * @if jp
@@ -698,9 +698,9 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    virtual CORBA::Boolean set_dependency(DependencyType dependency)
+    CORBA::Boolean set_dependency(DependencyType dependency)
       throw (CORBA::SystemException,
-             NotAvailable, InternalError);
+             NotAvailable, InternalError) override;
 
     // end of CORBA interface definition
     //============================================================

--- a/src/lib/rtm/SdoServiceProviderBase.h
+++ b/src/lib/rtm/SdoServiceProviderBase.h
@@ -143,7 +143,7 @@ namespace RTC
      * @brief virtual destructor
      * @endif
      */
-    virtual ~SdoServiceProviderBase() {}
+    ~SdoServiceProviderBase() override {}
 
     /*!
      * @if jp

--- a/src/lib/rtm/SharedMemoryPort.h
+++ b/src/lib/rtm/SharedMemoryPort.h
@@ -87,7 +87,7 @@ namespace RTC
      *
      * @endif
      */
-	  virtual ~SharedMemoryPort();
+	  ~SharedMemoryPort() override;
     /*!
      * @if jp
      * @brief 文字列で指定したデータサイズを数値に変換する
@@ -126,8 +126,8 @@ namespace RTC
      *
      * @endif
      */
-	virtual void create_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    	throw (CORBA::SystemException);
+	void create_memory(::CORBA::ULongLong memory_size, const char *shm_address)
+    	throw (CORBA::SystemException) override;
      /*!
      * @if jp
      * @brief 共有メモリのマッピングを行う
@@ -145,8 +145,8 @@ namespace RTC
      *
      * @endif
      */
-	virtual void open_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    	throw (CORBA::SystemException);
+	void open_memory(::CORBA::ULongLong memory_size, const char *shm_address)
+    	throw (CORBA::SystemException) override;
      /*!
      * @if jp
      * @brief マッピングした共有メモリをアンマップする
@@ -160,8 +160,8 @@ namespace RTC
      *
      * @endif
      */
-	virtual void close_memory(::CORBA::Boolean unlink = false)
-    	throw (CORBA::SystemException);
+	void close_memory(::CORBA::Boolean unlink = false)
+    	throw (CORBA::SystemException) override;
      /*!
      * @if jp
      * @brief データを書き込む
@@ -211,8 +211,8 @@ namespace RTC
      *
      * @endif
      */
-	virtual void setInterface(::OpenRTM::PortSharedMemory_ptr sm)
-    	throw (CORBA::SystemException);
+	void setInterface(::OpenRTM::PortSharedMemory_ptr sm)
+    	throw (CORBA::SystemException) override;
      /*!
      * @if jp
      * @brief エンディアンを設定する
@@ -228,8 +228,8 @@ namespace RTC
      *
      * @endif
      */
-	virtual void setEndian(::CORBA::Boolean endian)
-    	throw (CORBA::SystemException);
+	void setEndian(::CORBA::Boolean endian)
+    	throw (CORBA::SystemException) override;
      /*!
      * @if jp
      * @brief データの送信を知らせる
@@ -245,8 +245,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::OpenRTM::PortStatus put()
-      throw (CORBA::SystemException);
+    ::OpenRTM::PortStatus put()
+      throw (CORBA::SystemException) override;
      /*!
      * @if jp
      * @brief データの送信を要求する
@@ -262,8 +262,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ::OpenRTM::PortStatus get()
-      throw (CORBA::SystemException);
+    ::OpenRTM::PortStatus get()
+      throw (CORBA::SystemException) override;
 
 	virtual ::OpenRTM::PortSharedMemory_ptr getObjRef();
 

--- a/src/lib/rtm/SimulatorExecutionContext.h
+++ b/src/lib/rtm/SimulatorExecutionContext.h
@@ -68,7 +68,7 @@ namespace RTC
      * @brief Destructor 
      * @endif
      */
-    virtual ~SimulatorExecutionContext();
+    ~SimulatorExecutionContext() override;
 
     /*!
      * @if jp
@@ -92,9 +92,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
     /*!
      * @if jp
      * @brief RTコンポーネントを非アクティブ化する
@@ -117,9 +117,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
     /*!
      * @if jp
      * @brief RTコンポーネントをリセットする
@@ -142,9 +142,9 @@ namespace RTC
      *
      * @endif
      */
-    virtual RTC::ReturnCode_t
+    RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException);
+      throw (CORBA::SystemException) override;
 
   private:
 

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -90,7 +90,7 @@
       typedef ::__SameType< ::RTC::Link<S, SUPER>, LINK>::Check         \
         MustDeriveFromLink;                                             \
     }                                                                   \
-    ~S() {}                                                             \
+    ~S() override {}                                                    \
     static const char * _state_name() { return #S; }                    \
     Box & box() { return *static_cast<Box *>(_box()); }                 \
     friend class ::_VS8_Bug_101615;
@@ -118,7 +118,7 @@ namespace RTC
       : Macho::Machine<TOP>(), rtComponent(comp)
     {
     }
-    virtual ~Machine() {}
+    ~Machine() override {}
     virtual RingBuffer<EventBase*>& getBuffer()
     {
         return m_buffer;
@@ -170,7 +170,7 @@ namespace RTC
       : Macho::Link<C, P>(instance), rtComponent(nullptr)
     {
     }
-    virtual ~Link()
+    ~Link() override
     {
     }
 
@@ -184,7 +184,7 @@ namespace RTC
   public:
     typedef Link<C, P> LINK;
     
-    virtual void entry()
+    void entry() override
     {
       setrtc();
       if (rtComponent == nullptr)
@@ -198,7 +198,7 @@ namespace RTC
           rtComponent->postOnFsmEntry(C::_state_name(), onEntry());
         }
     }
-    virtual void init()
+    void init() override
     {
       setrtc();
       if (rtComponent == nullptr)
@@ -211,7 +211,7 @@ namespace RTC
           rtComponent->postOnFsmInit(C::_state_name(), onInit());
         }
     }
-    virtual void exit()
+    void exit() override
     {
       setrtc();
       if (rtComponent == nullptr)
@@ -225,10 +225,25 @@ namespace RTC
           rtComponent->preOnFsmStateChange(C::_state_name());
         }
     }
-
-    virtual ReturnCode_t onEntry() { return RTC::RTC_OK; }
-    virtual ReturnCode_t onInit()  { return RTC::RTC_OK; }
-    virtual ReturnCode_t onExit()  { return RTC::RTC_OK; }
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
+    // We can't use 'override' insetd of 'virtual', becase these
+    // methods are used as TOP LEVEL SUPPER CLASS and SUB CLASS.
+    virtual RTC::ReturnCode_t onEntry() { return RTC::RTC_OK; }
+    virtual RTC::ReturnCode_t onInit()  { return RTC::RTC_OK; }
+    virtual RTC::ReturnCode_t onExit()  { return RTC::RTC_OK; }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
     RTObject_impl* rtComponent;
   };

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -165,7 +165,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~Logger();
+    ~Logger() override;
 
     /*!
      * @if jp
@@ -345,7 +345,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual void write(int level, const std::string &mes);
+    void write(int level, const std::string &mes) override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/Timestamp.h
+++ b/src/lib/rtm/Timestamp.h
@@ -29,8 +29,8 @@ namespace RTC
     USE_CONNLISTENER_STATUS;
   public:
     Timestamp(const char* ts_type) : m_tstype(ts_type) {}
-    virtual ~Timestamp() {}
-    virtual ReturnCode operator()(ConnectorInfo& info, DataType& data)
+    ~Timestamp() override {}
+    ReturnCode operator()(ConnectorInfo& info, DataType& data) override
     {
       if (info.properties["timestamp_policy"] != m_tstype)
         {


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Description of the Change
C++11 対応として、 virtual を override で置換できる部分を変更する。  (#67 作業の一部)
注: StaticFSM.h にトップレベルとしても使われるし、サブクラスとしても使われるメソッドが存在する。特別に pragma 対応している。

### レビューにあたっての注意事項
- virtual が override に置き換えられているところは、コンパイラを信じればレビュー不要
- 元のコードで virtual がないのに override が付与された部分が正しいかどうかをチェック必要
- 今回の変化点ではない部分の virtual が継承関係上のトップレベルであるか確認したほうが良い。
  特に override のつもりが overload していただけの部分があるかもしれない。
   多くは戻り値や引数の型名 (const の有無とか) によりオーバーライドしたつもりになったというバグ。
- 設計上で override よりも final が適切なところがあるならば、そうしたほうが良い

## Verification 
ビルド確認のみ

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
- [ ] Have you passed the unit tests?  
