### PR TITLE
[compat, modify] modify warning for extra semicolons

### DIFF
--- a/examples/Analyzer/Analyzer.cpp
+++ b/examples/Analyzer/Analyzer.cpp
@@ -294,5 +294,5 @@ extern "C"
                              RTC::Delete<Analyzer>);
   }
   
-};
+}
 

--- a/examples/Analyzer/Analyzer.h
+++ b/examples/Analyzer/Analyzer.h
@@ -354,6 +354,6 @@ public:
 extern "C"
 {
   DLL_EXPORT void AnalyzerInit(RTC::Manager* manager);
-};
+}
 
 #endif // ANALYZER_H

--- a/examples/Analyzer/Analyzer_test.cpp
+++ b/examples/Analyzer/Analyzer_test.cpp
@@ -205,5 +205,5 @@ extern "C"
                              RTC::Delete<Analyzer_test>);
   }
   
-};
+}
 

--- a/examples/Analyzer/Analyzer_test.h
+++ b/examples/Analyzer/Analyzer_test.h
@@ -297,6 +297,6 @@ class Analyzer_test
 extern "C"
 {
   DLL_EXPORT void Analyzer_testInit(RTC::Manager* manager);
-};
+}
 
 #endif // ANALYZER_TEST_H

--- a/examples/Composite/Controller.cpp
+++ b/examples/Composite/Controller.cpp
@@ -153,7 +153,7 @@ extern "C"
                              RTC::Delete<Controller>);
   }
   
-};
+}
 
 
 

--- a/examples/Composite/Controller.h
+++ b/examples/Composite/Controller.h
@@ -124,7 +124,7 @@ class Controller  : public RTC::DataFlowComponentBase
 extern "C"
 {
   DLL_EXPORT void ControllerInit(RTC::Manager* manager);
-};
+}
 
 #endif // CONTROLLER_H
 

--- a/examples/Composite/Motor.cpp
+++ b/examples/Composite/Motor.cpp
@@ -160,7 +160,7 @@ extern "C"
                              RTC::Delete<Motor>);
   }
   
-};
+}
 
 
 

--- a/examples/Composite/Motor.h
+++ b/examples/Composite/Motor.h
@@ -125,7 +125,7 @@ class Motor  : public RTC::DataFlowComponentBase
 extern "C"
 {
   DLL_EXPORT void MotorInit(RTC::Manager* manager);
-};
+}
 
 #endif // MOTOR_H
 

--- a/examples/Composite/Sensor.cpp
+++ b/examples/Composite/Sensor.cpp
@@ -154,7 +154,7 @@ extern "C"
                              RTC::Delete<Sensor>);
   }
   
-};
+}
 
 
 

--- a/examples/Composite/Sensor.h
+++ b/examples/Composite/Sensor.h
@@ -124,7 +124,7 @@ class Sensor  : public RTC::DataFlowComponentBase
 extern "C"
 {
   DLL_EXPORT void SensorInit(RTC::Manager* manager);
-};
+}
 
 #endif // SENSOR_H
 

--- a/examples/ConfigSample/ConfigSample.cpp
+++ b/examples/ConfigSample/ConfigSample.cpp
@@ -230,6 +230,6 @@ extern "C"
                              RTC::Delete<ConfigSample>);
   }
   
-};
+}
 
 

--- a/examples/ConfigSample/ConfigSample.h
+++ b/examples/ConfigSample/ConfigSample.h
@@ -131,6 +131,6 @@ class ConfigSample
 extern "C"
 {
   DLL_EXPORT void ConfigSampleInit(RTC::Manager* manager);
-};
+}
 
 #endif // CONFIGSAMPLE_H

--- a/examples/ExtTrigger/ConsoleIn.cpp
+++ b/examples/ExtTrigger/ConsoleIn.cpp
@@ -83,6 +83,6 @@ extern "C"
                              RTC::Delete<ConsoleIn>);
   }
   
-};
+}
 
 

--- a/examples/ExtTrigger/ConsoleIn.h
+++ b/examples/ExtTrigger/ConsoleIn.h
@@ -122,6 +122,6 @@ class ConsoleIn
 extern "C"
 {
   DLL_EXPORT void ConsoleInInit(RTC::Manager* manager);
-};
+}
 
 #endif // CONSOLEIN_H

--- a/examples/ExtTrigger/ConsoleOut.cpp
+++ b/examples/ExtTrigger/ConsoleOut.cpp
@@ -87,6 +87,6 @@ extern "C"
                              RTC::Delete<ConsoleOut>);
   }
   
