### PR TITLE
Suppress warnings of generated source.

### DIFF
--- a/examples/Analyzer/CMakeLists.txt
+++ b/examples/Analyzer/CMakeLists.txt
@@ -6,9 +6,9 @@ project (Analyzer
 
 
 set(srcs Analyzer.cpp Analyzer.h)
-ComponentBuild(Analyzer "${srcs}" AnalyzerComp.cpp "" "")
+examples_build(Analyzer SRCS "${srcs}" MAIN AnalyzerComp.cpp)
 
 
 
 set(srcs Analyzer_test.cpp Analyzer_test.h)
-ComponentBuild(Analyzer_test "${srcs}" Analyzer_testComp.cpp "" "")
+examples_build(Analyzer_test SRCS "${srcs}" MAIN Analyzer_testComp.cpp)

--- a/examples/AutoTest/CMakeLists.txt
+++ b/examples/AutoTest/CMakeLists.txt
@@ -11,9 +11,9 @@ openrtm_idl_compile_all(${PROJECT_NAME}
 	"-I${CMAKE_CURRENT_SOURCE_DIR};-I${CMAKE_SOURCE_DIR}/src/lib/rtm/idl")
 
 set(srcs AutoTestIn.cpp AutoTestServiceSVC_impl.cpp ${${PROJECT_NAME}_IDLSKEL})
-ComponentBuild(AutoTestIn "${srcs}" AutoTestInComp.cpp "" "")
+examples_build(AutoTestIn SRCS "${srcs}" MAIN AutoTestInComp.cpp)
 target_include_directories(AutoTestIn_objlib SYSTEM PUBLIC ${PROJECT_BINARY_DIR})
 
 set(srcs AutoTestOut.cpp ${${PROJECT_NAME}_IDLSTUB})
-ComponentBuild(AutoTestOut "${srcs}" AutoTestOutComp.cpp "" "")
+examples_build(AutoTestOut SRCS "${srcs}" MAIN AutoTestOutComp.cpp)
 target_include_directories(AutoTestOut_objlib SYSTEM PUBLIC ${PROJECT_BINARY_DIR})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,83 +1,106 @@
 ﻿cmake_minimum_required (VERSION 3.0.2)
 
-
-function(ComponentBuild target srcs mainfile dependencies vxaddfile)
+function(examples_build target)
+	cmake_parse_arguments(EB
+		""
+		"MAIN;VXADDFILE"
+		"SRCS;GENSRCS;INCLUDE;DEPS"
+		${ARGN})
 	link_directories(${ORB_LINK_DIR})
 	add_definitions(${ORB_C_FLAGS_LIST})
 	add_definitions(${COIL_C_FLAGS_LIST})
 
 	if(VXWORKS AND NOT RTP)
-		set(standalone_srcs ${srcs} ${mainfile} ${CMAKE_SOURCE_DIR}/src/lib/rtm/DataFlowComponentBase.cpp ${vxaddfile})
+		set(standalone_srcs ${EB_SRCS} ${EB_MAIN}
+			${CMAKE_SOURCE_DIR}/src/lib/rtm/DataFlowComponentBase.cpp
+			${EB_VXADDFILE})
 		set(libs ${RTCSKEL_PROJECT_NAME})
 
 		add_executable(${target} ${standalone_srcs})
 		openrtm_common_set_compile_props(${target})
 		openrtm_include_rtm(${target})
+		if(EB_INCLUDE)
+			target_include_directories(${target} PRIVATE ${EB_INCLUDE})
+		endif()
 		target_link_libraries(${target} ${libs})
-		if(dependencies)
-			add_dependencies(${target} ${dependencies})
-		endif(dependencies)
+		if(EB_DEPS)
+			add_dependencies(${target} ${EB_DEPS})
+		endif()
 
 		install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
 					ARCHIVE DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
 					RUNTIME DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
 					COMPONENT examples)
+		install(FILES ${standalone_srcs} DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}/src/Analyzer COMPONENT sources)
 	else()
 		if(VXWORKS)
 			set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${COIL_PROJECT_NAME} ${RTCSKEL_PROJECT_NAME})
