### PR TITLE
sdo.service.consumer.enabled_services等のオプションが反映されない問題の修正(1.2)

### DIFF
--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -317,6 +317,10 @@ namespace RTC
   {
     RTC_TRACE(("initialize()"));
 
+
+    // SDO service admin initialization
+    m_sdoservice.init(m_properties);
+
     // EC creation
     std::vector<coil::Properties> ec_args;
     if (getContextOptions(ec_args) != RTC::RTC_OK)

--- a/src/lib/rtm/SdoServiceAdmin.h
+++ b/src/lib/rtm/SdoServiceAdmin.h
@@ -185,6 +185,17 @@ namespace RTC
      * @endif
      */
     virtual ~SdoServiceAdmin();
+
+    /*!
+     * @if jp
+     * @brief 初期化処理
+     *
+     * @else
+     * @brief Initialization
+     *
+     * @endif
+     */
+    virtual void init(coil::Properties& prop);
     
     /*!
      * @if jp
@@ -303,6 +314,26 @@ namespace RTC
     bool removeSdoServiceConsumer(const char* id);
     
 protected:
+    /*!
+     * @if jp
+     * @brief Provider 初期化処理
+     *
+     * @else
+     * @brief Provider Initialization
+     *
+     * @endif
+     */
+    void initProvider(coil::Properties& prop);
+    /*!
+     * @if jp
+     * @brief Consumer 初期化処理
+     *
+     * @else
+     * @brief Consumer Initialization
+     *
+     * @endif
+     */
+    void initConsumer(coil::Properties& prop);
     /*!
      * @if jp
      *


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

`sdo.service.consumer.enabled_services`、`sdo.service.provider.enabled_services`のオプションが設定しても反映されない。
masterはかなり前に修正済み。1.2以前の問題。

## Description of the Change

念のためにRELENG_1_2ブランチのSdoServiceAdmin.cppを修正した。
致命的と言えるほどの問題でもないので、インストーラーの更新はしなくてもいいと思います。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