-};
+}
 
 

--- a/examples/ExtTrigger/ConsoleOut.h
+++ b/examples/ExtTrigger/ConsoleOut.h
@@ -122,6 +122,6 @@ class ConsoleOut
 extern "C"
 {
   DLL_EXPORT void ConsoleOutInit(RTC::Manager* manager);
-};
+}
 
 #endif // CONSOLEOUT_H

--- a/examples/SeqIO/SeqIn.cpp
+++ b/examples/SeqIO/SeqIn.cpp
@@ -441,4 +441,4 @@ extern "C"
                              RTC::Delete<SeqIn>);
   }
   
-};
+}

--- a/examples/SeqIO/SeqIn.h
+++ b/examples/SeqIO/SeqIn.h
@@ -215,6 +215,6 @@ class SeqIn
 extern "C"
 {
   DLL_EXPORT void SeqInInit(RTC::Manager* manager);
-};
+}
 
 #endif // SEQIN_H

--- a/examples/SeqIO/SeqOut.cpp
+++ b/examples/SeqIO/SeqOut.cpp
@@ -397,4 +397,4 @@ extern "C"
                              RTC::Delete<SeqOut>);
   }
   
-};
+}

--- a/examples/SeqIO/SeqOut.h
+++ b/examples/SeqIO/SeqOut.h
@@ -219,6 +219,6 @@ class SeqOut
 extern "C"
 {
   DLL_EXPORT void SeqOutInit(RTC::Manager* manager);
-};
+}
 
 #endif // SEQOUT_H

--- a/examples/SimpleIO/ConsoleIn.cpp
+++ b/examples/SimpleIO/ConsoleIn.cpp
@@ -124,7 +124,7 @@ extern "C"
                              RTC::Delete<ConsoleIn>);
   }
   
-};
+}
 
 
 

--- a/examples/SimpleIO/ConsoleIn.h
+++ b/examples/SimpleIO/ConsoleIn.h
@@ -181,7 +181,7 @@ class ConsoleIn
 extern "C"
 {
   DLL_EXPORT void ConsoleInInit(RTC::Manager* manager);
-};
+}
 
 #endif // CONSOLEIN_H
 

--- a/examples/SimpleIO/ConsoleOut.cpp
+++ b/examples/SimpleIO/ConsoleOut.cpp
@@ -124,7 +124,7 @@ extern "C"
                              RTC::Delete<ConsoleOut>);
   }
   
-};
+}
 
 
 

--- a/examples/SimpleIO/ConsoleOut.h
+++ b/examples/SimpleIO/ConsoleOut.h
@@ -179,7 +179,7 @@ class ConsoleOut
 extern "C"
 {
   DLL_EXPORT void ConsoleOutInit(RTC::Manager* manager);
-};
+}
 
 #endif // CONSOLEOUT_H
 

--- a/examples/SimpleService/MyServiceConsumer.cpp
+++ b/examples/SimpleService/MyServiceConsumer.cpp
@@ -251,6 +251,6 @@ extern "C"
                              RTC::Delete<MyServiceConsumer>);
   }
   
-};
+}
 
 

--- a/examples/SimpleService/MyServiceConsumer.h
+++ b/examples/SimpleService/MyServiceConsumer.h
@@ -208,6 +208,6 @@ class MyServiceConsumer
 extern "C"
 {
   DLL_EXPORT void MyServiceConsumerInit(RTC::Manager* manager);
-};
+}
 
 #endif // MYSERVICECONSUMER_H

--- a/examples/SimpleService/MyServiceProvider.cpp
+++ b/examples/SimpleService/MyServiceProvider.cpp
@@ -151,6 +151,6 @@ extern "C"
                              RTC::Delete<MyServiceProvider>);
   }
   
-};
+}
 
 

--- a/examples/SimpleService/MyServiceProvider.h
+++ b/examples/SimpleService/MyServiceProvider.h
@@ -123,6 +123,6 @@ class MyServiceProvider
 extern "C"
 {
   DLL_EXPORT void MyServiceProviderInit(RTC::Manager* manager);
-};
+}
 
 #endif // MYSERVICEPROVIDER_H

--- a/examples/StaticFsm/Display.cpp
+++ b/examples/StaticFsm/Display.cpp
@@ -121,6 +121,6 @@ extern "C"
                              RTC::Create<Display>,
                              RTC::Delete<Display>);
   }
