### PR TITLE
DitectInPortBase、DirectOutPortBase、DirectPortBaseを抽象クラスで定義する

### DIFF
--- a/src/lib/rtm/DirectInPortBase.h
+++ b/src/lib/rtm/DirectInPortBase.h
@@ -48,22 +48,6 @@ namespace RTC
   class DirectInPortBase : public DirectPortBase
   {
   public:
-	  /*!
-	  * @if jp
-	  * @brief コンストラクタ
-	  *
-	  * @param value
-	  *
-	  * @else
-	  * @brief Constructor
-	  *
-	  * @param value
-	  *
-	  * @endif
-	  */
-    DirectInPortBase(DataType& value)
-    {
-    }
     
 	/*!
 	* @if jp
@@ -105,10 +89,7 @@ namespace RTC
      * 
      * @endif
      */
-    virtual bool isNew()
-    {
-		return false;
-    }
+    virtual bool isNew() = 0;
 
     /*!
      * @if jp
@@ -133,10 +114,7 @@ namespace RTC
      * 
      * @endif
      */
-    virtual bool isEmpty()
-    {
-		return true;
-    }
+    virtual bool isEmpty() = 0;
 
 	/*!
 	* @if jp
@@ -151,9 +129,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-    virtual void write(const DataType& data)
-    {
-    }
+    virtual void write(DataType& data) = 0;
 
 
   protected:

--- a/src/lib/rtm/DirectOutPortBase.h
+++ b/src/lib/rtm/DirectOutPortBase.h
@@ -50,22 +50,6 @@ namespace RTC
 	  typedef coil::Guard<coil::Mutex> Guard;
   public:
 	/*!
-     * @if jp
-     * @brief コンストラクタ
-     *
-     * @param value
-     *
-     * @else
-     * @brief Constructor
-     *
-     * @param value
-     *
-     * @endif
-     */
-	DirectOutPortBase(DataType& value)
-	{
-	}
-	/*!
 	* @if jp
 	* @brief デストラクタ
 	*
@@ -92,9 +76,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual void read(DataType& data)
-	{
-	}
+    virtual void read(DataType& data) = 0;
 	/*!
 	* @if jp
 	* @brief 新規データの存在確認
@@ -108,10 +90,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual bool isNew()
-	{
-		return false;
-	}
+    virtual bool isNew() = 0;
 	/*!
 	* @if jp
 	* @brief 新規データが無いことを確認
@@ -125,10 +104,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual bool isEmpty()
-	{
-		return true;
-	}
+    virtual bool isEmpty() = 0;
     
   protected:
   };

--- a/src/lib/rtm/DirectPortBase.h
+++ b/src/lib/rtm/DirectPortBase.h
@@ -46,19 +46,6 @@ namespace RTC
   class DirectPortBase
   {
   public:
-	  /*!
-	  * @if jp
-	  * @brief コンストラクタ
-	  *
-	  *
-	  * @else
-	  * @brief Constructor
-	  *
-	  *
-	  * @endif
-	  */
-    DirectPortBase(){};
-    
 	/*!
 	* @if jp
 	* @brief デストラクタ

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -154,7 +154,6 @@ namespace RTC
 #else
       : InPortBase(name, ::CORBA_Util::toRepositoryId<DataType>()),
 #endif
-	  DirectInPortBase<DataType>(value),
         m_name(name), m_value(value),
         m_OnRead(nullptr),  m_OnReadConvert(nullptr),
         m_status(1), m_directNewData(false)
@@ -448,7 +447,7 @@ namespace RTC
       return false;
     }
 
-    virtual void write(DataType& data)
+    void write(DataType& data) override
     {
       Guard guard(m_valueMutex);
       m_value = data;

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -141,7 +141,6 @@ namespace RTC
 #else
       : OutPortBase(name, ::CORBA_Util::toRepositoryId<DataType>()),
 #endif
-	  DirectOutPortBase<DataType>(value),
 	  m_value(value), m_onWrite(nullptr), m_onWriteConvert(nullptr),
 	  m_directNewData(false), m_directValue(value)
     {


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change

DitectInPortBase、DirectOutPortBase、DirectPortBaseクラスでIsNew関数、isEmpty関数等を単なるtrueやfalseを返す関数で定義していたが、その必要はないため純粋仮想関数に変更した。





## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