-		else(VXWORKS)
+		else()
 			set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${COIL_PROJECT_NAME} ${DATATYPE_FACTORIES})
-		endif(VXWORKS)
+		endif()
 
-		add_library(${target}_objlib OBJECT ${srcs})
+		# .cpp -> .o
+		add_library(${target}_objlib OBJECT ${EB_SRCS})
 		openrtm_common_set_compile_props(${target}_objlib)
 		openrtm_include_rtm(${target}_objlib)
-		add_executable(${target}Comp $<TARGET_OBJECTS:${target}_objlib> ${mainfile})
+		target_include_directories(${target}_objlib PRIVATE ${EB_INCLUDE})
+		if(EB_DEPS)
+			add_dependencies(${target}_objlib ${EB_DEPS})
+		endif()
+
+		# generated .cpp -> .o
+		if(EB_GENSRCS)
+			add_library(${target}_gen_objlib OBJECT ${EB_GENSRCS})
+			openrtm_gencode_set_compile_props(${target}_gen_objlib)
+			openrtm_include_rtm(${target}_gen_objlib)
+			target_include_directories(${target}_gen_objlib PRIVATE ${EB_INCLUDE})
+			if(EB_DEPS)
+				add_dependencies(${target}_gen_objlib ${EB_DEPS})
+			endif()
+			set(EB_GENOBJLIB $<TARGET_OBJECTS:${target}_gen_objlib>)
+		endif()
+
+		# .o, main() -> executable
+		add_executable(${target}Comp
+			$<TARGET_OBJECTS:${target}_objlib>
+			${EB_GENOBJLIB}
+			${EB_MAIN})
 		openrtm_common_set_compile_props(${target}Comp)
 		openrtm_include_rtm(${target}Comp)
+		target_include_directories(${target}Comp PRIVATE ${EB_INCLUDE})
 		target_link_libraries(${target}Comp ${libs} ${RTM_LINKER_OPTION})
-		if(DATATYPE_FACTORIES)
-			add_dependencies(${target}Comp ${DATATYPE_FACTORIES})
-		endif(DATATYPE_FACTORIES)
+		if(EB_DEPS)
+			add_dependencies(${target}Comp ${EB_DEPS})
+		endif()
 
-		add_library(${target} SHARED $<TARGET_OBJECTS:${target}_objlib>)
+		# .o -> .s
+		add_library(${target} SHARED
+			$<TARGET_OBJECTS:${target}_objlib>
+			${EB_GENOBJLIB})
 		target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION})
-		if(DATATYPE_FACTORIES)
-			add_dependencies(${target} ${DATATYPE_FACTORIES})
-		endif(DATATYPE_FACTORIES)
 		set_target_properties(${target} PROPERTIES PREFIX "")
 
-		if(dependencies)
-			add_dependencies(${target}_objlib ${dependencies})
-			add_dependencies(${target} ${dependencies})
-			add_dependencies(${target}Comp ${dependencies})
-		endif(dependencies)
+		install(TARGETS ${target}Comp LIBRARY
+			DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
+			ARCHIVE DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
+			RUNTIME DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
+			COMPONENT examples)
 
-		install(TARGETS ${target}Comp LIBRARY DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
-					ARCHIVE DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
-					RUNTIME DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}
-					COMPONENT examples)
-
-		install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXAMPLE_SHAREDLIB_DIR}
-					ARCHIVE DESTINATION ${INSTALL_RTM_EXAMPLE_SHAREDLIB_DIR}
-					RUNTIME DESTINATION ${INSTALL_RTM_EXAMPLE_SHAREDLIB_DIR}
-					COMPONENT examples)
-
-		install(FILES ${standalone_srcs} DESTINATION ${INSTALL_RTM_EXAMPLE_DIR}/src/Analyzer COMPONENT sources)
+		install(TARGETS ${target} LIBRARY
+			DESTINATION ${INSTALL_RTM_EXAMPLE_SHAREDLIB_DIR}
+			ARCHIVE DESTINATION ${INSTALL_RTM_EXAMPLE_SHAREDLIB_DIR}
+			RUNTIME DESTINATION ${INSTALL_RTM_EXAMPLE_SHAREDLIB_DIR}
+			COMPONENT examples)
 	endif()
