### PR TITLE
forループを可能な限り範囲for文に変更する

### DIFF
--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -94,9 +94,9 @@ RTC::ReturnCode_t Inputbutton::onExecute(RTC::UniqueId  /*ec_id*/)
   if (cmds.size() > 1)
     {
       std::cout << "  [args]: ";
-      for (size_t i(1); i < cmds.size(); ++i)
+      for(auto & cmd : cmds)
         {
-          std::cout << cmds[i] << " ";
+          std::cout << cmd << " ";
         }
    }
   std::cout << std::endl;

--- a/examples/StaticFsm/MicrowaveFsm.cpp
+++ b/examples/StaticFsm/MicrowaveFsm.cpp
@@ -88,7 +88,7 @@ namespace MicrowaveFsm
   void Programmed::minute(RTC::TimedLong time)
   {
     std::cout << "[Microwave] >>> Timer incremented <<<" << std::endl;
-    for (CORBA::ULong i(0); i < time.data; ++i)
+    for (CORBA::Long i(0); i < time.data; ++i)
       {
         TOP::box().incrementTimer();
       }

--- a/examples/StaticFsm/MicrowaveFsm.cpp
+++ b/examples/StaticFsm/MicrowaveFsm.cpp
@@ -88,7 +88,7 @@ namespace MicrowaveFsm
   void Programmed::minute(RTC::TimedLong time)
   {
     std::cout << "[Microwave] >>> Timer incremented <<<" << std::endl;
-    for (size_t i(0); i < static_cast<size_t>(time.data); ++i)
+    for (CORBA::ULong i(0); i < time.data; ++i)
       {
         TOP::box().incrementTimer();
       }

--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -62,20 +62,20 @@ namespace RTC
 
     const std::vector<coil::Properties*>& leaf(prop.getLeaf());
 
-    for (size_t i(0); i < leaf.size(); ++i)
+    for(auto & lprop : leaf)
       {
-        std::string key(leaf[i]->getName());
+        std::string key(lprop->getName());
         if (key.find("output") != std::string::npos)
           {
-            createOutputStream(*leaf[i]);
+            createOutputStream(lprop);
           }
         else if (key.find("input") != std::string::npos)
           {
-            createInputStream(*leaf[i]);
+            createInputStream(lprop);
           }
         else if (key.find("option") != std::string::npos)
         {
-            setServiceOption(*leaf[i]);
+            setServiceOption(lprop);
         }
       }
     // Start the background worker
@@ -87,9 +87,9 @@ namespace RTC
   {
     const std::vector<Properties*>& leaf = prop.getLeaf();
     int ret = 0;
-    for (size_t i(0); i < leaf.size(); ++i)
+    for(auto & lprop : leaf)
       {
-        ret = flb_service_set(s_flbContext, leaf[i]->getName(), leaf[i]->getValue(), NULL);
+        ret = flb_service_set(s_flbContext, lprop->getName(), lprop->getValue(), NULL);
       }
     return ret;
   }
@@ -102,10 +102,10 @@ namespace RTC
 
     m_flbOut.push_back(flbout);
     const std::vector<Properties*>& leaf = prop.getLeaf();
-    for (size_t i(0); i < leaf.size(); ++i)
+    for(auto & lprop : leaf)
       {
         flb_output_set(s_flbContext, flbout,
-                       leaf[i]->getName(), leaf[i]->getValue(), NULL);
+                       lprop->getName(), lprop->getValue(), NULL);
       }
     return true;
   }
@@ -118,10 +118,10 @@ namespace RTC
                                  (char*)plugin.c_str(), NULL);
     m_flbIn.push_back(flbin);
     const std::vector<Properties*>& leaf = prop.getLeaf();
-    for (size_t i(0); i < leaf.size(); ++i)
+    for(auto & lprop : leaf)
       {
         flb_input_set(s_flbContext, flbin,
-                      leaf[i]->getName(), leaf[i]->getValue(), NULL);
+                      lprop->getName(), lprop->getValue(), NULL);
       }
     return true;
   }
