### PR TITLE
RTC終了時に`ERROR: ec_worker: State of the RTC is not ACTIVE_STATE.`とログに出力される問題の修正

### DIFF
--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -5622,7 +5622,6 @@ namespace RTC
 
             ec->deactivate_component(
                             RTC::LightweightRTObject::_duplicate(m_comp));
-            ec->stop();
           }
       }
       LightweightRTObject_var m_comp;

--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -5619,9 +5619,17 @@ namespace RTC
       {
         if (!::CORBA::is_nil(ec) && !ec->_non_existent())
           {
-
-            ec->deactivate_component(
-                            RTC::LightweightRTObject::_duplicate(m_comp));
+            if (ec->get_component_state(m_comp) == RTC::ACTIVE_STATE)
+              {
+                ec->deactivate_component(
+                    RTC::LightweightRTObject::_duplicate(m_comp));
+              }
+            else if (ec->get_component_state(m_comp) == RTC::ERROR_STATE)
+              {
+                ec->reset_component(
+                    RTC::LightweightRTObject::_duplicate(m_comp));
+              }
+            
           }
       }
       LightweightRTObject_var m_comp;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#246 


## Description of the Change

RTC終了時に、対象のECでアクティブ状態であればdeactivate、エラー状態であればresetするように変更した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
