### PR TITLE
Fluent-Bit、および関連するライブラリがインストールされている前提でビルドする

### DIFF
--- a/src/ext/logger/fluentbit_stream/CMakeLists.txt
+++ b/src/ext/logger/fluentbit_stream/CMakeLists.txt
@@ -13,16 +13,6 @@ if(NOT FLUENTBIT_ROOT)
 	message(FATAL_ERROR "Please set FLUENTBIT_ROOT.")
 endif()
 
-set(FLUENTBIT_WORKDIR ${FLUENTBIT_WORKDIR} CACHE PATH "set FLUENTBIT_WORKDIR")
-
-if(NOT FLUENTBIT_WORKDIR)
-	message(FATAL_ERROR "Please set FLUENTBIT_WORKDIR.")
-endif()
-
-link_directories(${FLUENTBIT_WORKDIR}/lib)
-
-
-
 
 
 link_directories(${ORB_LINK_DIR})
@@ -57,17 +47,8 @@ else()
 	add_library(${target} SHARED ${srcs})
 	openrtm_common_set_compile_props(${target})
 	openrtm_include_rtm(${target})
-	target_include_directories(SYSTEM
-	PRIVATE ${FLUENTBIT_ROOT}/include
-	PRIVATE ${FLUENTBIT_ROOT}/lib/monkey/include
-	PRIVATE ${FLUENTBIT_ROOT}/lib/mbedtls-2.14.1/include
-	PRIVATE ${FLUENTBIT_ROOT}/lib/msgpack-3.1.1/include
-	PRIVATE ${FLUENTBIT_ROOT}/lib/flb_libco
-	PRIVATE ${FLUENTBIT_ROOT}/lib/jemalloc-5.1.0/include
-	PRIVATE ${FLUENTBIT_ROOT}/lib/jsmn
-	PRIVATE ${FLUENTBIT_ROOT}/lib/onigmo
-	PRIVATE ${FLUENTBIT_ROOT}/lib/sha1
-	PRIVATE ${FLUENTBIT_ROOT}/lib/sqlite-amalgamation-3400000)
+	target_include_directories(${target} SYSTEM
+	PRIVATE ${FLUENTBIT_ROOT}/lib/flb_libco)
 	target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} fluent-bit)
 	set_target_properties(${target} PROPERTIES PREFIX "")
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#263

インクルードディレクトリの指定でフォルダ名にライブラリのバージョン番号が入っている場合があり、fluentbit_streamのビルドに失敗する。


## Description of the Change

Fluent-Bit、関連するライブラリをインストールしてからビルドする手順に変更した。
インストール手順は以下の通り。

- https://tmp.openrtm.org/openrtm/ja/content/fluentbit#toc1

ただし、flb_libcoというライブラリだけは付属のCMakeLists.txtにインストールに関する設定が書かれておらずインストールはできないため、Fluent-Bitのソースディレクトリを指定する必要がある。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