@@ -130,13 +130,13 @@ namespace RTC
   {
     char tmp[BUFFER_LEN];
     std::streamsize n(0);
-    for (size_t i(0); i < m_flbIn.size(); ++i)
+    for(auto & flb : m_flbIn)
       {
 
         n = snprintf(tmp, sizeof(tmp) - 1,
                      "[%lu, {\"message\": \"%s\", \"time\":\"%s\",\"name\":\"%s\",\"level\":\"%s\"}]", time(NULL), mes, date.c_str(), name.c_str(), Logger::getLevelString(level).c_str());
 
-        flb_lib_push(s_flbContext, m_flbIn[i], tmp, n);
+        flb_lib_push(s_flbContext, flb tmp, n);
       }
     return n;
   }

--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
@@ -174,42 +174,42 @@ namespace RTC
       {
         flags[i] = false;
       }
-    for (size_t i(0); i < observed.size(); ++i)
+    for(auto & o : observed)
       {
-        coil::toUpper(observed[i]);
-        if (observed[i] == "COMPONENT_PROFILE")
+        coil::toUpper(o);
+        if (o == "COMPONENT_PROFILE")
           {
             flags[RTC::COMPONENT_PROFILE] = true;
           }
-        else if (observed[i] == "RTC_STATUS")
+        else if (o == "RTC_STATUS")
           {
             flags[RTC::RTC_STATUS] = true;
           }
-        else if (observed[i] == "EC_STATUS")
+        else if (o == "EC_STATUS")
           {
             flags[RTC::EC_STATUS] = true;
           }
-        else if (observed[i] == "PORT_PROFILE")
+        else if (o == "PORT_PROFILE")
           {
             flags[RTC::PORT_PROFILE] = true;
           }
-        else if (observed[i] == "CONFIGURATION")
+        else if (o == "CONFIGURATION")
           {
             flags[RTC::CONFIGURATION] = true;
           }
-        else if (observed[i] == "FSM_PROFILE")
+        else if (o == "FSM_PROFILE")
           {
             flags[RTC::FSM_PROFILE] = true;
           }
-        else if (observed[i] == "FSM_STATUS")
+        else if (o == "FSM_STATUS")
           {
             flags[RTC::FSM_STATUS] = true;
           }
-        else if (observed[i] == "FSM_STRUCTURE")
+        else if (o == "FSM_STRUCTURE")
           {
             flags[RTC::FSM_STRUCTURE] = true;
           }
-        else if (observed[i] == "ALL")
+        else if (o == "ALL")
           {
             for (int j(0); j < RTC::STATUS_KIND_NUM; ++j)
               {

--- a/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.cpp
+++ b/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.cpp
@@ -186,7 +186,7 @@ namespace RTC
 #if (FASTRTPS_VERSION_MAJOR <= 1) && (FASTRTPS_VERSION_MINOR == 6)
     bool CORBACdrDataPubSubType::getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t* handle) {
 #else
-    bool CORBACdrDataPubSubType::getKey(void *data, InstanceHandle_t* handle, bool force_md5) {
+    bool CORBACdrDataPubSubType::getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t* handle, bool force_md5) {
 #endif
         if(!m_isGetKeyDefined)
             return false;

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.h
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.h
@@ -664,9 +664,9 @@ namespace RTC
 
       data.data.length(msg.data.size());
       int count = 0;
-      for(auto itr=msg.data.begin();itr != msg.data.end();++itr)
+      for(auto & d : msg.data)
       {
-        data.data[count] = *itr;
+        data.data[count] = d;
         count++;
       }
 

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -68,8 +68,9 @@ namespace RTC
   {
     RTC_PARANOID(("~ROSInPort()"));
 
-    for(std::map<std::string, ros::ConnectionPtr>::iterator itr = m_tcp_connecters.begin(); itr != m_tcp_connecters.end(); ++itr) {
-      itr->second->drop(ros::Connection::Destructing);
+    for(auto & con : m_tcp_connecters)
+    {
+      con.second->drop(ros::Connection::Destructing);
     }
 
     RosTopicManager& topicmgr = RosTopicManager::instance();

--- a/src/ext/transport/ROSTransport/ROSOutPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSOutPort.cpp
@@ -51,8 +51,9 @@ namespace RTC
   {
     RTC_PARANOID(("~ROSOutPort()"));
     
-    for(std::map<std::string, ros::ConnectionPtr>::iterator itr = m_tcp_connecters.begin(); itr != m_tcp_connecters.end(); ++itr) {
-      itr->second->drop(ros::Connection::Destructing);
+    for(auto & con : m_tcp_connecters)
+    {
+      con.second->drop(ros::Connection::Destructing);
     }
     RosTopicManager& topicmgr = RosTopicManager::instance();
     topicmgr.removePublisher(this);

--- a/src/ext/transport/ROSTransport/ROSSerializer.h
+++ b/src/ext/transport/ROSTransport/ROSSerializer.h
@@ -427,9 +427,9 @@ namespace RTC
 
       data.data.length(msg.data.size());
       int count = 0;
-      for(auto itr=msg.data.begin();itr != msg.data.end();++itr)
+      for(auto & d : msg.data)
       {
-        data.data[count] = *itr;
+        data.data[count] = d;
         count++;
       }
 

--- a/src/ext/transport/ROSTransport/RosTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/RosTopicManager.cpp
@@ -241,7 +241,7 @@ namespace RTC
         //RTC_VERBOSE(("Caller ID:%s",caller_id.c_str()));
         //RTC_VERBOSE(("Topic Name:%s",topic.c_str()));
         //RTC_VERBOSE(("URI:%s",xmlrpc_uri.c_str()));
-        subscriber.connectTCP(caller_id, topic, xmlrpc_uri);
+        subscriber->connectTCP(caller_id, topic, xmlrpc_uri);
       }
       new_.push_back(xmlrpc_uri);
     }
@@ -256,7 +256,7 @@ namespace RTC
         //RTC_INFO(("Delete Connector:%s %s %s", caller_id.c_str(), topic.c_str(), old_uri->c_str()));
         for(auto & subscriber : m_subscribers)
         {
-          subscriber.deleteTCPConnector(caller_id, topic, old_uri);
+          subscriber->deleteTCPConnector(caller_id, topic, old_uri);
         }
       }
     }

--- a/src/ext/transport/ROSTransport/RosTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/RosTopicManager.cpp
@@ -235,28 +235,28 @@ namespace RTC
     for (int i = 0; i < params[2].size(); i++)
     {
       std::string xmlrpc_uri = params[2][i];
-      for(std::vector<ROSInPort*>::iterator itr=m_subscribers.begin();itr != m_subscribers.end();++itr)
+      for(auto & subscriber : m_subscribers)
       {
         //RTC_VERBOSE(("Connect TCP"));
         //RTC_VERBOSE(("Caller ID:%s",caller_id.c_str()));
         //RTC_VERBOSE(("Topic Name:%s",topic.c_str()));
         //RTC_VERBOSE(("URI:%s",xmlrpc_uri.c_str()));
-        (*itr)->connectTCP(caller_id, topic, xmlrpc_uri);
+        subscriber.connectTCP(caller_id, topic, xmlrpc_uri);
       }
       new_.push_back(xmlrpc_uri);
     }
 
-    for(std::vector<std::string>::iterator old_uri=old_.begin();old_uri != old_.end();++old_uri)
+    for(auto & old_uri : old_)
     {
-      std::vector<std::string>::iterator itr_uri = std::find(new_.begin(), new_.end(), *old_uri);
+      std::vector<std::string>::iterator itr_uri = std::find(new_.begin(), new_.end(), old_uri);
       size_t index = std::distance( new_.begin(), itr_uri );
 
       if (index == new_.size()) 
       {
         //RTC_INFO(("Delete Connector:%s %s %s", caller_id.c_str(), topic.c_str(), old_uri->c_str()));
-        for(std::vector<ROSInPort*>::iterator itr=m_subscribers.begin();itr != m_subscribers.end();++itr)
+        for(auto & subscriber : m_subscribers)
         {
-          (*itr)->deleteTCPConnector(caller_id, topic, *old_uri);
+          subscriber.deleteTCPConnector(caller_id, topic, old_uri);
         }
       }
     }

--- a/src/ext/transport/ROSTransport/RosTopicManager.h
+++ b/src/ext/transport/ROSTransport/RosTopicManager.h
@@ -260,7 +260,7 @@ namespace RTC
             //RTC_PARANOID(("tcprosAcceptConnection()"));
             for(auto & publisher : m_publishers) 
             {
-                publisher.connectTCP(transport);
+                publisher->connectTCP(transport);
             }
         };
 

--- a/src/ext/transport/ROSTransport/RosTopicManager.h
+++ b/src/ext/transport/ROSTransport/RosTopicManager.h
@@ -258,9 +258,9 @@ namespace RTC
         void tcprosAcceptConnection(const ros::TransportTCPPtr& transport)
         {
             //RTC_PARANOID(("tcprosAcceptConnection()"));
-            for(std::vector<ROSOutPort*>::iterator itr=m_publishers.begin();itr != m_publishers.end();++itr)
+            for(auto & publisher : m_publishers) 
             {
-                (*itr)->connectTCP(transport);
+                publisher.connectTCP(transport);
             }
         };
 

--- a/src/lib/coil/common/Logger.cpp
+++ b/src/lib/coil/common/Logger.cpp
@@ -149,10 +149,9 @@ namespace coil
     std::vector<LogStreamBuffer*> LogStreamBuffer::getBuffers()
     {
         std::vector<LogStreamBuffer*> buffs;
-        std::vector<Stream>::iterator it;
-        for (it = m_streams.begin(); it != m_streams.end(); ++it)
+        for(auto & s : m_streams)
         {
-            buffs.push_back((*it).stream_);
+            buffs.push_back(s.stream_);
         }
         return buffs;
     }
@@ -185,11 +184,10 @@ namespace coil
      */
     void LogStreamBuffer::write(int level, const std::string &name, const std::string &date, const std::string &mes)
     {
-        std::vector<Stream>::iterator it;
-        for (it = m_streams.begin(); it != m_streams.end(); ++it)
+        for(auto & s : m_streams) 
         {
-            Guard gaurd((*it).mutex_);
-            (*it).stream_->write(level, name, date, mes);
+            Guard gaurd(s.mutex_);
+            s.stream_->write(level, name, date, mes);
         }
 
     }

--- a/src/lib/coil/common/stringutil.h
+++ b/src/lib/coil/common/stringutil.h
@@ -606,7 +606,7 @@ namespace coil
     std::stringstream str_stream;
     str_stream << n;
     return str_stream.str();
-  };
+  }
 
   /*!
    * @if jp
@@ -727,7 +727,7 @@ namespace coil
     ss << reinterpret_cast<uintptr_t>(n);
     return ss.str();
 #endif
-  };
+  }
 
   /*!
    * @if jp

--- a/src/lib/coil/vxworks/coil/Affinity.cpp
+++ b/src/lib/coil/vxworks/coil/Affinity.cpp
@@ -84,10 +84,10 @@ namespace coil
   {
     coil::vstring tmp = coil::split(cpu_mask, ",", true);
     CpuMask mask;
-    for (size_t i(0); i < tmp.size(); ++i)
+    for(auto & m: tmp)
       {
         int num;
-        if (coil::stringTo(num, tmp[i].c_str()))
+        if (coil::stringTo(num, m.c_str()))
           {
             mask.push_back(num);
           }

--- a/src/lib/coil/win32/coil/Affinity.cpp
+++ b/src/lib/coil/win32/coil/Affinity.cpp
@@ -25,8 +25,9 @@ namespace coil
   DWORD_PTR listToCUPNUM(CpuMask &cpu_mask)
   {
     DWORD_PTR cpu_num = 0;
-    for(CpuMask::iterator itr = cpu_mask.begin(); itr != cpu_mask.end(); ++itr) {
-      DWORD_PTR p = (DWORD_PTR)0x01 << (*itr);
+    for(auto & m : cpu_mask)
+    {
+      DWORD_PTR p = (DWORD_PTR)0x01 << m;
       cpu_num += p;
     }
     return cpu_num;

--- a/src/lib/coil/win32/coil/OS.h
+++ b/src/lib/coil/win32/coil/OS.h
@@ -55,13 +55,12 @@ namespace coil
       {
 
       }
+      osversion(const osversion& obj) : major(obj.major), minor(obj.minor)
+      {
+
+      }
       osversion(DWORD majar_version,DWORD minor_version) : major(majar_version), minor(minor_version)
       {
-      }
-      osversion(osversion &obj)
-      {
-          major = obj.major;
-          minor = obj.minor;
       }
       DWORD major;
       DWORD minor;
@@ -192,14 +191,14 @@ namespace coil
         oslist["Windows 8.1"] = osversion(6, 3);
         oslist["Windows 10"] = osversion(10, 0);
 
-        for (std::map<std::string, osversion>::iterator itr = oslist.begin(); itr != oslist.end(); ++itr)
+        for(auto & o : oslist)
         {
             // name.release, name.version
             OSVERSIONINFOEX version_info;
             ULONGLONG condition = 0;
             version_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-            version_info.dwMajorVersion = itr->second.major;
-            version_info.dwMinorVersion = itr->second.minor;
+            version_info.dwMajorVersion = o.second.major;
+            version_info.dwMinorVersion = o.second.minor;
             VER_SET_CONDITION(condition, VER_MAJORVERSION, VER_EQUAL);
             VER_SET_CONDITION(condition, VER_MINORVERSION, VER_EQUAL);
 

--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -130,14 +130,13 @@ namespace coil
 
       out = coil::split(std::string(Buf), "\n");
 
-      for (coil::vstring::iterator itr = out.begin(); itr != out.end(); ++itr)
+      for(auto & o : out)
       {
-          std::string &tmp = (*itr);
-          if (0 < tmp.size())
+          if (0 < o.size())
           {
-              tmp.erase(tmp.size() - 1);
+              o.erase(o.size() - 1);
           }
-          coil::eraseBothEndsBlank(tmp);
+          coil::eraseBothEndsBlank(o);
       }
 
       delete lpcommand;

--- a/src/lib/rtm/ComponentActionListener.cpp
+++ b/src/lib/rtm/ComponentActionListener.cpp
@@ -105,11 +105,11 @@ namespace RTC
 
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;

--- a/src/lib/rtm/ConfigurationListener.cpp
+++ b/src/lib/rtm/ConfigurationListener.cpp
@@ -93,11 +93,11 @@ namespace RTC
 
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;
@@ -161,11 +161,11 @@ namespace RTC
 
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;
@@ -226,11 +226,11 @@ namespace RTC
     std::vector<Entry>::iterator it(m_listeners.begin());
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -106,11 +106,11 @@ namespace RTC
     std::vector<Entry>::iterator it(m_listeners.begin());
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;
@@ -179,11 +179,11 @@ namespace RTC
 
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;

--- a/src/lib/rtm/CorbaPort.cpp
+++ b/src/lib/rtm/CorbaPort.cpp
@@ -155,11 +155,9 @@ namespace RTC
    */
   void CorbaPort::activateInterfaces()
   {
-    CorbaProviderList::iterator it(m_providers.begin());
-    while (it != m_providers.end())
+    for(auto & provider : m_providers)
       {
-        it->activate();
-        ++it;
+        provider.activate();
       }
   }
 
@@ -172,11 +170,9 @@ namespace RTC
    */
   void CorbaPort::deactivateInterfaces()
   {
-    CorbaProviderList::iterator it(m_providers.begin());
-    while (it != m_providers.end())
+    for(auto & provider : m_providers)
       {
-        it->deactivate();
-        ++it;
+        provider.deactivate();
       }
   }
 
@@ -202,27 +198,25 @@ namespace RTC
       }
 
     NVList properties;