-};
+}
 
 

--- a/examples/StaticFsm/Display.h
+++ b/examples/StaticFsm/Display.h
@@ -183,6 +183,6 @@ class Display
 extern "C"
 {
   DLL_EXPORT void DisplayInit(RTC::Manager* manager);
-};
+}
 
 #endif // DISPLAY_H

--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -132,6 +132,6 @@ extern "C"
                              RTC::Delete<Inputbutton>);
   }
   
-};
+}
 
 

--- a/examples/StaticFsm/Inputbutton.h
+++ b/examples/StaticFsm/Inputbutton.h
@@ -191,6 +191,6 @@ class Inputbutton
 extern "C"
 {
   DLL_EXPORT void InputbuttonInit(RTC::Manager* manager);
-};
+}
 
 #endif // INPUTBUTTON_H

--- a/examples/StaticFsm/Microwave.cpp
+++ b/examples/StaticFsm/Microwave.cpp
@@ -89,6 +89,6 @@ extern "C"
                              RTC::Create<Microwave>,
                              RTC::Delete<Microwave>);
   }
-};
+}
 
 

--- a/examples/StaticFsm/Microwave.h
+++ b/examples/StaticFsm/Microwave.h
@@ -132,6 +132,6 @@ class Microwave
 extern "C"
 {
   DLL_EXPORT void MicrowaveInit(RTC::Manager* manager);
-};
+}
 
 #endif // MICROWAVE_H

--- a/examples/Throughput/Throughput.cpp
+++ b/examples/Throughput/Throughput.cpp
@@ -550,6 +550,6 @@ extern "C"
                              RTC::Delete<Throughput>);
   }
   
-};
+}
 
 

--- a/examples/Throughput/Throughput.h
+++ b/examples/Throughput/Throughput.h
@@ -489,6 +489,6 @@ public:
 extern "C"
 {
   DLL_EXPORT void ThroughputInit(RTC::Manager* manager);
-};
+}
 
 #endif // THROUGHPUT_H

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
@@ -563,4 +563,4 @@ extern "C"
                             ::coil::Destructor< ::RTC::ExecutionContextBase,
                             ::RTC::LogicalTimeTriggeredEC>);
   }
-};
+}

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
@@ -724,6 +724,6 @@ extern "C"
    * @endif
    */
   DLL_EXPORT void LogicalTimeTriggeredECInit(RTC::Manager* manager);
-};
+}
 
 #endif // RTC_EXTTRIGEXECUTIONCONTEXT_H

--- a/src/ext/ec/rtpreempt/RTPreemptEC.cpp
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.cpp
@@ -677,5 +677,5 @@ extern "C"
                             ::coil::Destructor< ::RTC::ExecutionContextBase,
                             ::RTC_exp::RTPreemptEC>);
   }
-};
+}
 

--- a/src/ext/ec/rtpreempt/RTPreemptEC.h
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.h
@@ -827,6 +827,6 @@ extern "C"
    * @endif
    */
   void RTPreemptECInit(RTC::Manager* manager);
-};
+}
 
 #endif // RTC_RTPREEMPTEC_H

--- a/src/ext/local_service/nameservice_file/FileNameservice.cpp
+++ b/src/ext/local_service/nameservice_file/FileNameservice.cpp
@@ -467,4 +467,4 @@ extern "C"
                        ::coil::Destructor< ::RTM::LocalServiceBase,
                        ::RTM::LocalService::FileNameservice>);
   }
-};
+}

--- a/src/ext/local_service/nameservice_file/FileNameservice.h
+++ b/src/ext/local_service/nameservice_file/FileNameservice.h
@@ -306,6 +306,6 @@ extern "C"
    * @endif
    */
   DLL_EXPORT void FileNameserviceInit();
-};
+}
 
 #endif /* FILENAMESERVICE_H_ */

--- a/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.cpp
+++ b/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.cpp
@@ -323,4 +323,4 @@ extern "C"
                        ::RTC::ExtendedFsmServiceProvider>);
                        std::cout << "Init()" << std::endl;
   }
-};
+}

--- a/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.h
+++ b/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.h
@@ -303,7 +303,7 @@ namespace RTC
 extern "C"
 {
   DLL_EXPORT void ExtendedFsmServiceProviderInit();
-};
+}
 
 #endif // RTC_EXTENDEDFSMSERVICEPROVIDER_H
 

--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
@@ -946,4 +946,4 @@ extern "C"
                        ::RTC::ComponentObserverConsumer>);
                        std::cout << "Init()" << std::endl;
   }
