### PR TITLE
suppress unused warnings in Macho

### DIFF
--- a/examples/StaticFsm/Display.h
+++ b/examples/StaticFsm/Display.h
@@ -18,9 +18,6 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/ConnectorListener.h>
 #include <rtm/Macho.h>
-#ifdef RTM_OS_LINUX
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 
 #include <iostream>
 

--- a/src/lib/rtm/Macho.cpp
+++ b/src/lib/rtm/Macho.cpp
@@ -48,7 +48,7 @@ void * Macho::_createBox<_EmptyBox>(void * &  /*place*/) {
 }
 
 template<>
-void Macho::_deleteBox<_EmptyBox>(void * & box, void * & place) {
+void Macho::_deleteBox<_EmptyBox>(void * & /* box */, void * & /* place */) {
 }
 
 #ifdef MACHO_SNAPSHOTS

--- a/src/lib/rtm/Macho.h
+++ b/src/lib/rtm/Macho.h
@@ -1,14 +1,6 @@
 ﻿#ifndef __MACHO_HPP__
 #define __MACHO_HPP__
 
-//#if defined(_MSC_VER)
-//#pragma warning(push)
-//#pragma warning(disable:4512 4251)
-//#elif defined(__GNUC__) && (__GNUC_MINOR__ >= 6)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-//#endif
-
 // Macho - C++ Machine Objects
 //
 // The Machine Objects class library (in short Macho) allows the creation of
@@ -462,7 +454,7 @@ namespace Macho {
 
 		// This is the method to bubble up history information
 		// for states whose superstates have no history (so does nothing).
-		virtual void _setHistorySuper(_StateInstance & self, _StateInstance & deep) {}
+		virtual void _setHistorySuper(_StateInstance & /* self */, _StateInstance & /* deep*/ ) {}
 
 	private:
 		// State exit. Not allowed to initiate state change.
@@ -497,10 +489,10 @@ namespace Macho {
 		// Create StateInstance object of state.
 		static _StateInstance & _getInstance(_MachineBase & machine);
 
-		virtual void _deleteBox(_StateInstance & instance) {}
+		virtual void _deleteBox(_StateInstance & /* instance */) {}
 
 		// Default history strategy (no history).
-		virtual void _saveHistory(_StateInstance & self, _StateInstance & shallow, _StateInstance & deep) {}
+		virtual void _saveHistory(_StateInstance & /* self */, _StateInstance & /* shallow */, _StateInstance & /* deep */) {}
 
 	private:
 		_StateInstance & _myStateInstance;
@@ -1675,6 +1667,8 @@ namespace Macho {
 		Machine() {
 			// Compile time check: TOP must directly derive from TopBase<TOP>
 			typedef typename __SameType<TopBase<TOP>, typename TOP::SUPER>::Check MustDeriveFromTopBase;
+			// suppress unused-typdefs warnig
+			static_assert(static_cast<MustDeriveFromTopBase*>(nullptr)==nullptr, "dummy");
 
 			allocate(theStateCount);
 			start(TOP::_getInstance(*this));
@@ -1685,6 +1679,8 @@ namespace Macho {
 		Machine(const Alias & state) {
 			// Compile time check: TOP must directly derive from TopBase<TOP>
 			typedef typename __SameType<TopBase<TOP>, typename TOP::SUPER>::Check MustDeriveFromTopBase;
+			// suppress unused-typdefs warnig
+			static_assert(static_cast<MustDeriveFromTopBase*>(nullptr)==nullptr, "dummy");
 
 			allocate(theStateCount);
 			start(state);

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -89,6 +89,8 @@
     {                                                                   \
       typedef ::__SameType< ::RTC::Link<S, SUPER>, LINK>::Check         \
         MustDeriveFromLink;                                             \
+      static_assert(static_cast<MustDeriveFromLink*>(nullptr)==nullptr, \
+                    "dummy assert for suppress warning");               \
     }                                                                   \
     ~S() override {}                                                    \
     static const char * _state_name() { return #S; }                    \


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Macho で発生する未使用系の警告がある


## Description of the Change
警告が表示されないように修正
- 引数のコメントアウト
- 型を使用するダミーコードを追加

## Verification 
動作変更なし、ビルド確認のみ

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
- [X] Have you passed the unit tests?   不要