-    CorbaProviderList::iterator it(m_providers.begin());
-    while (it != m_providers.end())
+    for(auto & provider : m_providers)
       {
         //------------------------------------------------------------
         // new version descriptor
         // <comp_iname>.port.<port_name>.provided.<type_name>.<instance_name>
         std::string newdesc((const char*)m_profile.name);
         newdesc.insert(m_ownerInstanceName.size(), ".port");
-        newdesc += ".provided." + it->descriptor();
+        newdesc += ".provided." + provider.descriptor();
         CORBA_SeqUtil::
           push_back(properties,
-                    NVUtil::newNV(newdesc.c_str(), it->ior().c_str()));
+                    NVUtil::newNV(newdesc.c_str(), provider.ior().c_str()));
 
         //------------------------------------------------------------
         // old version descriptor
         // port.<type_name>.<instance_name>
-        std::string olddesc = "port." + it->descriptor();
+        std::string olddesc = "port." + provider.descriptor();
         CORBA_SeqUtil::
           push_back(properties,
-                    NVUtil::newNV(olddesc.c_str(), it->ior().c_str()));
-        ++it;
+                    NVUtil::newNV(olddesc.c_str(), provider.ior().c_str()));
       }
 
 #ifdef ORB_IS_RTORB

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -245,11 +245,12 @@ namespace RTC
                 RTC_DEBUG(("no connectors"));
                 return false;
             }