-};
+}

--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
@@ -815,7 +815,7 @@ namespace RTC
 extern "C"
 {
   DLL_EXPORT void ComponentObserverConsumerInit();
-};
+}
 
 #endif // RTC_COMPONENTOBSERVERCONSUMER_H
 

--- a/src/ext/sdo/logger/LoggerConsumer.cpp
+++ b/src/ext/sdo/logger/LoggerConsumer.cpp
@@ -138,4 +138,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::SdoServiceConsumerBase,
                        ::RTC::LoggerConsumer>);
   }
-};
+}

--- a/src/ext/sdo/logger/LoggerConsumer.h
+++ b/src/ext/sdo/logger/LoggerConsumer.h
@@ -108,7 +108,7 @@ namespace RTC
 extern "C"
 {
   DLL_EXPORT void LoggerConsumerInit();
-};
+}
 
 #endif // RTC_LOGGERCONSUMER_H
 

--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -770,4 +770,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::SdoServiceConsumerBase,
                        ::RTC::ComponentObserverConsumer>);
   }
-};
+}

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -611,7 +611,7 @@ namespace RTC
 extern "C"
 {
   DLL_EXPORT void ComponentObserverConsumerInit();
-};
+}
 
 #endif // RTC_COMPONENTOBSERVERCONSUMER_H
 

--- a/src/ext/ssl/SSLTransport.cpp
+++ b/src/ext/ssl/SSLTransport.cpp
@@ -42,4 +42,4 @@ extern "C"
 		
 		SSLTransportSet(manager);
 	}
-};
+}

--- a/src/lib/coil/common/Properties.cpp
+++ b/src/lib/coil/common/Properties.cpp
@@ -149,7 +149,7 @@ namespace coil
       {
         root->removeNode(name.c_str());
       }
-  };
+  }
 
   //============================================================
   // public fnctions

--- a/src/lib/coil/posix/coil/OS.h
+++ b/src/lib/coil/posix/coil/OS.h
@@ -28,7 +28,7 @@
 extern "C"
 {
   extern char *optarg;
-};
+}
 
 namespace coil
 {

--- a/src/lib/coil/posix/coil/SharedMemory.cpp
+++ b/src/lib/coil/posix/coil/SharedMemory.cpp
@@ -328,7 +328,7 @@ namespace coil
   std::string SharedMemory::get_addresss()
   {
 	return m_shm_address;
-  };
+  }
   /*!
    * @if jp
    *

--- a/src/lib/rtm/CORBA_CdrMemoryStream.cpp
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.cpp
@@ -86,7 +86,7 @@ namespace RTC
 #endif
     {
         return m_cdr;
-    };
+    }
 
 
     void CORBA_CdrMemoryStream::writeCdrData(const unsigned char* buffer, unsigned long length)
@@ -98,7 +98,7 @@ namespace RTC
 #else
         m_cdr.put_octet_array(buffer, length);
 #endif
-    };
+    }
 
     void CORBA_CdrMemoryStream::readCdrData(unsigned char* buffer, unsigned long length) const
     {
@@ -116,7 +116,7 @@ namespace RTC
 #else
         memcpy(buffer, m_cdr.bufPtr(), length);
 #endif
-    };
+    }
 
 
 } // namespace RTC

--- a/src/lib/rtm/CORBA_CdrMemoryStream.h
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.h
@@ -659,7 +659,7 @@ void CdrMemoryStreamInit()
             ::RTC::CORBA_CdrSerializer<DataType> >,
             ::coil::Destructor< ::RTC::ByteDataStream<DataType>,
             ::RTC::CORBA_CdrSerializer<DataType> > );
-};
+}
 
 
 

--- a/src/lib/rtm/CdrRingBuffer.cpp
+++ b/src/lib/rtm/CdrRingBuffer.cpp
@@ -32,4 +32,4 @@ extern "C"
                  coil::Creator<RTC::CdrBufferBase, RTC::CdrRingBuffer>,
                  coil::Destructor<RTC::CdrBufferBase, RTC::CdrRingBuffer>);
   }
-};
+}

--- a/src/lib/rtm/CdrRingBuffer.h
+++ b/src/lib/rtm/CdrRingBuffer.h
@@ -32,5 +32,5 @@ namespace RTC
 extern "C"
 {
   void CdrRingBufferInit();
-};
+}
 #endif  // RTC_CDRRINGBUFFER_H

--- a/src/lib/rtm/CorbaPort.cpp
+++ b/src/lib/rtm/CorbaPort.cpp
@@ -114,7 +114,7 @@ namespace RTC
       }
 
     return true;
-  };
+  }
 
   /*!
    * @if jp

--- a/src/lib/rtm/DefaultPeriodicTask.cpp
+++ b/src/lib/rtm/DefaultPeriodicTask.cpp
@@ -32,5 +32,5 @@ extern "C"
                             ::coil::Destructor< ::coil::PeriodicTaskBase,
                                                 ::RTC::DefaultPeriodicTask >);
   }
-};
+}
 

--- a/src/lib/rtm/DefaultPeriodicTask.h
+++ b/src/lib/rtm/DefaultPeriodicTask.h
@@ -31,6 +31,6 @@ namespace RTC
 extern "C"
 {
   void DefaultPeriodicTaskInit();
-};
+}
 
 #endif  // RTC_DEFAULTPERIODICTASK_H

--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -492,4 +492,4 @@ extern "C"
                             ::coil::Destructor< ::RTC::ExecutionContextBase,
                             ::RTC::ExtTrigExecutionContext>);
   }
-};
+}

--- a/src/lib/rtm/ExtTrigExecutionContext.h
+++ b/src/lib/rtm/ExtTrigExecutionContext.h
@@ -683,6 +683,6 @@ extern "C"
    * @endif
    */
   void ExtTrigExecutionContextInit(RTC::Manager* manager);
