### PR TITLE
Python3でrtm-skelwrapperコマンド実行時にエラーが発生する問題の対応

### DIFF
--- a/utils/rtm-skelwrapper/skel_wrapper.py
+++ b/utils/rtm-skelwrapper/skel_wrapper.py
@@ -279,7 +279,7 @@ class skel_wrapper:
 		text = t.generate(data)
 
 		if os.access(fname, os.F_OK): # file exists
-			f = file(fname, "r")
+			f = open(fname, "r")
 			oldtext = f.read()
 			f.close()
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Python3でrtm-skelwrapper実行時に以下のエラーが発生。

```
   File "C:\work\OpenRTM-aist\utils\rtm-skelwrapper\skel_wrapper.py", line 282, in gen
   f = file(fname, "r")
```


## Description of the Change

Python3ではfile文が無くなったためopenに変更した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
