### PR TITLE
fluentbit_streamがビルドできなくなっていたため修正

### DIFF
--- a/src/ext/logger/fluentbit_stream/CMakeLists.txt
+++ b/src/ext/logger/fluentbit_stream/CMakeLists.txt
@@ -49,6 +49,7 @@ include_directories(
 
 add_definitions(${ORB_C_FLAGS_LIST})
 add_definitions(${COIL_C_FLAGS_LIST})
+add_definitions(-Dtypeof=decltype)
 
 
 set(target FluentBit)

--- a/src/ext/logger/fluentbit_stream/CMakeLists.txt
+++ b/src/ext/logger/fluentbit_stream/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.0.2)
 
 project (FluentBit
 	VERSION ${RTM_VERSION}
-	LANGUAGES CXX))
+	LANGUAGES CXX)
 
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
C++11の機能を有効にしたことによりtypeofが使用できなくなりfluent-bitのヘッダーファイルからエラーが出る。
またCMakeLists.txt内で括弧の数が間違っているためCMakeでエラーになる。


## Description of the Change

decltypeをtypeofという名前で定義することで解決した。

また、fluentbit_streamのCMakeLists.txtで括弧の数が間違っていたため修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