-            for (ConnectorList::iterator itr = m_connectors.begin(); itr != m_connectors.end(); ++itr)
+
+            for(auto & con : m_connectors)
             {
-                if (std::string((*itr)->name()) == name)
+                if (std::string(con->name()) == name)
                 {
-                    size_t r = (*itr)->getBuffer()->readable();
+                    size_t r = con->getBuffer()->readable();
                     if (r > 0)
                     {
                         RTC_DEBUG(("isNew() = true, readable data: %d", r));
@@ -276,12 +277,12 @@ namespace RTC
                 RTC_DEBUG(("no connectors"));
                 return false;
             }
-            for (ConnectorList::iterator itr = m_connectors.begin(); itr != m_connectors.end(); ++itr)
+            for(auto & con : m_connectors)
             {
-                size_t r = (*itr)->getBuffer()->readable();
+                size_t r = con->getBuffer()->readable();
                 if (r > 0)
                 {
-                    names.push_back((*itr)->name());
+                    names.push_back(con->name());
                 }
             }
             
@@ -367,11 +368,12 @@ namespace RTC
                 RTC_DEBUG(("no connectors"));
                 return false;
             }
-            for (ConnectorList::iterator itr = m_connectors.begin(); itr != m_connectors.end(); ++itr)
+
+            for(auto & con : m_connectors)
             {
-                if (std::string((*itr)->name()) == name)
+                if (std::string(con->name()) == name)
                 {
-                    size_t r = (*itr)->getBuffer()->readable();
+                    size_t r = con->getBuffer()->readable();
                     if (r == 0)
                     {
                         RTC_DEBUG(("isEmpty() = true, buffer is empty"));
@@ -398,12 +400,13 @@ namespace RTC
                 RTC_DEBUG(("no connectors"));
                 return false;
             }
-            for (ConnectorList::iterator itr = m_connectors.begin(); itr != m_connectors.end(); ++itr)
+
+            for(auto & con : m_connectors)
             {
-                size_t r = (*itr)->getBuffer()->readable();
+                size_t r = con->getBuffer()->readable();
                 if (r == 0)
                 {
-                    names.push_back((*itr)->name());
+                    names.push_back(con->name());
                 }
             }
 
@@ -575,11 +578,11 @@ namespace RTC
       }
       else
       {
-          for (ConnectorList::iterator itr = m_connectors.begin(); itr != m_connectors.end(); ++itr)
+          for(auto & con : m_connectors)
           {
-              if (std::string((*itr)->name()) == name)
+              if (std::string(con->name()) == name)
               {
-                  connector = (*itr);
+                  connector = con;
               }
           }
       }

--- a/src/lib/rtm/ListenerHolder.h
+++ b/src/lib/rtm/ListenerHolder.h
@@ -172,13 +172,12 @@ namespace util
     virtual ~ListenerHolder()
     {
       Guard guard(m_mutex);
-      EntryIterator it(m_listeners.begin());
 
-      for (; it != m_listeners.end(); ++it)
+      for(auto & listener : m_listeners)
         {
-          if ((*it).second)
+          if (listener.second)
             {
-              delete (*it).first;
+              delete listener.first;
             }
         }
       m_listeners.clear();

--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -163,7 +163,7 @@ namespace RTC
                 std::cerr << "Configuration file: " << m_configFile;
                 std::cerr << " not found." << std::endl;
 #ifndef __QNX__
-                for (size_t i(0); i < static_cast<size_t>(argc); ++i)
+                for (int i(0); i < argc; ++i)
                   {
                     std::string tmp(argv[i]);
                     if (tmp == "-i") { ignoreNoConf = true; }

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1236,10 +1236,10 @@ namespace RTM
   {
     RTC_TRACE(("createComponentByManagerName(%s)",create_arg.c_str()));
     coil::mapstring param = coil::urlparam2map(create_arg);
-    for (coil::mapstring::iterator it(param.begin()); it != param.end(); ++it)
+    for(auto & p : param)
       {
         RTC_DEBUG(("create_arg[%s] = %s",
-                   it->first.c_str(), it->second.c_str()));
+                   p.first.c_str(), p.second.c_str()));
       }
 
     std::string mgrstr = param["manager_name"];
@@ -1393,10 +1393,10 @@ namespace RTM
   {
     RTC_TRACE(("createComponentByAddress(%s)",create_arg.c_str()));
     coil::mapstring param = coil::urlparam2map(create_arg);
-    for (coil::mapstring::iterator it(param.begin()); it != param.end(); ++it)
+    for(auto & p : param)
       {
         RTC_DEBUG(("create_arg[%s] = %s",
-                   it->first.c_str(), it->second.c_str()));
+                   p.first.c_str(), p.second.c_str()));
       }
 
     std::string mgrstr = param["manager_address"];

--- a/src/lib/rtm/PortConnectListener.cpp
+++ b/src/lib/rtm/PortConnectListener.cpp
@@ -127,11 +127,11 @@ namespace RTC
 
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;
@@ -192,11 +192,11 @@ namespace RTC
     std::vector<Entry>::iterator it(m_listeners.begin());
     for (; it != m_listeners.end(); ++it)
       {
-        if ((*it).first == listener)
+        if (it->first == listener)
           {
-            if ((*it).second)
+            if (it->second)
               {
-                delete (*it).first;
+                delete it->first;
               }
             m_listeners.erase(it);
             return;

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -2048,21 +2048,18 @@ namespace RTC
   bool RTObject_impl::readAll()
   {
     RTC_TRACE(("readAll()"));
-    std::vector<InPortBase*>::iterator it     = m_inports.begin();
-    std::vector<InPortBase*>::iterator it_end = m_inports.end();
     bool ret(true);
 
-    while ( it != it_end )
+    for(auto & inport : m_inports)
       {
 
-        if (!((*it)->read()))
+        if (!(inport->read()))
           {
             RTC_DEBUG(("The error occurred in readAll()."));
             ret = false;
             if (!m_readAllCompletion)
               return false;
           }
-        ++it;
       }
 
     return ret;
@@ -2080,21 +2077,17 @@ namespace RTC
   bool RTObject_impl::writeAll()
   {
     RTC_TRACE(("writeAll()"));
-    std::vector<OutPortBase*>::iterator it     = m_outports.begin();
-    std::vector<OutPortBase*>::iterator it_end = m_outports.end();
-
     bool ret(true);
 
-    while ( it != it_end )
+    for(auto & outport : m_outports)
       {
-        if (!((*it)->write()))
+        if (!(outport->write()))
           {
             RTC_DEBUG(("The error occurred in writeAll()."));
             ret = false;
             if (!m_writeAllCompletion)
               return false;
           }
-        ++it;
       }
     return ret;
   }
@@ -2801,19 +2794,19 @@ namespace RTC
 
     coil::Properties default_opts;
     getInheritedECOptions(default_opts);
-    for (coil::vstring::const_iterator ec_itr = ecs_tmp.begin(); ec_itr != ecs_tmp.end(); ++ec_itr)
+    for(auto & ec_ : ecs_tmp)
       {
-        std::string ec_tmp = *ec_itr;
+        std::string ec_tmp = ec_;
         if (coil::normalize(ec_tmp) == "none")
           {
             RTC_INFO(("EC none. EC will not be bound to the RTC."));
             ec_args.clear();
             return RTC::RTC_OK;
           }
-        coil::vstring type_and_name = coil::split(*ec_itr, "(", true);
+        coil::vstring type_and_name = coil::split(ec_, "(", true);
         if (type_and_name.size() > 2)
           {
-            RTC_DEBUG(("Invalid EC type specified: %s", (*ec_itr).c_str()));
+            RTC_DEBUG(("Invalid EC type specified: %s", ec_.c_str()));
             continue;
           }
         coil::Properties p = default_opts;

--- a/src/lib/rtm/SdoServiceAdmin.cpp
+++ b/src/lib/rtm/SdoServiceAdmin.cpp
@@ -420,7 +420,7 @@ namespace RTC
             SdoServiceConsumerFactory&
               factory(SdoServiceConsumerFactory::instance());
             factory.deleteObject(*it);
-            it = m_consumers.erase(it);
+            m_consumers.erase(it);
             RTC_INFO(("SDO service has been deleted: %s", id));
             return true;
           }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

forループについて、変更可能な部分は全て範囲for文に統一する。


## Description of the Change

以下の場合を除いて変更した。

現在のループした回数が必要な場合

- VectorConvert.cpp 19行目
- ConfiguSamole.cpp 152行目
- Affinity.cpp 57、116行目
- Manager.cpp 710行目
- ManagerServant.cpp 201、568、621行目
- SdoConfiguration.cpp 519行目
- SdoServiceAdmin.cpp 208行目


ループ内で要素を削除する場合

- 多数のため省略


ループの終了条件が複数ある場合

- File.h 151行目

ループ内部で条件によりイテレータをインクリメントする場合

- Manager.cpp 2438行目

以下は問題があると考えられる箇所。

- OutPort.h 240行目
この部分のループ内で、以下のように`m_status`に値を格納する箇所がある。

```CPP
m_status[i] = ret;
```

現在のループ回数を必要とするのはこの部分のみであり、m_statusを削除する方針であれば範囲for文に変更したほうがいい。


- Timer.cpp 174行目

この部分ではforループでカウンタ変数をインクリメントすると同時にイテレータのインクリメントも実行している。
一般的な記述方法ではないため可読性が悪く、カウンタ変数が指す要素とイテレータの指す要素が一致している保証はなくバグの元になるため変更をお勧めします。

```CPP
    std::vector<Task>::iterator it;
    it = m_tasks.begin();

    for (size_t i(0), len(m_tasks.size()); i < len; ++i, ++it)
      {
        if (m_tasks[i].listener == id)
          {
            m_tasks.erase(it);
            return true;
          }
      }
```


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
