### PR TITLE
rtc.confで値が空白の場合に反映されない問題の修正

### DIFF
--- a/src/lib/coil/common/Properties.cpp
+++ b/src/lib/coil/common/Properties.cpp
@@ -38,8 +38,8 @@ namespace coil
    * @brief Constructor(Create only root node)
    * @endif
    */
-  Properties::Properties(const char* key, const char* value)
-    : name(key), value(value), default_value(""), root(nullptr), m_empty("")
+  Properties::Properties(const char* key, const char* value, bool set_value)
+    : name(key), value(value), default_value(""), set_value((this->value.empty()) ? set_value : true), root(nullptr), m_empty("")
   {
     leaf.clear();
   }
@@ -52,7 +52,7 @@ namespace coil
    * @endif
    */
   Properties::Properties(std::map<std::string, std::string>& defaults)
-    : name(""), value(""), default_value(""), root(nullptr), m_empty("")
+    : name(""), value(""), default_value(""), set_value(false), root(nullptr), m_empty("")
   {
     leaf.clear();
     std::map<std::string, std::string>::iterator it(defaults.begin());
@@ -73,7 +73,7 @@ namespace coil
    * @endif
    */
   Properties::Properties(const char** defaults, long num)
-    : name(""), value(""), default_value(""), root(nullptr), m_empty("")
+    : name(""), value(""), default_value(""), set_value(false), root(nullptr), m_empty("")
   {
     leaf.clear();
     setDefaults(defaults, num);
@@ -88,7 +88,7 @@ namespace coil
    */
   Properties::Properties(const Properties& prop)
     : name(prop.name), value(prop.value),
-      default_value(prop.default_value), root(nullptr), m_empty("")
+      default_value(prop.default_value), set_value(prop.set_value), root(nullptr), m_empty("")
   {
     std::vector<std::string> keys;
     keys = prop.propertyNames();
@@ -98,7 +98,10 @@ namespace coil
         if ((node = prop.findNode(key)) != nullptr)
           {
             setDefault(key,  node->default_value);
-            setProperty(key, node->value);
+            if (node->set_value)
+              {
+                setProperty(key, node->value);
+              }
           }
       }
   }
@@ -116,6 +119,7 @@ namespace coil
     name = prop.name;
     value = prop.value;
     default_value = prop.default_value;
+    set_value = prop.set_value;
 
     std::vector<std::string> keys;
     keys = prop.propertyNames();
@@ -125,7 +129,10 @@ namespace coil
         if (node != nullptr)
           {
             setDefault(key,  node->default_value);
-            setProperty(key, node->value);
+            if (node->set_value)
+              {
+                setProperty(key, node->value);
+              }
           }
       }
 
@@ -168,7 +175,7 @@ namespace coil
     Properties* node(nullptr);
     if ((node = _getNode(keys, 0, this)) != nullptr)
       {
-        return (!node->value.empty()) ? node->value : node->default_value;
+        return (node->set_value) ? node->value : node->default_value;
       }
     return m_empty;
   }
@@ -261,6 +268,7 @@ namespace coil
       }
     std::string retval(curr->value);
     curr->value = invalue;
+    curr->set_value = true;
     return retval;
   }
 
@@ -760,7 +768,7 @@ namespace coil
 
     if (curr->root != nullptr)
       {
-        if (curr->value.length() > 0)
+        if (curr->set_value)
           {
             out << curr_name << ": " << coil::escape(curr->value) << std::endl;
           }
@@ -780,7 +788,7 @@ namespace coil
     if (index != 0) out << indent(index) << "- " << curr.name;
     if (curr.leaf.empty())
       {
-        if (curr.value.empty())
+        if (!curr.set_value)
           {
             out << ": " << curr.default_value << std::endl;
           }
@@ -859,7 +867,7 @@ namespace coil
       if (index != 0) out += indent(index) + "- " + curr.name;
       if (curr.leaf.empty())
       {
-          if (curr.value.empty())
+          if (!curr.set_value)
           {
               out += ": " + curr.default_value + "\n";
           }
@@ -881,7 +889,7 @@ namespace coil
       if (index != 0) out.push_back(indent(index) + "- " + curr.name);
       if (curr.leaf.empty())
       {
-          if (curr.value.empty())
+          if (!curr.set_value)
           {
               out.push_back(": " + curr.default_value);
           }

--- a/src/lib/coil/common/Properties.h
+++ b/src/lib/coil/common/Properties.h
@@ -124,7 +124,7 @@ namespace coil
      *
      * @endif
      */
-    explicit Properties(const char* key = "", const char* value = "");
+    explicit Properties(const char* key = "", const char* value = "", bool set_value = false);
 
     /*!
      * @if jp
@@ -1338,6 +1338,7 @@ namespace coil
     std::string name;
     std::string value;
     std::string default_value;
+    bool set_value;
     Properties* root;
     std::vector<Properties*> leaf;
     const std::string m_empty;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#288 


## Description of the Change

Propertiesのvalueが設定されているかどうかを文字列が空かどうかで判定するのは適切ではなかったため、値を設定したかどうかのフラグで判別する手順に変更した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