-};
+}
 
 #endif  // RTC_EXTTRIGEXECUTIONCONTEXT_H

--- a/src/lib/rtm/InPortConnector.cpp
+++ b/src/lib/rtm/InPortConnector.cpp
@@ -166,11 +166,11 @@ namespace RTC
 		  m_outPortListeners = &(directOutPort->getListeners());
 		  return true;
 	  }
-  };
+  }
 
   BufferStatus::Enum InPortConnector::write(ByteData & /*cdr*/)
   {
       return BufferStatus::BUFFER_OK;
-  };
+  }
 
 } // namespace RTC

--- a/src/lib/rtm/InPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.cpp
@@ -366,4 +366,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortConsumer,
                                            ::RTC::InPortCorbaCdrConsumer>);
   }
-};
+}

--- a/src/lib/rtm/InPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.h
@@ -317,7 +317,7 @@ extern "C"
    * @endif
    */
   void InPortCorbaCdrConsumerInit(void);
-};
+}
 
 #endif  // RTC_INPORTCORBACDRCONSUMER_H
 

--- a/src/lib/rtm/InPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrProvider.cpp
@@ -254,4 +254,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortProvider,
                                            ::RTC::InPortCorbaCdrProvider>);
   }
-};
+}

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -402,7 +402,7 @@ extern "C"
    * @endif
    */
   void InPortCorbaCdrProviderInit(void);
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/InPortDSConsumer.cpp
+++ b/src/lib/rtm/InPortDSConsumer.cpp
@@ -364,4 +364,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortConsumer,
                                            ::RTC::InPortDSConsumer>);
   }
-};
+}

--- a/src/lib/rtm/InPortDSConsumer.h
+++ b/src/lib/rtm/InPortDSConsumer.h
@@ -315,7 +315,7 @@ extern "C"
    * @endif
    */
   void InPortDSConsumerInit(void);
-};
+}
 
 #endif  // RTC_INPORTDSCONSUMER_H
 

--- a/src/lib/rtm/InPortDSProvider.cpp
+++ b/src/lib/rtm/InPortDSProvider.cpp
@@ -245,4 +245,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortProvider,
                                            ::RTC::InPortDSProvider>);
   }
-};
+}

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -400,7 +400,7 @@ extern "C"
    * @endif
    */
   void InPortDSProviderInit(void);
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/InPortDirectConsumer.cpp
+++ b/src/lib/rtm/InPortDirectConsumer.cpp
@@ -132,4 +132,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortConsumer,
                                            ::RTC::InPortDirectConsumer>);
   }
-};
+}

--- a/src/lib/rtm/InPortDirectConsumer.h
+++ b/src/lib/rtm/InPortDirectConsumer.h
@@ -246,7 +246,7 @@ extern "C"
    * @endif
    */
   void InPortDirectConsumerInit(void);
-};
+}
 
 #endif  // RTC_INPORTDIRECTCONSUMER_H
 