-
 
 	if(VXWORKS)
 		if(RTP)
 			set_target_properties(${target}Comp PROPERTIES SUFFIX ".vxe")
-		else(RTP)	
+		else()
 			set_target_properties(${target} PROPERTIES SUFFIX ".out")
-		endif(RTP)
-	endif(VXWORKS)
-
+		endif()
+	endif()
 endfunction()
-
-
 
 add_subdirectory(SimpleIO)
 add_subdirectory(SeqIO)
@@ -90,7 +113,5 @@ add_subdirectory(ConfigSample)
 add_subdirectory(Composite)
 add_subdirectory(Analyzer)
 add_subdirectory(Throughput)
-
 add_subdirectory(StaticFsm)
-
 add_subdirectory(Templates)

--- a/examples/Composite/CMakeLists.txt
+++ b/examples/Composite/CMakeLists.txt
@@ -40,15 +40,15 @@ endif(VXWORKS)
 
 
 set(srcs Controller.cpp Controller.h)
-ComponentBuild(Controller "${srcs}" ControllerComp.cpp "" "")
+examples_build(Controller SRCS "${srcs}" MAIN ControllerComp.cpp)
 
 
 set(srcs Motor.cpp Motor.h)
-ComponentBuild(Motor "${srcs}" MotorComp.cpp "" "")
+examples_build(Motor SRCS "${srcs}" MAIN MotorComp.cpp)
 
 
 set(srcs Sensor.cpp Sensor.h)
-ComponentBuild(Sensor "${srcs}" SensorComp.cpp "" "")
+examples_build(Sensor SRCS "${srcs}" MAIN SensorComp.cpp)
 
 
 install(FILES composite.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMPONENT examples)

--- a/examples/ConfigSample/CMakeLists.txt
+++ b/examples/ConfigSample/CMakeLists.txt
@@ -6,7 +6,7 @@ project (${target}
 
 
 set(srcs ConfigSample.cpp ConfigSample.h)
-ComponentBuild(ConfigSample "${srcs}" ConfigSampleComp.cpp "" "")
+examples_build(ConfigSample SRCS "${srcs}" MAIN ConfigSampleComp.cpp)
 
 
 install(FILES configsample.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMPONENT examples)

--- a/examples/ExtTrigger/CMakeLists.txt
+++ b/examples/ExtTrigger/CMakeLists.txt
@@ -7,11 +7,11 @@ project (ExtTrigger
 
 
 set(srcs ConsoleIn.cpp ConsoleIn.h)
-ComponentBuild(ConsoleInEx "${srcs}" ConsoleInComp.cpp "" "")
+examples_build(ConsoleInEx SRCS "${srcs}" MAIN ConsoleInComp.cpp)
 
 
 set(srcs ConsoleOut.cpp ConsoleOut.h)
-ComponentBuild(ConsoleOutEx "${srcs}" ConsoleOutComp.cpp "" "")
+examples_build(ConsoleOutEx SRCS "${srcs}" MAIN ConsoleOutComp.cpp)
 
 
 set(target ConnectorCompEx)

--- a/examples/HelloWorld/CMakeLists.txt
+++ b/examples/HelloWorld/CMakeLists.txt
@@ -6,4 +6,4 @@ project (${target}
 
 
 set(srcs HelloRTWorld.cpp HelloRTWorld.h)
-ComponentBuild(HelloRTWorld "${srcs}" HelloRTWorldComp.cpp "" "")
+examples_build(HelloRTWorld SRCS "${srcs}" MAIN HelloRTWorldComp.cpp)

--- a/examples/SeqIO/CMakeLists.txt
+++ b/examples/SeqIO/CMakeLists.txt
@@ -2,8 +2,8 @@
 
 
 set(srcs SeqIn.cpp SeqIn.h)
-ComponentBuild(SeqIn "${srcs}" SeqInComp.cpp "" "")
+examples_build(SeqIn SRCS "${srcs}" MAIN SeqInComp.cpp)
 
 
 set(srcs SeqOut.cpp SeqOut.h)
-ComponentBuild(SeqOut "${srcs}" SeqOutComp.cpp "" "")
+examples_build(SeqOut SRCS "${srcs}" MAIN SeqOutComp.cpp)

--- a/examples/SimpleIO/CMakeLists.txt
+++ b/examples/SimpleIO/CMakeLists.txt
@@ -2,11 +2,11 @@
 
 
 set(srcs ConsoleIn.cpp ConsoleIn.h)
-ComponentBuild(ConsoleIn "${srcs}" ConsoleInComp.cpp "" "")
+examples_build(ConsoleIn SRCS "${srcs}" MAIN ConsoleInComp.cpp)
 
 
 set(srcs ConsoleOut.cpp ConsoleOut.h)
-ComponentBuild(ConsoleOut "${srcs}" ConsoleOutComp.cpp "" "")
+examples_build(ConsoleOut SRCS "${srcs}" MAIN ConsoleOutComp.cpp)
 
 
 install(FILES rtc.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMPONENT examples)

--- a/examples/SimpleService/CMakeLists.txt
+++ b/examples/SimpleService/CMakeLists.txt
@@ -10,14 +10,16 @@ openrtm_idl_compile_all(MyService
 	"${${PROJECT_NAME}_IDLS}"
 	"-I${CMAKE_CURRENT_SOURCE_DIR};-I${CMAKE_SOURCE_DIR}/src/lib/rtm/idl")
 
-include_directories(SYSTEM ${CMAKE_CURRENT_BINARY_DIR})
+examples_build(MyServiceConsumer
+	SRCS MyServiceConsumer.cpp
+	GENSRCS ${MyService_IDLSTUB}
+	MAIN MyServiceConsumerComp.cpp
+	INCLUDE ${CMAKE_CURRENT_BINARY_DIR}
+	DEPS MyService_IDLTGT)
 
-set(srcs MyServiceConsumer.cpp
-	${MyService_IDLSTUB})
-ComponentBuild(MyServiceConsumer "${srcs}" MyServiceConsumerComp.cpp "MyService_IDLTGT" "")
-
-set(srcs
-	MyServiceProvider.cpp
-	MyServiceSVC_impl.cpp
-	${MyService_IDLSKEL})
-ComponentBuild(MyServiceProvider "${srcs}" MyServiceProviderComp.cpp "MyService_IDLTGT" "")
+examples_build(MyServiceProvider
+	SRCS MyServiceProvider.cpp MyServiceSVC_impl.cpp
+	GENSRCS ${MyService_IDLSKEL}
+	MAIN MyServiceProviderComp.cpp
+	INCLUDE ${CMAKE_CURRENT_BINARY_DIR}
+	DEPS MyService_IDLTGT)

--- a/examples/StaticFsm/CMakeLists.txt
+++ b/examples/StaticFsm/CMakeLists.txt
@@ -4,13 +4,15 @@ project (StaticFSM
 	VERSION ${RTM_VERSION}
 	LANGUAGES CXX)
 
+examples_build(Display
+  SRCS Display.cpp Display.h
+  MAIN DisplayComp.cpp)
 
+examples_build(Inputbutton
+  SRCS Inputbutton.cpp Inputbutton.h
+  MAIN InputbuttonComp.cpp)
 
-set(srcs Display.cpp Display.h)
-ComponentBuild(Display "${srcs}" DisplayComp.cpp "" "")
-
-set(srcs Inputbutton.cpp Inputbutton.h)
-ComponentBuild(Inputbutton "${srcs}" InputbuttonComp.cpp "" "")
-
-set(srcs Microwave.cpp Microwave.h MicrowaveFsm.cpp MicrowaveFsm.h)
-ComponentBuild(Microwave "${srcs}" MicrowaveComp.cpp "" ${CMAKE_SOURCE_DIR}/src/lib/rtm/Macho.cpp)
+examples_build(Microwave
+  SRCS Microwave.cpp Microwave.h MicrowaveFsm.cpp MicrowaveFsm.h
+  MAIN MicrowaveComp.cpp
+  VXADDFILE ${CMAKE_SOURCE_DIR}/src/lib/rtm/Macho.cpp)

--- a/examples/StringIO/CMakeLists.txt
+++ b/examples/StringIO/CMakeLists.txt
@@ -7,8 +7,8 @@ project (StringIO
 
 
 set(srcs StringIn.cpp StringIn.h)
-ComponentBuild(StringIn "${srcs}" StringInComp.cpp "" "")
+examples_build(StringIn SRCS "${srcs}" MAIN StringInComp.cpp)
 
 
 set(srcs StringOut.cpp StringOut.h)
-ComponentBuild(StringOut "${srcs}" StringOutComp.cpp "" "")
+examples_build(StringOut SRCS "${srcs}" MAIN StringOutComp.cpp)

--- a/examples/Throughput/CMakeLists.txt
+++ b/examples/Throughput/CMakeLists.txt
@@ -7,4 +7,4 @@ project (Throughput
 
 
 set(srcs Throughput.cpp Throughput.h)
-ComponentBuild(Throughput "${srcs}" ThroughputComp.cpp "" "")
+examples_build(Throughput SRCS "${srcs}" MAIN ThroughputComp.cpp)

--- a/src/ext/ec/logical_time/CMakeLists.txt
+++ b/src/ext/ec/logical_time/CMakeLists.txt
@@ -22,7 +22,7 @@ if(VXWORKS AND NOT RTP)
 	add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS} ${${PROJECT_NAME}_IDLSKEL})
 	openrtm_common_set_compile_props(${PROJECT_NAME})
 	openrtm_include_rtm(${PROJECT_NAME})
-	target_include_directories(${PROJECT_NAME}
+	target_include_directories(${PROJECT_NAME} SYSTEM
 		PUBLIC ${PROJECT_BINARY_DIR})
 	target_link_libraries(${PROJECT_NAME} ${libs})
 	add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_IDLTGT)
@@ -41,14 +41,14 @@ else()
 	add_library(${PROJECT_NAME}_objlib OBJECT ${${PROJECT_NAME}_SRCS})
 	openrtm_common_set_compile_props(${PROJECT_NAME}_objlib)
 	openrtm_include_rtm(${PROJECT_NAME}_objlib)
-	target_include_directories(${PROJECT_NAME}_objlib
+	target_include_directories(${PROJECT_NAME}_objlib SYSTEM
 		PUBLIC ${PROJECT_BINARY_DIR})
 	add_dependencies(${PROJECT_NAME}_objlib ${PROJECT_NAME}_IDLTGT)
 
 	add_library(${PROJECT_NAME}_idl_objlib OBJECT ${${PROJECT_NAME}_IDLSKEL})
 	openrtm_gencode_set_compile_props(${PROJECT_NAME}_idl_objlib)
 	openrtm_include_rtm(${PROJECT_NAME}_idl_objlib)
-	target_include_directories(${PROJECT_NAME}_idl_objlib
+	target_include_directories(${PROJECT_NAME}_idl_objlib SYSTEM
 		PUBLIC ${PROJECT_BINARY_DIR})
 	add_dependencies(${PROJECT_NAME}_idl_objlib ${PROJECT_NAME}_IDLTGT)
 


### PR DESCRIPTION
## Identify the Bug
#280

## Description of the Change
- LogicalTimeTriggeredEC の生成ファイルが出す警告を抑制
- SimpleService の Skel/Stub を通常のコンパイルオプション(生成用でないもの)になっているのを修正

## Verification 
ビルド確認のみ 

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
- [X] Have you passed the unit tests?  不要