--- a/src/lib/rtm/InPortDirectProvider.cpp
+++ b/src/lib/rtm/InPortDirectProvider.cpp
@@ -114,4 +114,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortProvider,
                                            ::RTC::InPortDirectProvider>);
   }
-};
+}

--- a/src/lib/rtm/InPortDirectProvider.h
+++ b/src/lib/rtm/InPortDirectProvider.h
@@ -365,7 +365,7 @@ extern "C"
    * @endif
    */
   void InPortDirectProviderInit(void);
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/InPortPushConnector.cpp
+++ b/src/lib/rtm/InPortPushConnector.cpp
@@ -271,7 +271,7 @@ namespace RTC
 
 
       return ret;
-  };
+  }
 
 } // namespace RTC
 

--- a/src/lib/rtm/InPortSHMConsumer.cpp
+++ b/src/lib/rtm/InPortSHMConsumer.cpp
@@ -346,4 +346,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortConsumer,
                                            ::RTC::InPortSHMConsumer>);
   }
-};
+}

--- a/src/lib/rtm/InPortSHMConsumer.h
+++ b/src/lib/rtm/InPortSHMConsumer.h
@@ -187,7 +187,7 @@ extern "C"
    * @endif
    */
   void InPortSHMConsumerInit(void);
-};
+}
 
 #endif // RTC_INPORTCORBACDRCONSUMER_H
 

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -219,4 +219,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::InPortProvider,
                                            ::RTC::InPortSHMProvider>);
   }
-};
+}

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -265,7 +265,7 @@ extern "C"
    * @endif
    */
   void InPortSHMProviderInit();
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -444,5 +444,5 @@ extern "C"
                             ::coil::Destructor< ::RTC::LogstreamBase,
                                                 ::RTC::LogstreamFile>);
   }
-};
+}
 

--- a/src/lib/rtm/LogstreamFile.h
+++ b/src/lib/rtm/LogstreamFile.h
@@ -495,6 +495,6 @@ namespace RTC
 extern "C"
 {
   void DLL_EXPORT LogstreamFileInit();
-};
+}
 
 #endif // RTC_LOGSTREAMFILE_H

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -452,5 +452,5 @@ extern "C"
     coil::vstring ecs;
     ecs = RTC::ExecutionContextFactory::instance().getIdentifiers();
   }
-};
+}
 

--- a/src/lib/rtm/MultilayerCompositeEC.h
+++ b/src/lib/rtm/MultilayerCompositeEC.h
@@ -197,6 +197,6 @@ extern "C"
    * @endif
    */
   void MultilayerCompositeECInit(RTC::Manager* manager);
-};
+}
 
 #endif  // RTC_MULTILAYERCOMPOSITEEC_H

--- a/src/lib/rtm/NamingServiceNumberingPolicy.cpp
+++ b/src/lib/rtm/NamingServiceNumberingPolicy.cpp
@@ -116,5 +116,5 @@ extern "C"
                             ::coil::Destructor< ::RTM::NumberingPolicyBase,
 							::RTM::NamingServiceNumberingPolicy>);
   }
-};
+}
 

--- a/src/lib/rtm/NamingServiceNumberingPolicy.h
+++ b/src/lib/rtm/NamingServiceNumberingPolicy.h
@@ -167,6 +167,6 @@ namespace RTM
 extern "C"
 {
 	void DLL_EXPORT NamingServiceNumberingPolicyInit();
-};
+}
 
 #endif // RTC_NAMINGSERVICENUMBERINGPOLICY_H

--- a/src/lib/rtm/NodeNumberingPolicy.cpp
+++ b/src/lib/rtm/NodeNumberingPolicy.cpp
@@ -118,5 +118,5 @@ extern "C"
                             ::coil::Destructor< ::RTM::NumberingPolicyBase,
 							::RTM::NodeNumberingPolicy>);
   }
-};
+}
 

--- a/src/lib/rtm/NodeNumberingPolicy.h
+++ b/src/lib/rtm/NodeNumberingPolicy.h
@@ -168,6 +168,6 @@ namespace RTM
 extern "C"
 {
 	void DLL_EXPORT NodeNumberingPolicyInit();
-};
+}
 
 #endif // RTC_NODENUMBERINGPOLICY_H

--- a/src/lib/rtm/NumberingPolicy.cpp
+++ b/src/lib/rtm/NumberingPolicy.cpp
@@ -107,5 +107,5 @@ extern "C"
                             ::coil::Destructor< ::RTM::NumberingPolicyBase,
                                                 ::RTM::ProcessUniquePolicy>);
   }
-};
+}
 

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -338,4 +338,4 @@ extern "C"
                             ::coil::Destructor< ::RTC::ExecutionContextBase,
                             ::RTC::OpenHRPExecutionContext>);
   }
-};
+}

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -536,7 +536,7 @@ extern "C"
    * @endif
    */
   DLL_EXPORT void OpenHRPExecutionContextInit(RTC::Manager* manager);
-};
+}
 
 #endif  // RTC_OPENHRPEXECUTIONCONTEXT_H
 

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -102,7 +102,7 @@ namespace RTC
     // In the FSM4RTC specification, publisher type is defined as "io_mode"
     addProperty("dataport.io_mode", pubs.c_str());
 
-  };
+  }
 
   /*!
    * @if jp

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
@@ -293,4 +293,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortConsumer,
                                            ::RTC::OutPortCorbaCdrConsumer>);
   }
-};
+}

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.h
@@ -391,6 +391,6 @@ extern "C"
    * @endif
    */
   void OutPortCorbaCdrConsumerInit(void);
-};
+}
 
 #endif  // RTC_OUTPORTCORBACDRCONSUMER_H

--- a/src/lib/rtm/OutPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.cpp
@@ -272,4 +272,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortProvider,
                                            ::RTC::OutPortCorbaCdrProvider>);
   }
-};
+}

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -376,7 +376,7 @@ extern "C"
    * @endif
    */
   void OutPortCorbaCdrProviderInit(void);
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/OutPortDSConsumer.cpp
+++ b/src/lib/rtm/OutPortDSConsumer.cpp
@@ -290,4 +290,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortConsumer,
                                            ::RTC::OutPortDSConsumer>);
   }
-};
+}

--- a/src/lib/rtm/OutPortDSConsumer.h
+++ b/src/lib/rtm/OutPortDSConsumer.h
@@ -389,6 +389,6 @@ extern "C"
    * @endif
    */
   void OutPortDSConsumerInit(void);
-};
+}
 
 #endif  // RTC_OUTPORTDSCONSUMER_H

--- a/src/lib/rtm/OutPortDSProvider.cpp
+++ b/src/lib/rtm/OutPortDSProvider.cpp
@@ -270,4 +270,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortProvider,
                                            ::RTC::OutPortDSProvider>);
   }
-};
+}

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -374,7 +374,7 @@ extern "C"
    * @endif
    */
   void OutPortDSProviderInit(void);
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/OutPortDirectConsumer.cpp
+++ b/src/lib/rtm/OutPortDirectConsumer.cpp
@@ -142,4 +142,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortConsumer,
                                            ::RTC::OutPortDirectConsumer>);
   }
-};
+}

--- a/src/lib/rtm/OutPortDirectConsumer.h
+++ b/src/lib/rtm/OutPortDirectConsumer.h
@@ -279,6 +279,6 @@ extern "C"
    * @endif
    */
 	void OutPortDirectConsumerInit(void);
-};
+}
 
 #endif // RTC_OUTPORTDIRECTCONSUMER_H

--- a/src/lib/rtm/OutPortDirectProvider.cpp
+++ b/src/lib/rtm/OutPortDirectProvider.cpp
@@ -120,4 +120,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortProvider,
                                            ::RTC::OutPortDirectProvider>);
   }
-};
+}

--- a/src/lib/rtm/OutPortDirectProvider.h
+++ b/src/lib/rtm/OutPortDirectProvider.h
@@ -339,7 +339,7 @@ extern "C"
    * @endif
    */
   void OutPortDirectProviderInit(void);
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/OutPortSHMConsumer.cpp
+++ b/src/lib/rtm/OutPortSHMConsumer.cpp
@@ -314,4 +314,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortConsumer,
                                            ::RTC::OutPortSHMConsumer>);
   }
-};
+}

--- a/src/lib/rtm/OutPortSHMConsumer.h
+++ b/src/lib/rtm/OutPortSHMConsumer.h
@@ -355,6 +355,6 @@ extern "C"
    * @endif
    */
   void OutPortSHMConsumerInit(void);
-};
+}
 
 #endif // RTC_OUTPORTSHMCONSUMER_H

--- a/src/lib/rtm/OutPortSHMProvider.cpp
+++ b/src/lib/rtm/OutPortSHMProvider.cpp
@@ -264,4 +264,4 @@ extern "C"
                        ::coil::Destructor< ::RTC::OutPortProvider,
                                            ::RTC::OutPortSHMProvider>);
   }
-};
+}

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -322,7 +322,7 @@ extern "C"
    * @endif
    */
   void OutPortSHMProviderInit(void);
-};
+}
 
 #ifdef WIN32
 #pragma warning( default : 4290 )

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -870,4 +870,4 @@ extern "C"
                              RTC::Create<RTC::PeriodicECSharedComposite>,
                              RTC::Delete<RTC::PeriodicECSharedComposite>);
   }
-};
+}

--- a/src/lib/rtm/PeriodicECSharedComposite.h
+++ b/src/lib/rtm/PeriodicECSharedComposite.h
@@ -687,6 +687,6 @@ namespace RTC
 extern "C"
 {
   DLL_EXPORT void PeriodicECSharedCompositeInit(RTC::Manager* manager);
-};
+}
 
 #endif  // RTC_PERIODICECSHAREDCOMPOSITE_H

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -665,5 +665,5 @@ extern "C"
     coil::vstring ecs;
     ecs = RTC::ExecutionContextFactory::instance().getIdentifiers();
   }
-};
+}
 

--- a/src/lib/rtm/PeriodicExecutionContext.h
+++ b/src/lib/rtm/PeriodicExecutionContext.h
@@ -737,6 +737,6 @@ extern "C"
    * @endif
    */
   void PeriodicExecutionContextInit(RTC::Manager* manager);
-};
+}
 
 #endif  // RTC_PERIODICEXECUTIONCONTEXT_H

--- a/src/lib/rtm/PublisherFlush.cpp
+++ b/src/lib/rtm/PublisherFlush.cpp
@@ -242,5 +242,5 @@ extern "C"
                             ::coil::Destructor< ::RTC::PublisherBase,
                                                 ::RTC::PublisherFlush>);
   }
-};
+}
 

--- a/src/lib/rtm/PublisherFlush.h
+++ b/src/lib/rtm/PublisherFlush.h
@@ -442,7 +442,7 @@ namespace RTC
 extern "C"
 {
   void DLL_EXPORT PublisherFlushInit();
-};
+}
 
 #endif  // RTC_PUBLISHERFLUSH_H
 

--- a/src/lib/rtm/PublisherNew.cpp
+++ b/src/lib/rtm/PublisherNew.cpp
@@ -598,4 +598,4 @@ extern "C"
                             ::coil::Destructor< ::RTC::PublisherBase,
                                                 ::RTC::PublisherNew>);
   }
-};
+}

--- a/src/lib/rtm/PublisherNew.h
+++ b/src/lib/rtm/PublisherNew.h
@@ -737,7 +737,7 @@ namespace RTC
 extern "C"
 {
   void DLL_EXPORT PublisherNewInit();
-};
+}
 
 #endif  // RTC_PUBLISHERNEW_H
 

--- a/src/lib/rtm/PublisherPeriodic.cpp
+++ b/src/lib/rtm/PublisherPeriodic.cpp
@@ -614,4 +614,4 @@ extern "C"
                             ::coil::Destructor< ::RTC::PublisherBase,
                                                 ::RTC::PublisherPeriodic>);
   }
-};
+}

--- a/src/lib/rtm/PublisherPeriodic.h
+++ b/src/lib/rtm/PublisherPeriodic.h
@@ -757,6 +757,6 @@ namespace RTC
 extern "C"
 {
   void DLL_EXPORT PublisherPeriodicInit();
-};
+}
 
 #endif  // RTC_PUBLISHERPERIODIC_H

--- a/src/lib/rtm/SimulatorExecutionContext.cpp
+++ b/src/lib/rtm/SimulatorExecutionContext.cpp
@@ -235,4 +235,4 @@ extern "C"
                             ::coil::Destructor< ::RTC::ExecutionContextBase,
                             ::RTC::SimulatorExecutionContext>);
   }
-};
+}

--- a/src/lib/rtm/SimulatorExecutionContext.h
+++ b/src/lib/rtm/SimulatorExecutionContext.h
@@ -167,6 +167,6 @@ extern "C"
    * @endif
    */
   DLL_EXPORT void SimulatorExecutionContextInit(RTC::Manager* manager);
-};
+}
 
 #endif


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#282 

## Description of the Change
clang-7では指摘されず、g++-8では指摘される余分なセミコロンを削除する

## Verification 

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
- 余分なセミコロンの削除のため単体テストは不要
