### PR TITLE
Use noexcept.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,20 +576,26 @@ elseif(WIN32)
 endif()
 
 function(openrtm_include_rtm target)
-target_include_directories(${target}
-	PRIVATE ${CMAKE_SOURCE_DIR}/src/lib/coil/common
-	PRIVATE ${CMAKE_SOURCE_DIR}/src/lib/coil/${COIL_OS_DIR}
-	PRIVATE ${CMAKE_SOURCE_DIR}/src/lib)
-target_include_directories(${target} SYSTEM
-	PRIVATE ${CMAKE_BINARY_DIR}/src/lib/rtm/idl
-	PRIVATE ${CMAKE_BINARY_DIR}/src/lib
-	${ORB_INCLUDE_DIR})
-add_dependencies(${target} ${RTCSKEL_PROJECT_NAME}_IDLTGT)
+	target_include_directories(${target}
+		PRIVATE ${CMAKE_SOURCE_DIR}/src/lib/coil/common
+		PRIVATE ${CMAKE_SOURCE_DIR}/src/lib/coil/${COIL_OS_DIR}
+		PRIVATE ${CMAKE_SOURCE_DIR}/src/lib)
+	target_include_directories(${target} SYSTEM
+		PRIVATE ${CMAKE_BINARY_DIR}/src/lib/rtm/idl
+		PRIVATE ${CMAKE_BINARY_DIR}/src/lib
+		${ORB_INCLUDE_DIR})
+	add_dependencies(${target} ${RTCSKEL_PROJECT_NAME}_IDLTGT)
 endfunction()
 
 function(openrtm_common_set_compile_definitions target)
-  target_compile_definitions(${target} PRIVATE
-		# none
+	target_compile_definitions(${target} PRIVATE
+		$<$<CXX_COMPILER_ID:MSVC>:
+			# MSVC 2013 does not support noexcept.
+			$<$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},19.00>:
+				_ALLOW_KEYWORD_MACROS
+				noexcept=_NOEXCEPT
+			>
+		>
 	)
 endfunction()
 
@@ -735,9 +741,9 @@ function(openrtm_common_set_compile_options target)
 		# C++11: target_compile_features can't be used becase it's support after v3.1.0.
 		$<$<CXX_COMPILER_ID:GNU>:-std=c++11>
 		$<$<CXX_COMPILER_ID:Clang>:-std=c++11>
-		## MSVC always enable c++11 and c++14, so we use c++14 after MSVC 2015.
+		## MSVC always enable c++11 and c++14 after MSVC 2015 Update 3.
 		$<$<CXX_COMPILER_ID:MSVC>:
-			$<$<VERSION_GREATER:${MSVC_VERSION}, 1900>:/std:c++14>
+			$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},19.00.23918>:/std:c++14>
 		>
 
 		# warning options
@@ -781,9 +787,9 @@ function(openrtm_gencode_set_compile_options target)
 		# C++11: target_compile_features can't be used becase it's support after v3.1.0.
 		$<$<CXX_COMPILER_ID:GNU>:-std=c++11>
 		$<$<CXX_COMPILER_ID:Clang>:-std=c++11>
-		## MSVC always enable c++11 and c++14, so we use c++14 after MSVC 2015.
+		## MSVC always enable c++11 and c++14 after MSVC 2015 Update 3.
 		$<$<CXX_COMPILER_ID:MSVC>:
-			$<$<VERSION_GREATER:${MSVC_VERSION}, 1900>:/std:c++14>
+			$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},19.00.23918>:/std:c++14>
 		>
 
 		$<$<CXX_COMPILER_ID:MSVC>:

--- a/examples/SimpleService/MyServiceSVC_impl.cpp
+++ b/examples/SimpleService/MyServiceSVC_impl.cpp
@@ -41,7 +41,7 @@ MyServiceSVC_impl::~MyServiceSVC_impl()
  * Methods corresponding to IDL attributes and operations
  */
 char* MyServiceSVC_impl::echo(const char* msg)
-  throw (CORBA::SystemException)
+  noexcept(false)
 {
   CORBA_SeqUtil::push_back(m_echoList, CORBA::string_dup(msg));
   std::cout << "MyService::echo() was called." << std::endl;
@@ -57,7 +57,7 @@ char* MyServiceSVC_impl::echo(const char* msg)
 }
 
 SimpleService::EchoList* MyServiceSVC_impl::get_echo_history()
-  throw (CORBA::SystemException)
+  noexcept(false)
 {
   std::cout << "MyService::get_echo_history() was called." << std::endl;
   CORBA_SeqUtil::for_each(m_echoList, seq_print<const char*>());
@@ -68,7 +68,7 @@ SimpleService::EchoList* MyServiceSVC_impl::get_echo_history()
 }
 
 void MyServiceSVC_impl::set_value(CORBA::Float value)
-  throw (CORBA::SystemException)
+  noexcept(false)
 {
   CORBA_SeqUtil::push_back(m_valueList, value);
   m_value = value;
@@ -87,7 +87,7 @@ void MyServiceSVC_impl::set_value(CORBA::Float value)
 }
 
 CORBA::Float MyServiceSVC_impl::get_value()
-  throw (CORBA::SystemException)
+  noexcept(false)
 {
   std::cout << "MyService::get_value() was called." << std::endl;
   std::cout << "Current value: " << m_value << std::endl;
@@ -96,7 +96,7 @@ CORBA::Float MyServiceSVC_impl::get_value()
 }
 
 SimpleService::ValueList* MyServiceSVC_impl::get_value_history()
-  throw (CORBA::SystemException)
+  noexcept(false)
 {
   std::cout << "MyService::get_value_history() was called." << std::endl;
   CORBA_SeqUtil::for_each(m_valueList, seq_print<CORBA::Float>());

--- a/examples/SimpleService/MyServiceSVC_impl.cpp
+++ b/examples/SimpleService/MyServiceSVC_impl.cpp
@@ -41,7 +41,6 @@ MyServiceSVC_impl::~MyServiceSVC_impl()
  * Methods corresponding to IDL attributes and operations
  */
 char* MyServiceSVC_impl::echo(const char* msg)
-  noexcept(false)
 {
   CORBA_SeqUtil::push_back(m_echoList, CORBA::string_dup(msg));
   std::cout << "MyService::echo() was called." << std::endl;
@@ -57,7 +56,6 @@ char* MyServiceSVC_impl::echo(const char* msg)
 }
 
 SimpleService::EchoList* MyServiceSVC_impl::get_echo_history()
-  noexcept(false)
 {
   std::cout << "MyService::get_echo_history() was called." << std::endl;
   CORBA_SeqUtil::for_each(m_echoList, seq_print<const char*>());
@@ -68,7 +66,6 @@ SimpleService::EchoList* MyServiceSVC_impl::get_echo_history()
 }
 
 void MyServiceSVC_impl::set_value(CORBA::Float value)
-  noexcept(false)
 {
   CORBA_SeqUtil::push_back(m_valueList, value);
   m_value = value;
@@ -87,7 +84,6 @@ void MyServiceSVC_impl::set_value(CORBA::Float value)
 }
 
 CORBA::Float MyServiceSVC_impl::get_value()
-  noexcept(false)
 {
   std::cout << "MyService::get_value() was called." << std::endl;
   std::cout << "Current value: " << m_value << std::endl;
@@ -96,7 +92,6 @@ CORBA::Float MyServiceSVC_impl::get_value()
 }
 
 SimpleService::ValueList* MyServiceSVC_impl::get_value_history()
-  noexcept(false)
 {
   std::cout << "MyService::get_value_history() was called." << std::endl;
   CORBA_SeqUtil::for_each(m_valueList, seq_print<CORBA::Float>());

--- a/examples/SimpleService/MyServiceSVC_impl.h
+++ b/examples/SimpleService/MyServiceSVC_impl.h
@@ -29,15 +29,15 @@ class MyServiceSVC_impl
 
    // attributes and operations
    char* echo(const char* msg)
-     throw (CORBA::SystemException) override;
+     noexcept(false) override;
   SimpleService::EchoList* get_echo_history()
-     throw (CORBA::SystemException) override;
+     noexcept(false) override;
    void set_value(CORBA::Float value)
-     throw (CORBA::SystemException) override;
+     noexcept(false) override;
    CORBA::Float get_value()
-     throw (CORBA::SystemException) override;
+     noexcept(false) override;
   SimpleService::ValueList* get_value_history()
-     throw (CORBA::SystemException) override;
+     noexcept(false) override;
 
 private:
   CORBA::Float m_value;

--- a/examples/SimpleService/MyServiceSVC_impl.h
+++ b/examples/SimpleService/MyServiceSVC_impl.h
@@ -28,16 +28,11 @@ class MyServiceSVC_impl
    ~MyServiceSVC_impl() override;
 
    // attributes and operations
-   char* echo(const char* msg)
-     noexcept(false) override;
-  SimpleService::EchoList* get_echo_history()
-     noexcept(false) override;
-   void set_value(CORBA::Float value)
-     noexcept(false) override;
-   CORBA::Float get_value()
-     noexcept(false) override;
-  SimpleService::ValueList* get_value_history()
-     noexcept(false) override;
+   char* echo(const char* msg) override;
+  SimpleService::EchoList* get_echo_history() override;
+   void set_value(CORBA::Float value) override;
+   CORBA::Float get_value() override;
+  SimpleService::ValueList* get_value_history() override;
 
 private:
   CORBA::Float m_value;

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
@@ -195,7 +195,7 @@ namespace RTC
    */
   void LogicalTimeTriggeredEC::
   tick(::CORBA::ULong sec, ::CORBA::ULong usec)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("tick(sec = %d, usec = %d)", sec, usec));
     coil::TimeValue time(sec, usec);
@@ -225,7 +225,7 @@ namespace RTC
   
   void LogicalTimeTriggeredEC::
   get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     coil::TimeValue time(m_clock.gettime());
     sec  = time.sec();
@@ -243,7 +243,7 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean LogicalTimeTriggeredEC::is_running()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -256,7 +256,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::start()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -269,7 +269,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::stop()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -284,7 +284,7 @@ namespace RTC
    * @endif
    */
   CORBA::Double LogicalTimeTriggeredEC::get_rate()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -297,7 +297,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::set_rate(CORBA::Double rate)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -311,7 +311,7 @@ namespace RTC
    */
   RTC::ReturnCode_t
   LogicalTimeTriggeredEC::add_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -325,7 +325,7 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -339,7 +339,7 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -353,7 +353,7 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -367,7 +367,7 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -381,7 +381,7 @@ namespace RTC
    */
   RTC::LifeCycleState LogicalTimeTriggeredEC::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getComponentState(comp);
   }
@@ -394,7 +394,7 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionKind LogicalTimeTriggeredEC::get_kind()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -410,7 +410,7 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionContextProfile* LogicalTimeTriggeredEC::get_profile()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
@@ -195,7 +195,6 @@ namespace RTC
    */
   void LogicalTimeTriggeredEC::
   tick(::CORBA::ULong sec, ::CORBA::ULong usec)
-    noexcept(false)
   {
     RTC_TRACE(("tick(sec = %d, usec = %d)", sec, usec));
     coil::TimeValue time(sec, usec);
@@ -225,7 +224,6 @@ namespace RTC
   
   void LogicalTimeTriggeredEC::
   get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec)
-    noexcept(false)
   {
     coil::TimeValue time(m_clock.gettime());
     sec  = time.sec();
@@ -243,7 +241,6 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean LogicalTimeTriggeredEC::is_running()
-    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -256,7 +253,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::start()
-    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -269,7 +265,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::stop()
-    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -284,7 +279,6 @@ namespace RTC
    * @endif
    */
   CORBA::Double LogicalTimeTriggeredEC::get_rate()
-    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -297,7 +291,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::set_rate(CORBA::Double rate)
-    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -311,7 +304,6 @@ namespace RTC
    */
   RTC::ReturnCode_t
   LogicalTimeTriggeredEC::add_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -325,7 +317,6 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -339,7 +330,6 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -353,7 +343,6 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -367,7 +356,6 @@ namespace RTC
    */
   RTC::ReturnCode_t LogicalTimeTriggeredEC::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -381,7 +369,6 @@ namespace RTC
    */
   RTC::LifeCycleState LogicalTimeTriggeredEC::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::getComponentState(comp);
   }
@@ -394,7 +381,6 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionKind LogicalTimeTriggeredEC::get_kind()
-    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -410,7 +396,6 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionContextProfile* LogicalTimeTriggeredEC::get_profile()
-    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
@@ -209,9 +209,9 @@ namespace RTC
      * @endif
      */
     void tick(::CORBA::ULong sec, ::CORBA::ULong usec)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
     void get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     //============================================================
     // ExecutionContextService
@@ -241,7 +241,7 @@ namespace RTC
      * @endif
      */
     CORBA::Boolean is_running()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -271,7 +271,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t start()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -300,7 +300,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -323,7 +323,7 @@ namespace RTC
      * @endif
      */
     CORBA::Double get_rate()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -355,7 +355,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -392,7 +392,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
     
     /*!
      * @if jp
@@ -428,7 +428,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -463,7 +463,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -493,7 +493,7 @@ namespace RTC
      */
     RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -515,7 +515,7 @@ namespace RTC
      * @endif
      */
     RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -549,7 +549,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -583,7 +583,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -605,7 +605,7 @@ namespace RTC
      * @endif
      */
     RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   protected:
     /*!

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
@@ -208,10 +208,8 @@ namespace RTC
      *
      * @endif
      */
-    void tick(::CORBA::ULong sec, ::CORBA::ULong usec)
-      noexcept(false) override;
-    void get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec)
-      noexcept(false) override;
+    void tick(::CORBA::ULong sec, ::CORBA::ULong usec) override;
+    void get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec) override;
 
     //============================================================
     // ExecutionContextService
@@ -240,8 +238,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Boolean is_running()
-      noexcept(false) override;
+    CORBA::Boolean is_running() override;
 
     /*!
      * @if jp
@@ -270,8 +267,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t start()
-      noexcept(false) override;
+    RTC::ReturnCode_t start() override;
 
     /*!
      * @if jp
@@ -299,8 +295,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t stop()
-      noexcept(false) override;
+    RTC::ReturnCode_t stop() override;
 
     /*!
      * @if jp
@@ -322,8 +317,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Double get_rate()
-      noexcept(false) override;
+    CORBA::Double get_rate() override;
 
     /*!
      * @if jp
@@ -354,8 +348,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      noexcept(false) override;
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate) override;
 
     /*!
      * @if jp
@@ -391,8 +384,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    activate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    activate_component(RTC::LightweightRTObject_ptr comp) override;
     
     /*!
      * @if jp
@@ -427,8 +419,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    deactivate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    deactivate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -462,8 +453,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    reset_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    reset_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -492,8 +482,7 @@ namespace RTC
      * @endif
      */
     RTC::LifeCycleState
-    get_component_state(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    get_component_state(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -514,8 +503,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ExecutionKind get_kind()
-      noexcept(false) override;
+    RTC::ExecutionKind get_kind() override;
 
     /*!
      * @if jp
@@ -548,8 +536,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -582,8 +569,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    remove_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    remove_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -604,8 +590,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ExecutionContextProfile* get_profile()
-      noexcept(false) override;
+    RTC::ExecutionContextProfile* get_profile() override;
 
   protected:
     /*!

--- a/src/ext/ec/rtpreempt/RTPreemptEC.cpp
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.cpp
@@ -230,7 +230,6 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Boolean RTPreemptEC::is_running()
-    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -243,7 +242,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t RTPreemptEC::start()
-    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -256,7 +254,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t RTPreemptEC::stop()
-    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -271,7 +268,6 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Double RTPreemptEC::get_rate()
-    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -284,7 +280,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t RTPreemptEC::set_rate(CORBA::Double rate)
-    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -298,7 +293,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t
   RTPreemptEC::add_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -312,7 +306,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -326,7 +319,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -340,7 +332,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -354,7 +345,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -368,7 +358,6 @@ namespace RTC_exp
    */
   RTC::LifeCycleState RTPreemptEC::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     RTC::LifeCycleState ret = ExecutionContextBase::getComponentState(comp);
     return ret;
@@ -382,7 +371,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionKind RTPreemptEC::get_kind()
-    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -398,7 +386,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionContextProfile* RTPreemptEC::get_profile()
-    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/ext/ec/rtpreempt/RTPreemptEC.cpp
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.cpp
@@ -230,7 +230,7 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Boolean RTPreemptEC::is_running()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -243,7 +243,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t RTPreemptEC::start()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -256,7 +256,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t RTPreemptEC::stop()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -271,7 +271,7 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Double RTPreemptEC::get_rate()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -284,7 +284,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t RTPreemptEC::set_rate(CORBA::Double rate)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -298,7 +298,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t
   RTPreemptEC::add_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -312,7 +312,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -326,7 +326,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -340,7 +340,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -354,7 +354,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t RTPreemptEC::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -368,7 +368,7 @@ namespace RTC_exp
    */
   RTC::LifeCycleState RTPreemptEC::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC::LifeCycleState ret = ExecutionContextBase::getComponentState(comp);
     return ret;
@@ -382,7 +382,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionKind RTPreemptEC::get_kind()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -398,7 +398,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionContextProfile* RTPreemptEC::get_profile()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/ext/ec/rtpreempt/RTPreemptEC.h
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.h
@@ -296,8 +296,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    CORBA::Boolean is_running()
-      noexcept(false) override;
+    CORBA::Boolean is_running() override;
 
     /*!
      * @if jp
@@ -326,8 +325,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ReturnCode_t start()
-      noexcept(false) override;
+    RTC::ReturnCode_t start() override;
 
     /*!
      * @if jp
@@ -355,8 +353,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ReturnCode_t stop()
-      noexcept(false) override;
+    RTC::ReturnCode_t stop() override;
 
     /*!
      * @if jp
@@ -378,8 +375,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    CORBA::Double get_rate()
-      noexcept(false) override;
+    CORBA::Double get_rate() override;
 
     /*!
      * @if jp
@@ -410,8 +406,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      noexcept(false) override;
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate) override;
 
     /*!
      * @if jp
@@ -447,8 +442,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    activate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    activate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -483,8 +477,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    deactivate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    deactivate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -518,8 +511,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    reset_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    reset_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -548,8 +540,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::LifeCycleState
-    get_component_state(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    get_component_state(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -570,8 +561,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ExecutionKind get_kind()
-      noexcept(false) override;
+    RTC::ExecutionKind get_kind() override;
 
     /*!
      * @if jp
@@ -605,8 +595,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    add_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    add_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -638,8 +627,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    remove_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    remove_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -660,8 +648,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ExecutionContextProfile* get_profile()
-      noexcept(false) override;
+    RTC::ExecutionContextProfile* get_profile() override;
 
   protected:
     /*!

--- a/src/ext/ec/rtpreempt/RTPreemptEC.h
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.h
@@ -297,7 +297,7 @@ namespace RTC_exp
      * @endif
      */
     CORBA::Boolean is_running()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -327,7 +327,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t start()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -356,7 +356,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -379,7 +379,7 @@ namespace RTC_exp
      * @endif
      */
     CORBA::Double get_rate()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -411,7 +411,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -448,7 +448,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -484,7 +484,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -519,7 +519,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -549,7 +549,7 @@ namespace RTC_exp
      */
     RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -571,7 +571,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -606,7 +606,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -639,7 +639,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -661,7 +661,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   protected:
     /*!

--- a/src/lib/coil/common/Allocator.cpp
+++ b/src/lib/coil/common/Allocator.cpp
@@ -29,7 +29,7 @@ namespace coil
    * @brief Create of memory allocation
    * @endif
    */
-  void* Allocator::New(size_t t) throw (std::bad_alloc)
+  void* Allocator::New(size_t t) noexcept(false)
   {
     return operator new(t);
   }
@@ -41,7 +41,7 @@ namespace coil
    * @brief Delete of memory allocation
    * @endif
    */
-  void Allocator::Delete(void* p) throw ()
+  void Allocator::Delete(void* p) noexcept
   {
     operator delete(p);
   }
@@ -53,7 +53,7 @@ namespace coil
    * @brief Create of array memory allocation
    * @endif
    */
-  void* Allocator::NewArray(size_t t) throw (std::bad_alloc)
+  void* Allocator::NewArray(size_t t) noexcept(false)
   {
     return operator new[](t);
   }
@@ -65,7 +65,7 @@ namespace coil
    * @brief Delete of array memory allocation
    * @endif
    */
-  void Allocator::DeleteArray(void* p) throw ()
+  void Allocator::DeleteArray(void* p) noexcept
   {
     operator delete[](p);
   }

--- a/src/lib/coil/common/Allocator.cpp
+++ b/src/lib/coil/common/Allocator.cpp
@@ -29,7 +29,7 @@ namespace coil
    * @brief Create of memory allocation
    * @endif
    */
-  void* Allocator::New(size_t t) noexcept(false)
+  void* Allocator::New(size_t t)
   {
     return operator new(t);
   }
@@ -53,7 +53,7 @@ namespace coil
    * @brief Create of array memory allocation
    * @endif
    */
-  void* Allocator::NewArray(size_t t) noexcept(false)
+  void* Allocator::NewArray(size_t t)
   {
     return operator new[](t);
   }

--- a/src/lib/coil/common/Allocator.h
+++ b/src/lib/coil/common/Allocator.h
@@ -84,7 +84,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void* New(size_t t) throw (std::bad_alloc);
+    virtual void* New(size_t t) noexcept(false);
 
     /*!
      * @if jp
@@ -105,7 +105,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void Delete(void* p) throw ();
+    virtual void Delete(void* p) noexcept;
 
     /*!
      * @if jp
@@ -130,7 +130,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void* NewArray(size_t t) throw (std::bad_alloc);
+    virtual void* NewArray(size_t t) noexcept(false);
 
     /*!
      * @if jp
@@ -151,7 +151,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void DeleteArray(void* p) throw ();
+    virtual void DeleteArray(void* p) noexcept;
 
   };
 } // namespace coil

--- a/src/lib/coil/common/Allocator.h
+++ b/src/lib/coil/common/Allocator.h
@@ -84,7 +84,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void* New(size_t t) noexcept(false);
+    virtual void* New(size_t t);
 
     /*!
      * @if jp
@@ -130,7 +130,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void* NewArray(size_t t) noexcept(false);
+    virtual void* NewArray(size_t t);
 
     /*!
      * @if jp

--- a/src/lib/rtm/CorbaNaming.cpp
+++ b/src/lib/rtm/CorbaNaming.cpp
@@ -105,7 +105,7 @@ namespace RTC
    */
   void CorbaNaming::bind(const CosNaming::Name& name, CORBA::Object_ptr obj,
                          const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     try
       {
@@ -134,7 +134,7 @@ namespace RTC
    */
   void CorbaNaming::bindByString(const char* string_name, CORBA::Object_ptr obj,
                                  const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     this->bind(toName(string_name), obj, force);
   }
@@ -149,7 +149,7 @@ namespace RTC
   void CorbaNaming::bindRecursive(CosNaming::NamingContext_ptr context,
                                   const CosNaming::Name& name,
                                   CORBA::Object_ptr obj)
-    throw (SystemException, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     CORBA::ULong len(name.length());
     CosNaming::NamingContext_var cxt;
@@ -183,7 +183,7 @@ namespace RTC
   void CorbaNaming::rebind(const CosNaming::Name& name,
                            CORBA::Object_ptr obj,
                            const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     try
       {
@@ -213,7 +213,7 @@ namespace RTC
   void CorbaNaming::rebindByString(const char* string_name,
                                    CORBA::Object_ptr obj,
                                    const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     rebind(toName(string_name), obj, force);
   }
@@ -228,7 +228,7 @@ namespace RTC
   void CorbaNaming::rebindRecursive(CosNaming::NamingContext_ptr context,
                                     const CosNaming::Name& name,
                                     CORBA::Object_ptr obj)
-    throw (SystemException, CannotProceed, InvalidName)
+    noexcept(false)
   {
     CORBA::ULong len(name.length());
     CosNaming::NamingContext_var cxt;
@@ -274,7 +274,7 @@ namespace RTC
   void CorbaNaming::bindContext(const CosNaming::Name& name,
                                 CosNaming::NamingContext_ptr name_cxt,
                                 const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     bind(name, name_cxt, force);
   }
@@ -289,7 +289,7 @@ namespace RTC
   void CorbaNaming::bindContext(const char* string_name,
                                 CosNaming::NamingContext_ptr name_cxt,
                                 const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     bindContext(toName(string_name), name_cxt, force);
   }
@@ -320,7 +320,7 @@ namespace RTC
   void CorbaNaming::rebindContext(const CosNaming::Name& name,
                                   CosNaming::NamingContext_ptr name_cxt,
                                   const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     rebind(name, name_cxt, force);
     return;
@@ -336,7 +336,7 @@ namespace RTC
   void CorbaNaming::rebindContext(const char* string_name,
                                   CosNaming::NamingContext_ptr name_cxt,
                                   const bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     rebindContext(toName(string_name), name_cxt, force);
   }
@@ -365,7 +365,7 @@ namespace RTC
    * @endif
    */
   CORBA::Object_ptr CorbaNaming::resolve(const CosNaming::Name& name)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     return m_rootContext->resolve(name);
   }
@@ -378,7 +378,7 @@ namespace RTC
    * @endif
    */
   CORBA::Object_ptr CorbaNaming::resolve(const char* string_name)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     return resolve(toName(string_name));
   }
@@ -391,7 +391,7 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::unbind(const CosNaming::Name& name)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     m_rootContext->unbind(name);
   }
@@ -404,7 +404,7 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::unbind(const char* string_name)
-    throw (SystemException, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     unbind(toName(string_name));
   }
@@ -430,7 +430,7 @@ namespace RTC
    */
   CosNaming::NamingContext_ptr
   CorbaNaming::bindNewContext(const CosNaming::Name& name, bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     try
       {
@@ -461,7 +461,7 @@ namespace RTC
    */
   CosNaming::NamingContext_ptr
   CorbaNaming::bindNewContext(const char* string_name, bool force)
-    throw (SystemException, NotFound, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     return bindNewContext(toName(string_name), force);
   }
@@ -474,7 +474,7 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::destroy(CosNaming::NamingContext_ptr context)
-    throw (SystemException, NotEmpty)
+    noexcept(false)
   {
     context->destroy();
   }
@@ -487,7 +487,7 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::destroyRecursive(CosNaming::NamingContext_ptr context)
-    throw (SystemException, NotEmpty, NotFound, CannotProceed, InvalidName)
+    noexcept(false)
   {
     CosNaming::BindingList_var     bl;
     CosNaming::BindingIterator_var bi;
@@ -671,7 +671,7 @@ namespace RTC
    * @endif
    */
   char* CorbaNaming::toString(const CosNaming::Name& name)
-    throw (SystemException, InvalidName)
+    noexcept(false)
   {
     if (name.length() == 0)
       throw InvalidName();
@@ -693,7 +693,7 @@ namespace RTC
    * @endif
    */
   CosNaming::Name CorbaNaming::toName(const char* sname)
-    throw (SystemException, InvalidName)
+    noexcept(false)
   {
     if (sname == nullptr)         throw InvalidName();
     if (*sname == '\0') throw InvalidName();
@@ -743,7 +743,7 @@ namespace RTC
    * @endif
    */
   char* CorbaNaming::toUrl(char* addr, char* string_name)
-    throw (SystemException, InvalidAddress, InvalidName)
+    noexcept(false)
   {
     return m_rootContext->to_url(addr, string_name);
   }
@@ -756,7 +756,7 @@ namespace RTC
    * @endif
    */
   CORBA::Object_ptr CorbaNaming::resolveStr(const char* string_name)
-    throw (SystemException, NotFound, CannotProceed, InvalidName, AlreadyBound)
+    noexcept(false)
   {
     return resolve(string_name);
   }

--- a/src/lib/rtm/CorbaNaming.cpp
+++ b/src/lib/rtm/CorbaNaming.cpp
@@ -105,7 +105,6 @@ namespace RTC
    */
   void CorbaNaming::bind(const CosNaming::Name& name, CORBA::Object_ptr obj,
                          const bool force)
-    noexcept(false)
   {
     try
       {
@@ -134,7 +133,6 @@ namespace RTC
    */
   void CorbaNaming::bindByString(const char* string_name, CORBA::Object_ptr obj,
                                  const bool force)
-    noexcept(false)
   {
     this->bind(toName(string_name), obj, force);
   }
@@ -149,7 +147,6 @@ namespace RTC
   void CorbaNaming::bindRecursive(CosNaming::NamingContext_ptr context,
                                   const CosNaming::Name& name,
                                   CORBA::Object_ptr obj)
-    noexcept(false)
   {
     CORBA::ULong len(name.length());
     CosNaming::NamingContext_var cxt;
@@ -183,7 +180,6 @@ namespace RTC
   void CorbaNaming::rebind(const CosNaming::Name& name,
                            CORBA::Object_ptr obj,
                            const bool force)
-    noexcept(false)
   {
     try
       {
@@ -213,7 +209,6 @@ namespace RTC
   void CorbaNaming::rebindByString(const char* string_name,
                                    CORBA::Object_ptr obj,
                                    const bool force)
-    noexcept(false)
   {
     rebind(toName(string_name), obj, force);
   }
@@ -228,7 +223,6 @@ namespace RTC
   void CorbaNaming::rebindRecursive(CosNaming::NamingContext_ptr context,
                                     const CosNaming::Name& name,
                                     CORBA::Object_ptr obj)
-    noexcept(false)
   {
     CORBA::ULong len(name.length());
     CosNaming::NamingContext_var cxt;
@@ -274,7 +268,6 @@ namespace RTC
   void CorbaNaming::bindContext(const CosNaming::Name& name,
                                 CosNaming::NamingContext_ptr name_cxt,
                                 const bool force)
-    noexcept(false)
   {
     bind(name, name_cxt, force);
   }
@@ -289,7 +282,6 @@ namespace RTC
   void CorbaNaming::bindContext(const char* string_name,
                                 CosNaming::NamingContext_ptr name_cxt,
                                 const bool force)
-    noexcept(false)
   {
     bindContext(toName(string_name), name_cxt, force);
   }
@@ -320,7 +312,6 @@ namespace RTC
   void CorbaNaming::rebindContext(const CosNaming::Name& name,
                                   CosNaming::NamingContext_ptr name_cxt,
                                   const bool force)
-    noexcept(false)
   {
     rebind(name, name_cxt, force);
     return;
@@ -336,7 +327,6 @@ namespace RTC
   void CorbaNaming::rebindContext(const char* string_name,
                                   CosNaming::NamingContext_ptr name_cxt,
                                   const bool force)
-    noexcept(false)
   {
     rebindContext(toName(string_name), name_cxt, force);
   }
@@ -365,7 +355,6 @@ namespace RTC
    * @endif
    */
   CORBA::Object_ptr CorbaNaming::resolve(const CosNaming::Name& name)
-    noexcept(false)
   {
     return m_rootContext->resolve(name);
   }
@@ -378,7 +367,6 @@ namespace RTC
    * @endif
    */
   CORBA::Object_ptr CorbaNaming::resolve(const char* string_name)
-    noexcept(false)
   {
     return resolve(toName(string_name));
   }
@@ -391,7 +379,6 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::unbind(const CosNaming::Name& name)
-    noexcept(false)
   {
     m_rootContext->unbind(name);
   }
@@ -404,7 +391,6 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::unbind(const char* string_name)
-    noexcept(false)
   {
     unbind(toName(string_name));
   }
@@ -430,7 +416,6 @@ namespace RTC
    */
   CosNaming::NamingContext_ptr
   CorbaNaming::bindNewContext(const CosNaming::Name& name, bool force)
-    noexcept(false)
   {
     try
       {
@@ -461,7 +446,6 @@ namespace RTC
    */
   CosNaming::NamingContext_ptr
   CorbaNaming::bindNewContext(const char* string_name, bool force)
-    noexcept(false)
   {
     return bindNewContext(toName(string_name), force);
   }
@@ -474,7 +458,6 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::destroy(CosNaming::NamingContext_ptr context)
-    noexcept(false)
   {
     context->destroy();
   }
@@ -487,7 +470,6 @@ namespace RTC
    * @endif
    */
   void CorbaNaming::destroyRecursive(CosNaming::NamingContext_ptr context)
-    noexcept(false)
   {
     CosNaming::BindingList_var     bl;
     CosNaming::BindingIterator_var bi;
@@ -671,7 +653,6 @@ namespace RTC
    * @endif
    */
   char* CorbaNaming::toString(const CosNaming::Name& name)
-    noexcept(false)
   {
     if (name.length() == 0)
       throw InvalidName();
@@ -693,7 +674,6 @@ namespace RTC
    * @endif
    */
   CosNaming::Name CorbaNaming::toName(const char* sname)
-    noexcept(false)
   {
     if (sname == nullptr)         throw InvalidName();
     if (*sname == '\0') throw InvalidName();
@@ -743,7 +723,6 @@ namespace RTC
    * @endif
    */
   char* CorbaNaming::toUrl(char* addr, char* string_name)
-    noexcept(false)
   {
     return m_rootContext->to_url(addr, string_name);
   }
@@ -756,7 +735,6 @@ namespace RTC
    * @endif
    */
   CORBA::Object_ptr CorbaNaming::resolveStr(const char* string_name)
-    noexcept(false)
   {
     return resolve(string_name);
   }

--- a/src/lib/rtm/CorbaNaming.h
+++ b/src/lib/rtm/CorbaNaming.h
@@ -253,8 +253,7 @@ namespace RTC
      * @endif
      */
     void bind(const CosNaming::Name& name, CORBA::Object_ptr obj,
-              bool force = true)
-      noexcept(false);
+              bool force = true);
 
     /*!
      * @if jp
@@ -295,8 +294,7 @@ namespace RTC
      * @endif
      */
     void bindByString(const char* string_name, CORBA::Object_ptr obj,
-                      bool force = true)
-      noexcept(false);
+                      bool force = true);
 
     /*!
      * @if jp
@@ -360,8 +358,7 @@ namespace RTC
      */
     void bindRecursive(CosNaming::NamingContext_ptr context,
                        const CosNaming::Name& name,
-                       CORBA::Object_ptr obj)
-      noexcept(false);
+                       CORBA::Object_ptr obj);
 
     /*!
      * @if jp
@@ -401,8 +398,7 @@ namespace RTC
      * @endif
      */
     void rebind(const CosNaming::Name& name, CORBA::Object_ptr obj,
-                bool force = true)
-      noexcept(false);
+                bool force = true);
 
     /*!
      * @if jp
@@ -441,8 +437,7 @@ namespace RTC
      * @endif
      */
     void rebindByString(const char* string_name, CORBA::Object_ptr obj,
-                        bool force = true)
-      noexcept(false);
+                        bool force = true);
 
     /*!
      * @if jp
@@ -483,8 +478,7 @@ namespace RTC
      */
     void rebindRecursive(CosNaming::NamingContext_ptr context,
                          const CosNaming::Name& name,
-                         CORBA::Object_ptr obj)
-      noexcept(false);
+                         CORBA::Object_ptr obj);
 
     /*!
      * @if jp
@@ -524,8 +518,7 @@ namespace RTC
      */
     void bindContext(const CosNaming::Name& name,
                      CosNaming::NamingContext_ptr name_cxt,
-                     bool force = true)
-      noexcept(false);
+                     bool force = true);
 
     /*!
      * @if jp
@@ -566,8 +559,7 @@ namespace RTC
      */
     void bindContext(const char* string_name,
                      CosNaming::NamingContext_ptr name_cxt,
-                     bool force = true)
-      noexcept(false);
+                     bool force = true);
 
     /*!
      * @if jp
@@ -638,8 +630,7 @@ namespace RTC
      */
     void rebindContext(const CosNaming::Name& name,
                        CosNaming::NamingContext_ptr name_cxt,
-                       bool force = true)
-      noexcept(false);
+                       bool force = true);
 
     /*!
      * @if jp
@@ -681,8 +672,7 @@ namespace RTC
      */
     void rebindContext(const char* string_name,
                        CosNaming::NamingContext_ptr name_cxt,
-                       bool force = true)
-      noexcept(false);
+                       bool force = true);
 
     /*!
      * @if jp
@@ -754,8 +744,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Object_ptr resolve(const CosNaming::Name& name)
-      noexcept(false);
+    CORBA::Object_ptr resolve(const CosNaming::Name& name);
 
     /*!
      * @if jp
@@ -799,8 +788,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Object_ptr resolve(const char* string_name)
-      noexcept(false);
+    CORBA::Object_ptr resolve(const char* string_name);
 
     /*!
      * @if jp
@@ -839,8 +827,7 @@ namespace RTC
      *
      * @endif
      */
-    void unbind(const CosNaming::Name& name)
-      noexcept(false);
+    void unbind(const CosNaming::Name& name);
 
     /*!
      * @if jp
@@ -884,8 +871,7 @@ namespace RTC
      *
      * @endif
      */
-    void unbind(const char* string_name)
-      noexcept(false);
+    void unbind(const char* string_name);
 
     /*!
      * @if jp
@@ -950,8 +936,7 @@ namespace RTC
      * @endif
      */
     CosNaming::NamingContext_ptr
-    bindNewContext(const CosNaming::Name& name, bool force = true)
-      noexcept(false);
+    bindNewContext(const CosNaming::Name& name, bool force = true);
 
     /*!
      * @if jp
@@ -994,8 +979,7 @@ namespace RTC
      * @endif
      */
     CosNaming::NamingContext_ptr
-    bindNewContext(const char* string_name, bool force = true)
-      noexcept(false);
+    bindNewContext(const char* string_name, bool force = true);
 
     /*!
      * @if jp
@@ -1024,8 +1008,7 @@ namespace RTC
      *
      * @endif
      */
-    void destroy(CosNaming::NamingContext_ptr context)
-      noexcept(false);
+    void destroy(CosNaming::NamingContext_ptr context);
 
     /*!
      * @if jp
@@ -1058,8 +1041,7 @@ namespace RTC
      *
      * @endif
      */
-    void destroyRecursive(CosNaming::NamingContext_ptr context)
-      noexcept(false);
+    void destroyRecursive(CosNaming::NamingContext_ptr context);
 
     /*!
      * @if jp
@@ -1220,8 +1202,7 @@ namespace RTC
      *
      * @endif
      */
-    char* toString(const CosNaming::Name& name)
-      noexcept(false);
+    char* toString(const CosNaming::Name& name);
 
     /*!
      * @if jp
@@ -1248,8 +1229,7 @@ namespace RTC
      *
      * @endif
      */
-    CosNaming::Name toName(const char* sname)
-      noexcept(false);
+    CosNaming::Name toName(const char* sname);
 
     /*!
      * @if jp
@@ -1280,8 +1260,7 @@ namespace RTC
      *
      * @endif
      */
-    char* toUrl(char* addr, char* string_name)
-      noexcept(false);
+    char* toUrl(char* addr, char* string_name);
 
     /*!
      * @if jp
@@ -1314,8 +1293,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Object_ptr resolveStr(const char* string_name)
-      noexcept(false);
+    CORBA::Object_ptr resolveStr(const char* string_name);
 
     //============================================================
     // Find functions

--- a/src/lib/rtm/CorbaNaming.h
+++ b/src/lib/rtm/CorbaNaming.h
@@ -254,8 +254,7 @@ namespace RTC
      */
     void bind(const CosNaming::Name& name, CORBA::Object_ptr obj,
               bool force = true)
-      throw (SystemException, NotFound, CannotProceed,
-             InvalidName, AlreadyBound);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -297,8 +296,7 @@ namespace RTC
      */
     void bindByString(const char* string_name, CORBA::Object_ptr obj,
                       bool force = true)
-      throw (SystemException, NotFound, CannotProceed,
-             InvalidName, AlreadyBound);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -363,7 +361,7 @@ namespace RTC
     void bindRecursive(CosNaming::NamingContext_ptr context,
                        const CosNaming::Name& name,
                        CORBA::Object_ptr obj)
-      throw (SystemException, CannotProceed, InvalidName, AlreadyBound);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -404,7 +402,7 @@ namespace RTC
      */
     void rebind(const CosNaming::Name& name, CORBA::Object_ptr obj,
                 bool force = true)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -444,7 +442,7 @@ namespace RTC
      */
     void rebindByString(const char* string_name, CORBA::Object_ptr obj,
                         bool force = true)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -486,7 +484,7 @@ namespace RTC
     void rebindRecursive(CosNaming::NamingContext_ptr context,
                          const CosNaming::Name& name,
                          CORBA::Object_ptr obj)
-      throw (SystemException, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -527,8 +525,7 @@ namespace RTC
     void bindContext(const CosNaming::Name& name,
                      CosNaming::NamingContext_ptr name_cxt,
                      bool force = true)
-      throw (SystemException, NotFound, CannotProceed,
-             InvalidName, AlreadyBound);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -570,8 +567,7 @@ namespace RTC
     void bindContext(const char* string_name,
                      CosNaming::NamingContext_ptr name_cxt,
                      bool force = true)
-      throw (SystemException, NotFound, CannotProceed,
-             InvalidName, AlreadyBound);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -643,7 +639,7 @@ namespace RTC
     void rebindContext(const CosNaming::Name& name,
                        CosNaming::NamingContext_ptr name_cxt,
                        bool force = true)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -686,7 +682,7 @@ namespace RTC
     void rebindContext(const char* string_name,
                        CosNaming::NamingContext_ptr name_cxt,
                        bool force = true)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -759,7 +755,7 @@ namespace RTC
      * @endif
      */
     CORBA::Object_ptr resolve(const CosNaming::Name& name)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -804,7 +800,7 @@ namespace RTC
      * @endif
      */
     CORBA::Object_ptr resolve(const char* string_name)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -844,7 +840,7 @@ namespace RTC
      * @endif
      */
     void unbind(const CosNaming::Name& name)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -889,7 +885,7 @@ namespace RTC
      * @endif
      */
     void unbind(const char* string_name)
-      throw (SystemException, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -955,8 +951,7 @@ namespace RTC
      */
     CosNaming::NamingContext_ptr
     bindNewContext(const CosNaming::Name& name, bool force = true)
-      throw (SystemException, NotFound, CannotProceed,
-             InvalidName, AlreadyBound);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -1000,8 +995,7 @@ namespace RTC
      */
     CosNaming::NamingContext_ptr
     bindNewContext(const char* string_name, bool force = true)
-      throw (SystemException, NotFound, CannotProceed,
-             InvalidName, AlreadyBound);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -1031,7 +1025,7 @@ namespace RTC
      * @endif
      */
     void destroy(CosNaming::NamingContext_ptr context)
-      throw (SystemException, NotEmpty);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -1065,7 +1059,7 @@ namespace RTC
      * @endif
      */
     void destroyRecursive(CosNaming::NamingContext_ptr context)
-      throw (SystemException, NotEmpty, NotFound, CannotProceed, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -1227,7 +1221,7 @@ namespace RTC
      * @endif
      */
     char* toString(const CosNaming::Name& name)
-      throw (SystemException, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -1255,7 +1249,7 @@ namespace RTC
      * @endif
      */
     CosNaming::Name toName(const char* sname)
-      throw (SystemException, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -1287,7 +1281,7 @@ namespace RTC
      * @endif
      */
     char* toUrl(char* addr, char* string_name)
-      throw (SystemException, InvalidAddress, InvalidName);
+      noexcept(false);
 
     /*!
      * @if jp
@@ -1321,8 +1315,7 @@ namespace RTC
      * @endif
      */
     CORBA::Object_ptr resolveStr(const char* string_name)
-      throw (SystemException, NotFound, CannotProceed,
-             InvalidName, AlreadyBound);
+      noexcept(false);
 
     //============================================================
     // Find functions

--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -178,7 +178,7 @@ namespace RTC
    * @endif
    */
   void ExtTrigExecutionContext::tick()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("tick()"));
     if (!isRunning())
@@ -204,7 +204,7 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean ExtTrigExecutionContext::is_running()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -217,7 +217,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::start()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -230,7 +230,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::stop()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -245,7 +245,7 @@ namespace RTC
    * @endif
    */
   CORBA::Double ExtTrigExecutionContext::get_rate()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -258,7 +258,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::set_rate(CORBA::Double rate)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -272,7 +272,7 @@ namespace RTC
    */
   RTC::ReturnCode_t
   ExtTrigExecutionContext::add_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -286,7 +286,7 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -300,7 +300,7 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -314,7 +314,7 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -328,7 +328,7 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -342,7 +342,7 @@ namespace RTC
    */
   RTC::LifeCycleState ExtTrigExecutionContext::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getComponentState(comp);
   }
@@ -355,7 +355,7 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionKind ExtTrigExecutionContext::get_kind()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -371,7 +371,7 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionContextProfile* ExtTrigExecutionContext::get_profile()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -178,7 +178,6 @@ namespace RTC
    * @endif
    */
   void ExtTrigExecutionContext::tick()
-    noexcept(false)
   {
     RTC_TRACE(("tick()"));
     if (!isRunning())
@@ -204,7 +203,6 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean ExtTrigExecutionContext::is_running()
-    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -217,7 +215,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::start()
-    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -230,7 +227,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::stop()
-    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -245,7 +241,6 @@ namespace RTC
    * @endif
    */
   CORBA::Double ExtTrigExecutionContext::get_rate()
-    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -258,7 +253,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::set_rate(CORBA::Double rate)
-    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -272,7 +266,6 @@ namespace RTC
    */
   RTC::ReturnCode_t
   ExtTrigExecutionContext::add_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -286,7 +279,6 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -300,7 +292,6 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -314,7 +305,6 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -328,7 +318,6 @@ namespace RTC
    */
   RTC::ReturnCode_t ExtTrigExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -342,7 +331,6 @@ namespace RTC
    */
   RTC::LifeCycleState ExtTrigExecutionContext::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::getComponentState(comp);
   }
@@ -355,7 +343,6 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionKind ExtTrigExecutionContext::get_kind()
-    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -371,7 +358,6 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionContextProfile* ExtTrigExecutionContext::get_profile()
-    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/lib/rtm/ExtTrigExecutionContext.h
+++ b/src/lib/rtm/ExtTrigExecutionContext.h
@@ -188,7 +188,7 @@ namespace RTC
      * @endif
      */
     void tick()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     //============================================================
     // ExecutionContextService
@@ -218,7 +218,7 @@ namespace RTC
      * @endif
      */
     CORBA::Boolean is_running()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -248,7 +248,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t start()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -277,7 +277,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -300,7 +300,7 @@ namespace RTC
      * @endif
      */
     CORBA::Double get_rate()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -332,7 +332,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -369,7 +369,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -405,7 +405,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -440,7 +440,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -470,7 +470,7 @@ namespace RTC
      */
     RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -492,7 +492,7 @@ namespace RTC
      * @endif
      */
     RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -526,7 +526,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -560,7 +560,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -582,7 +582,7 @@ namespace RTC
      * @endif
      */
     RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   protected:
     /*!

--- a/src/lib/rtm/ExtTrigExecutionContext.h
+++ b/src/lib/rtm/ExtTrigExecutionContext.h
@@ -187,8 +187,7 @@ namespace RTC
      *
      * @endif
      */
-    void tick()
-      noexcept(false) override;
+    void tick() override;
 
     //============================================================
     // ExecutionContextService
@@ -217,8 +216,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Boolean is_running()
-      noexcept(false) override;
+    CORBA::Boolean is_running() override;
 
     /*!
      * @if jp
@@ -247,8 +245,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t start()
-      noexcept(false) override;
+    RTC::ReturnCode_t start() override;
 
     /*!
      * @if jp
@@ -276,8 +273,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t stop()
-      noexcept(false) override;
+    RTC::ReturnCode_t stop() override;
 
     /*!
      * @if jp
@@ -299,8 +295,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Double get_rate()
-      noexcept(false) override;
+    CORBA::Double get_rate() override;
 
     /*!
      * @if jp
@@ -331,8 +326,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      noexcept(false) override;
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate) override;
 
     /*!
      * @if jp
@@ -368,8 +362,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    activate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    activate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -404,8 +397,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    deactivate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    deactivate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -439,8 +431,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    reset_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    reset_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -469,8 +460,7 @@ namespace RTC
      * @endif
      */
     RTC::LifeCycleState
-    get_component_state(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    get_component_state(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -491,8 +481,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ExecutionKind get_kind()
-      noexcept(false) override;
+    RTC::ExecutionKind get_kind() override;
 
     /*!
      * @if jp
@@ -525,8 +514,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -559,8 +547,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    remove_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    remove_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -581,8 +568,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ExecutionContextProfile* get_profile()
-      noexcept(false) override;
+    RTC::ExecutionContextProfile* get_profile() override;
 
   protected:
     /*!

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -444,7 +444,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t InPortBase::connect(ConnectorProfile& connector_profile)
-    noexcept(false)
   {
     RTC_TRACE(("InPortBase::connect()"));
 
@@ -1093,7 +1092,6 @@ namespace RTC
   }
 
   ReturnCode_t InPortBase::notify_connect(ConnectorProfile& connector_profile)
-    noexcept(false)
   {
 	  Properties prop;
 	  NVUtil::copyToProperties(prop, connector_profile.properties);

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -444,7 +444,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t InPortBase::connect(ConnectorProfile& connector_profile)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("InPortBase::connect()"));
 
@@ -1093,7 +1093,7 @@ namespace RTC
   }
 
   ReturnCode_t InPortBase::notify_connect(ConnectorProfile& connector_profile)
-	  throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  Properties prop;
 	  NVUtil::copyToProperties(prop, connector_profile.properties);

--- a/src/lib/rtm/InPortBase.h
+++ b/src/lib/rtm/InPortBase.h
@@ -602,8 +602,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t
-    connect(ConnectorProfile& connector_profile)
-      noexcept(false) override;
+    connect(ConnectorProfile& connector_profile) override;
 
     /*!
      * @if jp
@@ -623,8 +622,7 @@ namespace RTC
      * @endif
      */
     virtual ConnectorListeners& getListeners();
-    ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-		noexcept(false) override;
+    ReturnCode_t notify_connect(ConnectorProfile& connector_profile) override;
 
   protected:
     /*!

--- a/src/lib/rtm/InPortBase.h
+++ b/src/lib/rtm/InPortBase.h
@@ -603,7 +603,7 @@ namespace RTC
      */
     ReturnCode_t
     connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -624,7 +624,7 @@ namespace RTC
      */
     virtual ConnectorListeners& getListeners();
     ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-		throw (CORBA::SystemException) override;
+		noexcept(false) override;
 
   protected:
     /*!

--- a/src/lib/rtm/InPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrProvider.cpp
@@ -151,7 +151,7 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   InPortCorbaCdrProvider::put(const ::OpenRTM::CdrData& data)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("InPortCorbaCdrProvider::put()"));
 

--- a/src/lib/rtm/InPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrProvider.cpp
@@ -151,7 +151,6 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   InPortCorbaCdrProvider::put(const ::OpenRTM::CdrData& data)
-    noexcept(false)
   {
     RTC_PARANOID(("InPortCorbaCdrProvider::put()"));
 

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -244,8 +244,7 @@ namespace RTC
      *
      * @endif
      */
-    ::OpenRTM::PortStatus put(const ::OpenRTM::CdrData& data)
-      noexcept(false) override;
+    ::OpenRTM::PortStatus put(const ::OpenRTM::CdrData& data) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -245,7 +245,7 @@ namespace RTC
      * @endif
      */
     ::OpenRTM::PortStatus put(const ::OpenRTM::CdrData& data)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortDSProvider.cpp
+++ b/src/lib/rtm/InPortDSProvider.cpp
@@ -149,7 +149,7 @@ namespace RTC
    */
   ::RTC::PortStatus
   InPortDSProvider::push(const ::RTC::OctetSeq& data)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("InPortDSProvider::push()"));
 

--- a/src/lib/rtm/InPortDSProvider.cpp
+++ b/src/lib/rtm/InPortDSProvider.cpp
@@ -149,7 +149,6 @@ namespace RTC
    */
   ::RTC::PortStatus
   InPortDSProvider::push(const ::RTC::OctetSeq& data)
-    noexcept(false)
   {
     RTC_PARANOID(("InPortDSProvider::push()"));
 

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -242,8 +242,7 @@ namespace RTC
      *
      * @endif
      */
-    ::RTC::PortStatus push(const ::RTC::OctetSeq& data)
-      noexcept(false) override;
+    ::RTC::PortStatus push(const ::RTC::OctetSeq& data) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -243,7 +243,7 @@ namespace RTC
      * @endif
      */
     ::RTC::PortStatus push(const ::RTC::OctetSeq& data)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   private:
     /*!

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -120,7 +120,7 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   InPortSHMProvider::put()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("InPortSHMProvider::put()"));
     if (m_connector == nullptr)

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -120,7 +120,6 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   InPortSHMProvider::put()
-    noexcept(false)
   {
     RTC_PARANOID(("InPortSHMProvider::put()"));
     if (m_connector == nullptr)

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -182,7 +182,7 @@ namespace RTC
      * @endif
      */
     ::OpenRTM::PortStatus put()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
     
   private:
 

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -181,8 +181,7 @@ namespace RTC
      *
      * @endif
      */
-    ::OpenRTM::PortStatus put()
-      noexcept(false) override;
+    ::OpenRTM::PortStatus put() override;
     
   private:
 

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -222,7 +222,6 @@ namespace RTC
    */
   void* ModuleManager::symbol(const std::string& file_name,
                               const std::string& func_name)
-    noexcept(false)
   {
     RTC_TRACE(("symbol(%s, %s)",
                file_name.c_str(), func_name.c_str()))

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -222,7 +222,7 @@ namespace RTC
    */
   void* ModuleManager::symbol(const std::string& file_name,
                               const std::string& func_name)
-    throw (ModuleNotFound, SymbolNotFound)
+    noexcept(false)
   {
     RTC_TRACE(("symbol(%s, %s)",
                file_name.c_str(), func_name.c_str()))

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -350,8 +350,7 @@ namespace RTC
      * @brief Refer to the symbol of the module
      * @endif
      */
-    void* symbol(const std::string& file_name, const std::string& func_name)
-      noexcept(false);
+    void* symbol(const std::string& file_name, const std::string& func_name);
 
     /*!
      * @if jp

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -351,7 +351,7 @@ namespace RTC
      * @endif
      */
     void* symbol(const std::string& file_name, const std::string& func_name)
-      throw (ModuleNotFound, SymbolNotFound);
+      noexcept(false);
 
     /*!
      * @if jp

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -70,7 +70,6 @@ namespace RTC
    * @endif
    */
   void OpenHRPExecutionContext::tick()
-    noexcept(false)
   {
     RTC_TRACE(("tick()"));
     if (!isRunning()) { return; }
@@ -119,7 +118,6 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean OpenHRPExecutionContext::is_running()
-    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -132,7 +130,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::start()
-    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -145,7 +142,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::stop()
-    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -160,7 +156,6 @@ namespace RTC
    * @endif
    */
   CORBA::Double OpenHRPExecutionContext::get_rate()
-    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -173,7 +168,6 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::set_rate(CORBA::Double rate)
-    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -187,7 +181,6 @@ namespace RTC
    */
   RTC::ReturnCode_t
   OpenHRPExecutionContext::add_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -201,7 +194,6 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -215,7 +207,6 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -229,7 +220,6 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -243,7 +233,6 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -257,7 +246,6 @@ namespace RTC
    */
   RTC::LifeCycleState OpenHRPExecutionContext::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::getComponentState(comp);
   }
@@ -270,7 +258,6 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionKind OpenHRPExecutionContext::get_kind()
-    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -286,7 +273,6 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionContextProfile* OpenHRPExecutionContext::get_profile()
-    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -70,7 +70,7 @@ namespace RTC
    * @endif
    */
   void OpenHRPExecutionContext::tick()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("tick()"));
     if (!isRunning()) { return; }
@@ -119,7 +119,7 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean OpenHRPExecutionContext::is_running()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -132,7 +132,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::start()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -145,7 +145,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::stop()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -160,7 +160,7 @@ namespace RTC
    * @endif
    */
   CORBA::Double OpenHRPExecutionContext::get_rate()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -173,7 +173,7 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::set_rate(CORBA::Double rate)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -187,7 +187,7 @@ namespace RTC
    */
   RTC::ReturnCode_t
   OpenHRPExecutionContext::add_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -201,7 +201,7 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -215,7 +215,7 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -229,7 +229,7 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -243,7 +243,7 @@ namespace RTC
    */
   RTC::ReturnCode_t OpenHRPExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -257,7 +257,7 @@ namespace RTC
    */
   RTC::LifeCycleState OpenHRPExecutionContext::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getComponentState(comp);
   }
@@ -270,7 +270,7 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionKind OpenHRPExecutionContext::get_kind()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -286,7 +286,7 @@ namespace RTC
    * @endif
    */
   RTC::ExecutionContextProfile* OpenHRPExecutionContext::get_profile()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -91,8 +91,7 @@ namespace RTC
      *
      * @endif
      */
-    void tick()
-      noexcept(false) override;
+    void tick() override;
 
     //============================================================
     // ExecutionContextService
@@ -121,8 +120,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Boolean is_running()
-      noexcept(false) override;
+    CORBA::Boolean is_running() override;
 
     /*!
      * @if jp
@@ -151,8 +149,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t start()
-      noexcept(false) override;
+    RTC::ReturnCode_t start() override;
 
     /*!
      * @if jp
@@ -180,8 +177,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t stop()
-      noexcept(false) override;
+    RTC::ReturnCode_t stop() override;
 
     /*!
      * @if jp
@@ -203,8 +199,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Double get_rate()
-      noexcept(false) override;
+    CORBA::Double get_rate() override;
 
     /*!
      * @if jp
@@ -235,8 +230,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      noexcept(false) override;
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate) override;
 
     /*!
      * @if jp
@@ -272,8 +266,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    activate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    activate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -308,8 +301,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    deactivate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    deactivate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -343,8 +335,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    reset_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    reset_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -373,8 +364,7 @@ namespace RTC
      * @endif
      */
     RTC::LifeCycleState
-    get_component_state(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    get_component_state(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -395,8 +385,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ExecutionKind get_kind()
-      noexcept(false) override;
+    RTC::ExecutionKind get_kind() override;
 
     /*!
      * @if jp
@@ -429,8 +418,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -463,8 +451,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    remove_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    remove_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -485,8 +472,7 @@ namespace RTC
      *
      * @endif
      */
-    RTC::ExecutionContextProfile* get_profile()
-      noexcept(false) override;
+    RTC::ExecutionContextProfile* get_profile() override;
   protected:
     // template virtual functions adding/removing component	
     /*!

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -92,7 +92,7 @@ namespace RTC
      * @endif
      */
     void tick()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     //============================================================
     // ExecutionContextService
@@ -122,7 +122,7 @@ namespace RTC
      * @endif
      */
     CORBA::Boolean is_running()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -152,7 +152,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t start()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -181,7 +181,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -204,7 +204,7 @@ namespace RTC
      * @endif
      */
     CORBA::Double get_rate()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -236,7 +236,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -273,7 +273,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -309,7 +309,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -344,7 +344,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -374,7 +374,7 @@ namespace RTC
      */
     RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -396,7 +396,7 @@ namespace RTC
      * @endif
      */
     RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -430,7 +430,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -464,7 +464,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -486,7 +486,7 @@ namespace RTC
      * @endif
      */
     RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
   protected:
     // template virtual functions adding/removing component	
     /*!

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -475,7 +475,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t OutPortBase::connect(ConnectorProfile& connector_profile)
-    noexcept(false)
   {
     RTC_TRACE(("OutPortBase::connect()"));
 
@@ -1110,7 +1109,6 @@ namespace RTC
   }
 
   ReturnCode_t OutPortBase::notify_connect(ConnectorProfile& connector_profile)
-	  noexcept(false)
   {
 	  Properties prop;
 	  NVUtil::copyToProperties(prop, connector_profile.properties);

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -475,7 +475,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t OutPortBase::connect(ConnectorProfile& connector_profile)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("OutPortBase::connect()"));
 
@@ -1110,7 +1110,7 @@ namespace RTC
   }
 
   ReturnCode_t OutPortBase::notify_connect(ConnectorProfile& connector_profile)
-	  throw (CORBA::SystemException)
+	  noexcept(false)
   {
 	  Properties prop;
 	  NVUtil::copyToProperties(prop, connector_profile.properties);

--- a/src/lib/rtm/OutPortBase.h
+++ b/src/lib/rtm/OutPortBase.h
@@ -776,7 +776,7 @@ namespace RTC
      */
     ReturnCode_t
     connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
 	/*!
 	* @if jp
@@ -1035,7 +1035,7 @@ namespace RTC
                                       OutPortProvider* provider);
 
     ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-		throw (CORBA::SystemException) override;
+		noexcept(false) override;
 
 
   protected:

--- a/src/lib/rtm/OutPortBase.h
+++ b/src/lib/rtm/OutPortBase.h
@@ -775,8 +775,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t
-    connect(ConnectorProfile& connector_profile)
-      noexcept(false) override;
+    connect(ConnectorProfile& connector_profile) override;
 
 	/*!
 	* @if jp
@@ -1034,8 +1033,7 @@ namespace RTC
                                       coil::Properties& prop,
                                       OutPortProvider* provider);
 
-    ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-		noexcept(false) override;
+    ReturnCode_t notify_connect(ConnectorProfile& connector_profile) override;
 
 
   protected:

--- a/src/lib/rtm/OutPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.cpp
@@ -163,7 +163,7 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   OutPortCorbaCdrProvider::get(::OpenRTM::CdrData_out data)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("OutPortCorbaCdrProvider::get()"));
     // at least the output "data" area should be allocated

--- a/src/lib/rtm/OutPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.cpp
@@ -163,7 +163,6 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   OutPortCorbaCdrProvider::get(::OpenRTM::CdrData_out data)
-    noexcept(false)
   {
     RTC_PARANOID(("OutPortCorbaCdrProvider::get()"));
     // at least the output "data" area should be allocated

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -241,7 +241,7 @@ namespace RTC
      * @endif
      */
     ::OpenRTM::PortStatus get(::OpenRTM::CdrData_out data)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
 
   private:

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -240,8 +240,7 @@ namespace RTC
      *
      * @endif
      */
-    ::OpenRTM::PortStatus get(::OpenRTM::CdrData_out data)
-      noexcept(false) override;
+    ::OpenRTM::PortStatus get(::OpenRTM::CdrData_out data) override;
 
 
   private:

--- a/src/lib/rtm/OutPortDSProvider.cpp
+++ b/src/lib/rtm/OutPortDSProvider.cpp
@@ -161,7 +161,6 @@ namespace RTC
    */
   ::RTC::PortStatus
       OutPortDSProvider::pull(::RTC::OctetSeq_out data)
-    noexcept(false)
   {
     RTC_PARANOID(("OutPortDSProvider::get()"));
     // at least the output "data" area should be allocated

--- a/src/lib/rtm/OutPortDSProvider.cpp
+++ b/src/lib/rtm/OutPortDSProvider.cpp
@@ -161,7 +161,7 @@ namespace RTC
    */
   ::RTC::PortStatus
       OutPortDSProvider::pull(::RTC::OctetSeq_out data)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("OutPortDSProvider::get()"));
     // at least the output "data" area should be allocated

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -239,7 +239,7 @@ namespace RTC
      * @endif
      */
     ::RTC::PortStatus pull(::RTC::OctetSeq_out data)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
 
   private:

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -238,8 +238,7 @@ namespace RTC
      *
      * @endif
      */
-    ::RTC::PortStatus pull(::RTC::OctetSeq_out data)
-      noexcept(false) override;
+    ::RTC::PortStatus pull(::RTC::OctetSeq_out data) override;
 
 
   private:

--- a/src/lib/rtm/OutPortSHMProvider.cpp
+++ b/src/lib/rtm/OutPortSHMProvider.cpp
@@ -160,7 +160,6 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   OutPortSHMProvider::get()
-    noexcept(false)
   {
     RTC_PARANOID(("OutPortSHMProvider::get()"));
     // at least the output "data" area should be allocated

--- a/src/lib/rtm/OutPortSHMProvider.cpp
+++ b/src/lib/rtm/OutPortSHMProvider.cpp
@@ -160,7 +160,7 @@ namespace RTC
    */
   ::OpenRTM::PortStatus
   OutPortSHMProvider::get()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("OutPortSHMProvider::get()"));
     // at least the output "data" area should be allocated

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -185,7 +185,7 @@ namespace RTC
      * @endif
      */
     ::OpenRTM::PortStatus get()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     
   private:

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -184,8 +184,7 @@ namespace RTC
      *
      * @endif
      */
-    ::OpenRTM::PortStatus get()
-      noexcept(false) override;
+    ::OpenRTM::PortStatus get() override;
 
     
   private:

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -61,7 +61,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean PeriodicECOrganization::add_members(const SDOList& sdo_list)
-    noexcept(false)
   {
     RTC_DEBUG(("add_members()"));
 
@@ -100,7 +99,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean PeriodicECOrganization::set_members(const SDOList& sdo_list)
-    noexcept(false)
   {
 
     RTC_DEBUG(("set_members()"));
@@ -150,7 +148,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean PeriodicECOrganization::remove_member(const char* id)
-    noexcept(false)
   {
     RTC_DEBUG(("remove_member(id = %s)", id));
     for (MemIt it(m_rtcMembers.begin()); it != m_rtcMembers.end();)
@@ -824,7 +821,6 @@ namespace RTC
 
 
   ReturnCode_t PeriodicECSharedComposite::exit()
-    noexcept(false)
   {
     ReturnCode_t ret = RTObject_impl::exit();
     try

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -61,8 +61,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean PeriodicECOrganization::add_members(const SDOList& sdo_list)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_DEBUG(("add_members()"));
 
@@ -101,8 +100,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean PeriodicECOrganization::set_members(const SDOList& sdo_list)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
 
     RTC_DEBUG(("set_members()"));
@@ -152,8 +150,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean PeriodicECOrganization::remove_member(const char* id)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_DEBUG(("remove_member(id = %s)", id));
     for (MemIt it(m_rtcMembers.begin()); it != m_rtcMembers.end();)
@@ -827,7 +824,7 @@ namespace RTC
 
 
   ReturnCode_t PeriodicECSharedComposite::exit()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     ReturnCode_t ret = RTObject_impl::exit();
     try

--- a/src/lib/rtm/PeriodicECSharedComposite.h
+++ b/src/lib/rtm/PeriodicECSharedComposite.h
@@ -129,8 +129,7 @@ namespace SDOPackage
      * @endif
      */
     ::CORBA::Boolean add_members(const SDOList& sdo_list)
-      throw (::CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -156,8 +155,7 @@ namespace SDOPackage
      * @endif
      */
     ::CORBA::Boolean set_members(const SDOList& sdo_list)
-      throw (::CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -181,8 +179,7 @@ namespace SDOPackage
      * @endif
      */
     ::CORBA::Boolean remove_member(const char* id)
-      throw (::CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -646,7 +643,7 @@ namespace RTC
     ReturnCode_t onFinalize() override;
 
     ReturnCode_t exit()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   protected:
     /*!

--- a/src/lib/rtm/PeriodicECSharedComposite.h
+++ b/src/lib/rtm/PeriodicECSharedComposite.h
@@ -128,8 +128,7 @@ namespace SDOPackage
      *
      * @endif
      */
-    ::CORBA::Boolean add_members(const SDOList& sdo_list)
-      noexcept(false) override;
+    ::CORBA::Boolean add_members(const SDOList& sdo_list) override;
 
     /*!
      * @if jp
@@ -154,8 +153,7 @@ namespace SDOPackage
      *
      * @endif
      */
-    ::CORBA::Boolean set_members(const SDOList& sdo_list)
-      noexcept(false) override;
+    ::CORBA::Boolean set_members(const SDOList& sdo_list) override;
 
     /*!
      * @if jp
@@ -178,8 +176,7 @@ namespace SDOPackage
      *
      * @endif
      */
-    ::CORBA::Boolean remove_member(const char* id)
-      noexcept(false) override;
+    ::CORBA::Boolean remove_member(const char* id) override;
 
     /*!
      * @if jp
@@ -642,8 +639,7 @@ namespace RTC
      */
     ReturnCode_t onFinalize() override;
 
-    ReturnCode_t exit()
-      noexcept(false) override;
+    ReturnCode_t exit() override;
 
   protected:
     /*!

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -235,7 +235,6 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Boolean PeriodicExecutionContext::is_running()
-    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -248,7 +247,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t PeriodicExecutionContext::start()
-    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -261,7 +259,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t PeriodicExecutionContext::stop()
-    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -276,7 +273,6 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Double PeriodicExecutionContext::get_rate()
-    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -289,7 +285,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t PeriodicExecutionContext::set_rate(CORBA::Double rate)
-    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -303,7 +298,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t
   PeriodicExecutionContext::add_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -317,7 +311,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -331,7 +324,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -345,7 +337,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -359,7 +350,6 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -373,7 +363,6 @@ namespace RTC_exp
    */
   RTC::LifeCycleState PeriodicExecutionContext::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
     RTC::LifeCycleState ret = ExecutionContextBase::getComponentState(comp);
     return ret;
@@ -387,7 +376,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionKind PeriodicExecutionContext::get_kind()
-    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -403,7 +391,6 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionContextProfile* PeriodicExecutionContext::get_profile()
-    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -235,7 +235,7 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Boolean PeriodicExecutionContext::is_running()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::isRunning();
   }
@@ -248,7 +248,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t PeriodicExecutionContext::start()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::start();
   }
@@ -261,7 +261,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t PeriodicExecutionContext::stop()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::stop();
   }
@@ -276,7 +276,7 @@ namespace RTC_exp
    * @endif
    */
   CORBA::Double PeriodicExecutionContext::get_rate()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getRate();
   }
@@ -289,7 +289,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ReturnCode_t PeriodicExecutionContext::set_rate(CORBA::Double rate)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::setRate(rate);
   }
@@ -303,7 +303,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t
   PeriodicExecutionContext::add_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::addComponent(comp);
   }
@@ -317,7 +317,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   remove_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::removeComponent(comp);
   }
@@ -331,7 +331,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   activate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::activateComponent(comp);
   }
@@ -345,7 +345,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::deactivateComponent(comp);
   }
@@ -359,7 +359,7 @@ namespace RTC_exp
    */
   RTC::ReturnCode_t PeriodicExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::resetComponent(comp);
   }
@@ -373,7 +373,7 @@ namespace RTC_exp
    */
   RTC::LifeCycleState PeriodicExecutionContext::
   get_component_state(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC::LifeCycleState ret = ExecutionContextBase::getComponentState(comp);
     return ret;
@@ -387,7 +387,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionKind PeriodicExecutionContext::get_kind()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getKind();
   }
@@ -403,7 +403,7 @@ namespace RTC_exp
    * @endif
    */
   RTC::ExecutionContextProfile* PeriodicExecutionContext::get_profile()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     return ExecutionContextBase::getProfile();
   }

--- a/src/lib/rtm/PeriodicExecutionContext.h
+++ b/src/lib/rtm/PeriodicExecutionContext.h
@@ -219,8 +219,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    CORBA::Boolean is_running()
-      noexcept(false) override;
+    CORBA::Boolean is_running() override;
 
     /*!
      * @if jp
@@ -249,8 +248,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ReturnCode_t start()
-      noexcept(false) override;
+    RTC::ReturnCode_t start() override;
 
     /*!
      * @if jp
@@ -278,8 +276,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ReturnCode_t stop()
-      noexcept(false) override;
+    RTC::ReturnCode_t stop() override;
 
     /*!
      * @if jp
@@ -301,8 +298,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    CORBA::Double get_rate()
-      noexcept(false) override;
+    CORBA::Double get_rate() override;
 
     /*!
      * @if jp
@@ -333,8 +329,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      noexcept(false) override;
+    RTC::ReturnCode_t  set_rate(CORBA::Double rate) override;
 
     /*!
      * @if jp
@@ -370,8 +365,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    activate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    activate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -406,8 +400,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    deactivate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    deactivate_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -441,8 +434,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    reset_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    reset_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -471,8 +463,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::LifeCycleState
-    get_component_state(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    get_component_state(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -493,8 +484,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ExecutionKind get_kind()
-      noexcept(false) override;
+    RTC::ExecutionKind get_kind() override;
 
     /*!
      * @if jp
@@ -527,8 +517,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -561,8 +550,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t
-    remove_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    remove_component(RTC::LightweightRTObject_ptr comp) override;
 
     /*!
      * @if jp
@@ -583,8 +571,7 @@ namespace RTC_exp
      *
      * @endif
      */
-    RTC::ExecutionContextProfile* get_profile()
-      noexcept(false) override;
+    RTC::ExecutionContextProfile* get_profile() override;
 
   protected:
     template <class T>

--- a/src/lib/rtm/PeriodicExecutionContext.h
+++ b/src/lib/rtm/PeriodicExecutionContext.h
@@ -220,7 +220,7 @@ namespace RTC_exp
      * @endif
      */
     CORBA::Boolean is_running()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -250,7 +250,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t start()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -279,7 +279,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t stop()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -302,7 +302,7 @@ namespace RTC_exp
      * @endif
      */
     CORBA::Double get_rate()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -334,7 +334,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t  set_rate(CORBA::Double rate)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -371,7 +371,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -407,7 +407,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -442,7 +442,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -472,7 +472,7 @@ namespace RTC_exp
      */
     RTC::LifeCycleState
     get_component_state(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -494,7 +494,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ExecutionKind get_kind()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -528,7 +528,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ReturnCode_t add_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -562,7 +562,7 @@ namespace RTC_exp
      */
     RTC::ReturnCode_t
     remove_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -584,7 +584,7 @@ namespace RTC_exp
      * @endif
      */
     RTC::ExecutionContextProfile* get_profile()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   protected:
     template <class T>

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -107,8 +107,7 @@ namespace RTC
    * @brief [CORBA interface] Get the PortProfile of the Port
    * @endif
    */
-  PortProfile* PortBase::get_port_profile()
-    throw (CORBA::SystemException)
+  PortProfile* PortBase::get_port_profile() noexcept(false)
   {
     RTC_TRACE(("get_port_profile()"));
 
@@ -141,7 +140,7 @@ namespace RTC
    * @endif
    */
   ConnectorProfileList* PortBase::get_connector_profiles()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_connector_profiles()"));
 
@@ -161,7 +160,7 @@ namespace RTC
    * @endif
    */
   ConnectorProfile* PortBase::get_connector_profile(const char* connector_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_connector_profile(%s)", connector_id));
 
@@ -189,7 +188,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::connect(ConnectorProfile& connector_profile)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("connect()"));
     if (isEmptyId(connector_profile))
@@ -237,7 +236,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::notify_connect(ConnectorProfile& connector_profile)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("notify_connect()"));
     Guard guard(m_connectorsMutex);
@@ -372,7 +371,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::disconnect(const char* connector_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("disconnect(%s)", connector_id));
 
@@ -433,7 +432,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::notify_disconnect(const char* connector_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("notify_disconnect(%s)", connector_id));
     Guard guard(m_connectorsMutex);
@@ -491,7 +490,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::disconnect_all()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("disconnect_all()"));
 

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -107,7 +107,7 @@ namespace RTC
    * @brief [CORBA interface] Get the PortProfile of the Port
    * @endif
    */
-  PortProfile* PortBase::get_port_profile() noexcept(false)
+  PortProfile* PortBase::get_port_profile()
   {
     RTC_TRACE(("get_port_profile()"));
 
@@ -140,7 +140,6 @@ namespace RTC
    * @endif
    */
   ConnectorProfileList* PortBase::get_connector_profiles()
-    noexcept(false)
   {
     RTC_TRACE(("get_connector_profiles()"));
 
@@ -160,7 +159,6 @@ namespace RTC
    * @endif
    */
   ConnectorProfile* PortBase::get_connector_profile(const char* connector_id)
-    noexcept(false)
   {
     RTC_TRACE(("get_connector_profile(%s)", connector_id));
 
@@ -188,7 +186,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::connect(ConnectorProfile& connector_profile)
-    noexcept(false)
   {
     RTC_TRACE(("connect()"));
     if (isEmptyId(connector_profile))
@@ -236,7 +233,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::notify_connect(ConnectorProfile& connector_profile)
-    noexcept(false)
   {
     RTC_TRACE(("notify_connect()"));
     Guard guard(m_connectorsMutex);
@@ -371,7 +367,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::disconnect(const char* connector_id)
-    noexcept(false)
   {
     RTC_TRACE(("disconnect(%s)", connector_id));
 
@@ -432,7 +427,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::notify_disconnect(const char* connector_id)
-    noexcept(false)
   {
     RTC_TRACE(("notify_disconnect(%s)", connector_id));
     Guard guard(m_connectorsMutex);
@@ -490,7 +484,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t PortBase::disconnect_all()
-    noexcept(false)
   {
     RTC_TRACE(("disconnect_all()"));
 

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -234,7 +234,7 @@ namespace RTC
      * @endif
      */
     PortProfile* get_port_profile()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -316,7 +316,7 @@ namespace RTC
      * @endif
      */
     ConnectorProfileList* get_connector_profiles()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -358,7 +358,7 @@ namespace RTC
      * @endif
      */
     ConnectorProfile* get_connector_profile(const char* connector_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -518,7 +518,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -636,7 +636,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -704,7 +704,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t disconnect(const char* connector_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -795,7 +795,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t notify_disconnect(const char* connector_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -817,7 +817,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t disconnect_all()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     //============================================================
     // Local operations

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -233,8 +233,7 @@ namespace RTC
      *
      * @endif
      */
-    PortProfile* get_port_profile()
-      noexcept(false) override;
+    PortProfile* get_port_profile() override;
 
     /*!
      * @if jp
@@ -315,8 +314,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectorProfileList* get_connector_profiles()
-      noexcept(false) override;
+    ConnectorProfileList* get_connector_profiles() override;
 
     /*!
      * @if jp
@@ -357,8 +355,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectorProfile* get_connector_profile(const char* connector_id)
-      noexcept(false) override;
+    ConnectorProfile* get_connector_profile(const char* connector_id) override;
 
     /*!
      * @if jp
@@ -517,8 +514,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t connect(ConnectorProfile& connector_profile)
-      noexcept(false) override;
+    ReturnCode_t connect(ConnectorProfile& connector_profile) override;
 
     /*!
      * @if jp
@@ -635,8 +631,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t notify_connect(ConnectorProfile& connector_profile)
-      noexcept(false) override;
+    ReturnCode_t notify_connect(ConnectorProfile& connector_profile) override;
 
     /*!
      * @if jp
@@ -703,8 +698,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t disconnect(const char* connector_id)
-      noexcept(false) override;
+    ReturnCode_t disconnect(const char* connector_id) override;
 
     /*!
      * @if jp
@@ -794,8 +788,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t notify_disconnect(const char* connector_id)
-      noexcept(false) override;
+    ReturnCode_t notify_disconnect(const char* connector_id) override;
 
     /*!
      * @if jp
@@ -816,8 +809,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t disconnect_all()
-      noexcept(false) override;
+    ReturnCode_t disconnect_all() override;
 
     //============================================================
     // Local operations

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -314,7 +314,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::initialize()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("initialize()"));
 
@@ -365,7 +365,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::finalize()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("finalize()"));
     if (m_created)  { return RTC::PRECONDITION_NOT_MET; }
@@ -402,7 +402,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::exit()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("exit()"));
     if (m_created) { return RTC::PRECONDITION_NOT_MET; }
@@ -449,7 +449,7 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean RTObject_impl::is_alive(ExecutionContext_ptr exec_context)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("is_alive()"));
     for (::CORBA::ULong i(0), len(m_ecMine.length()); i < len; ++i)
@@ -477,7 +477,7 @@ namespace RTC
    * @endif
    */
   ExecutionContext_ptr RTObject_impl::get_context(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_context(%d)", ec_id));
     // owned EC
@@ -515,7 +515,7 @@ namespace RTC
    * @endif
    */
   ExecutionContextList* RTObject_impl::get_owned_contexts()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_owned_context()"));
 
@@ -552,7 +552,7 @@ namespace RTC
    * @endif
    */
   ExecutionContextList* RTObject_impl::get_participating_contexts()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_participating_contexts()"));
     ExecutionContextList_var execlist;
@@ -573,7 +573,7 @@ namespace RTC
    */
   ExecutionContextHandle_t
   RTObject_impl::get_context_handle(ExecutionContext_ptr cxt)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_context_handle()"));
     CORBA::Long num;
@@ -599,7 +599,7 @@ namespace RTC
    * @endif
    */
   UniqueId RTObject_impl::attach_context(ExecutionContext_ptr exec_context)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("attach_context()"));
     // ID: 0 - (offset-1) : owned ec
@@ -676,7 +676,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::detach_context(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("detach_context(%d)", ec_id));
     ::CORBA::ULong len(m_ecOther.length());
@@ -714,7 +714,7 @@ namespace RTC
    * @endif
    */
   ComponentProfile* RTObject_impl::get_component_profile()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_component_profile()"));
     try
@@ -769,7 +769,7 @@ namespace RTC
    * @endif
    */
   PortServiceList* RTObject_impl::get_ports()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("get_ports()"));
     try
@@ -795,7 +795,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_initialize()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_initialize()"));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -850,7 +850,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_finalize()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_finalize()"));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -875,7 +875,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_startup(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_startup(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -900,7 +900,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_shutdown(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_shutdown(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -925,7 +925,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_activated(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_activated(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -952,7 +952,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_deactivated(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_deactivated(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -978,7 +978,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_aborting(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_aborting(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1003,7 +1003,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_error(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_error(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1029,7 +1029,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_reset(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_reset(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1055,7 +1055,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_execute(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("on_execute(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1083,7 +1083,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_state_update(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_PARANOID(("on_state_update(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1109,7 +1109,7 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_rate_changed(UniqueId ec_id)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
     RTC_TRACE(("on_rate_changed(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1137,8 +1137,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::OrganizationList* RTObject_impl::get_owned_organizations()
-    throw (CORBA::SystemException,
-           SDOPackage::NotAvailable, SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_owned_organizations()"));
     try
@@ -1163,8 +1162,7 @@ namespace RTC
    * @endif
    */
   char* RTObject_impl::get_sdo_id()
-    throw (CORBA::SystemException,
-           SDOPackage::NotAvailable, SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_sdo_id()"));
     try
@@ -1187,8 +1185,7 @@ namespace RTC
    * @endif
    */
   char* RTObject_impl::get_sdo_type()
-    throw (CORBA::SystemException,
-           SDOPackage::NotAvailable, SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_sdo_type()"));
     CORBA::String_var sdo_type;
@@ -1213,8 +1210,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::DeviceProfile* RTObject_impl::get_device_profile()
-    throw (CORBA::SystemException,
-           SDOPackage::NotAvailable, SDOPackage::InternalError)
+    noexcept (false)
   {
     RTC_TRACE(("get_device_profile()"));
     try
@@ -1242,8 +1238,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::ServiceProfileList* RTObject_impl::get_service_profiles()
-    throw (CORBA::SystemException,
-           SDOPackage::NotAvailable, SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_service_profiles()"));
 
@@ -1270,9 +1265,7 @@ namespace RTC
    */
   SDOPackage::ServiceProfile*
   RTObject_impl::get_service_profile(const char* id)
-    throw (CORBA::SystemException,
-           SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-           SDOPackage::InternalError)
+    noexcept(false)
   {
     if (id == nullptr)
       {
@@ -1307,9 +1300,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::SDOService_ptr RTObject_impl::get_sdo_service(const char* id)
-    throw (CORBA::SystemException,
-           SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-           SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_sdo_service(%s))", id));
     if (id == nullptr)
@@ -1341,9 +1332,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::Configuration_ptr RTObject_impl::get_configuration()
-    throw (CORBA::SystemException,
-           SDOPackage::InterfaceNotImplemented, SDOPackage::NotAvailable,
-           SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_configuration()"));
     if (m_pSdoConfig == nullptr)
@@ -1375,9 +1364,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::Monitoring_ptr RTObject_impl::get_monitoring()
-    throw (CORBA::SystemException,
-           SDOPackage::InterfaceNotImplemented, SDOPackage::NotAvailable,
-           SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_monitoring()"));
     throw SDOPackage::InterfaceNotImplemented();
@@ -1391,8 +1378,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::OrganizationList* RTObject_impl::get_organizations()
-    throw (CORBA::SystemException,
-           SDOPackage::NotAvailable, SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_organizations()"));
     m_sdoOrganizations = m_pSdoConfigImpl->getOrganizations();
@@ -1417,8 +1403,7 @@ namespace RTC
    * @endif
    */
   SDOPackage::NVList* RTObject_impl::get_status_list()
-    throw (CORBA::SystemException,
-           SDOPackage::NotAvailable, SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_status_list()"));
     try
@@ -1442,9 +1427,7 @@ namespace RTC
    * @endif
    */
   CORBA::Any* RTObject_impl::get_status(const char* name)
-    throw (CORBA::SystemException,
-           SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-           SDOPackage::InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_status(%s)", name));
     CORBA::Long index;

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -314,7 +314,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::initialize()
-    noexcept(false)
   {
     RTC_TRACE(("initialize()"));
 
@@ -365,7 +364,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::finalize()
-    noexcept(false)
   {
     RTC_TRACE(("finalize()"));
     if (m_created)  { return RTC::PRECONDITION_NOT_MET; }
@@ -402,7 +400,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::exit()
-    noexcept(false)
   {
     RTC_TRACE(("exit()"));
     if (m_created) { return RTC::PRECONDITION_NOT_MET; }
@@ -449,7 +446,6 @@ namespace RTC
    * @endif
    */
   CORBA::Boolean RTObject_impl::is_alive(ExecutionContext_ptr exec_context)
-    noexcept(false)
   {
     RTC_TRACE(("is_alive()"));
     for (::CORBA::ULong i(0), len(m_ecMine.length()); i < len; ++i)
@@ -477,7 +473,6 @@ namespace RTC
    * @endif
    */
   ExecutionContext_ptr RTObject_impl::get_context(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("get_context(%d)", ec_id));
     // owned EC
@@ -515,7 +510,6 @@ namespace RTC
    * @endif
    */
   ExecutionContextList* RTObject_impl::get_owned_contexts()
-    noexcept(false)
   {
     RTC_TRACE(("get_owned_context()"));
 
@@ -552,7 +546,6 @@ namespace RTC
    * @endif
    */
   ExecutionContextList* RTObject_impl::get_participating_contexts()
-    noexcept(false)
   {
     RTC_TRACE(("get_participating_contexts()"));
     ExecutionContextList_var execlist;
@@ -573,7 +566,6 @@ namespace RTC
    */
   ExecutionContextHandle_t
   RTObject_impl::get_context_handle(ExecutionContext_ptr cxt)
-    noexcept(false)
   {
     RTC_TRACE(("get_context_handle()"));
     CORBA::Long num;
@@ -599,7 +591,6 @@ namespace RTC
    * @endif
    */
   UniqueId RTObject_impl::attach_context(ExecutionContext_ptr exec_context)
-    noexcept(false)
   {
     RTC_TRACE(("attach_context()"));
     // ID: 0 - (offset-1) : owned ec
@@ -676,7 +667,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::detach_context(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("detach_context(%d)", ec_id));
     ::CORBA::ULong len(m_ecOther.length());
@@ -714,7 +704,6 @@ namespace RTC
    * @endif
    */
   ComponentProfile* RTObject_impl::get_component_profile()
-    noexcept(false)
   {
     RTC_TRACE(("get_component_profile()"));
     try
@@ -769,7 +758,6 @@ namespace RTC
    * @endif
    */
   PortServiceList* RTObject_impl::get_ports()
-    noexcept(false)
   {
     RTC_TRACE(("get_ports()"));
     try
@@ -795,7 +783,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_initialize()
-    noexcept(false)
   {
     RTC_TRACE(("on_initialize()"));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -850,7 +837,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_finalize()
-    noexcept(false)
   {
     RTC_TRACE(("on_finalize()"));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -875,7 +861,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_startup(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_startup(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -900,7 +885,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_shutdown(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_shutdown(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -925,7 +909,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_activated(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_activated(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -952,7 +935,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_deactivated(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_deactivated(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -978,7 +960,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_aborting(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_aborting(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1003,7 +984,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_error(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_error(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1029,7 +1009,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_reset(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_reset(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1055,7 +1034,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_execute(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_PARANOID(("on_execute(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1083,7 +1061,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_state_update(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_PARANOID(("on_state_update(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1109,7 +1086,6 @@ namespace RTC
    * @endif
    */
   ReturnCode_t RTObject_impl::on_rate_changed(UniqueId ec_id)
-    noexcept(false)
   {
     RTC_TRACE(("on_rate_changed(%d)", ec_id));
     ReturnCode_t ret(RTC::RTC_ERROR);
@@ -1137,7 +1113,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::OrganizationList* RTObject_impl::get_owned_organizations()
-    noexcept(false)
   {
     RTC_TRACE(("get_owned_organizations()"));
     try
@@ -1162,7 +1137,6 @@ namespace RTC
    * @endif
    */
   char* RTObject_impl::get_sdo_id()
-    noexcept(false)
   {
     RTC_TRACE(("get_sdo_id()"));
     try
@@ -1185,7 +1159,6 @@ namespace RTC
    * @endif
    */
   char* RTObject_impl::get_sdo_type()
-    noexcept(false)
   {
     RTC_TRACE(("get_sdo_type()"));
     CORBA::String_var sdo_type;
@@ -1210,7 +1183,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::DeviceProfile* RTObject_impl::get_device_profile()
-    noexcept (false)
   {
     RTC_TRACE(("get_device_profile()"));
     try
@@ -1238,7 +1210,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::ServiceProfileList* RTObject_impl::get_service_profiles()
-    noexcept(false)
   {
     RTC_TRACE(("get_service_profiles()"));
 
@@ -1265,7 +1236,6 @@ namespace RTC
    */
   SDOPackage::ServiceProfile*
   RTObject_impl::get_service_profile(const char* id)
-    noexcept(false)
   {
     if (id == nullptr)
       {
@@ -1300,7 +1270,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::SDOService_ptr RTObject_impl::get_sdo_service(const char* id)
-    noexcept(false)
   {
     RTC_TRACE(("get_sdo_service(%s))", id));
     if (id == nullptr)
@@ -1332,7 +1301,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::Configuration_ptr RTObject_impl::get_configuration()
-    noexcept(false)
   {
     RTC_TRACE(("get_configuration()"));
     if (m_pSdoConfig == nullptr)
@@ -1364,7 +1332,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::Monitoring_ptr RTObject_impl::get_monitoring()
-    noexcept(false)
   {
     RTC_TRACE(("get_monitoring()"));
     throw SDOPackage::InterfaceNotImplemented();
@@ -1378,7 +1345,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::OrganizationList* RTObject_impl::get_organizations()
-    noexcept(false)
   {
     RTC_TRACE(("get_organizations()"));
     m_sdoOrganizations = m_pSdoConfigImpl->getOrganizations();
@@ -1403,7 +1369,6 @@ namespace RTC
    * @endif
    */
   SDOPackage::NVList* RTObject_impl::get_status_list()
-    noexcept(false)
   {
     RTC_TRACE(("get_status_list()"));
     try
@@ -1427,7 +1392,6 @@ namespace RTC
    * @endif
    */
   CORBA::Any* RTObject_impl::get_status(const char* name)
-    noexcept(false)
   {
     RTC_TRACE(("get_status(%s)", name));
     CORBA::Long index;

--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -618,7 +618,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t initialize()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -666,7 +666,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t finalize()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -712,7 +712,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t exit()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -748,7 +748,7 @@ namespace RTC
      * @endif
      */
     CORBA::Boolean is_alive(ExecutionContext_ptr exec_context)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -778,7 +778,7 @@ namespace RTC
      * @endif
      */
     ExecutionContext_ptr get_context(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -799,7 +799,7 @@ namespace RTC
      * @endif
      */
     ExecutionContextList* get_owned_contexts()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -820,7 +820,7 @@ namespace RTC
      * @endif
      */
     ExecutionContextList* get_participating_contexts()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -838,7 +838,7 @@ namespace RTC
      */
     ExecutionContextHandle_t
     get_context_handle(ExecutionContext_ptr cxt)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -871,7 +871,7 @@ namespace RTC
      * @endif
      */
     UniqueId attach_context(ExecutionContext_ptr exec_context)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     UniqueId bindContext(ExecutionContext_ptr exec_context);
 
@@ -917,7 +917,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t detach_context(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     //============================================================
     // RTC::RTObject
@@ -942,7 +942,7 @@ namespace RTC
      * @endif
      */
     ComponentProfile* get_component_profile()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -964,7 +964,7 @@ namespace RTC
      * @endif
      */
     PortServiceList* get_ports()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1019,7 +1019,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_initialize()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1046,7 +1046,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_finalize()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1077,7 +1077,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_startup(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1108,7 +1108,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_shutdown(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1137,7 +1137,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_activated(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1167,7 +1167,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_deactivated(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1202,7 +1202,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_aborting(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1248,7 +1248,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_error(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1285,7 +1285,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_reset(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     //============================================================
     // RTC::DataFlowComponentAction
@@ -1333,7 +1333,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_execute(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1379,7 +1379,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_state_update(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1418,7 +1418,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t on_rate_changed(UniqueId ec_id)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
     //============================================================
     // SDOPackage::SdoSystemElement
@@ -1461,8 +1461,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::OrganizationList* get_owned_organizations()
-      throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     //============================================================
     // SDOPackage::SDO
@@ -1501,8 +1500,7 @@ namespace RTC
      * @endif
      */
     char* get_sdo_id()
-      throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1538,8 +1536,7 @@ namespace RTC
      * @endif
      */
     char* get_sdo_type()
-      throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1578,8 +1575,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::DeviceProfile* get_device_profile()
-      throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1618,8 +1614,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::ServiceProfileList* get_service_profiles()
-      throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1663,9 +1658,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::ServiceProfile* get_service_profile(const char* id)
-      throw (CORBA::SystemException,
-             SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-             SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1715,9 +1708,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::SDOService_ptr get_sdo_service(const char* id)
-      throw (CORBA::SystemException,
-             SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-             SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1764,9 +1755,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::Configuration_ptr get_configuration()
-      throw (CORBA::SystemException,
-             SDOPackage::InterfaceNotImplemented, SDOPackage::NotAvailable,
-             SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1812,9 +1801,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::Monitoring_ptr get_monitoring()
-      throw (CORBA::SystemException,
-             SDOPackage::InterfaceNotImplemented, SDOPackage::NotAvailable,
-             SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1852,8 +1839,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::OrganizationList* get_organizations()
-      throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1887,8 +1873,7 @@ namespace RTC
      * @endif
      */
     SDOPackage::NVList* get_status_list()
-      throw (CORBA::SystemException,
-             SDOPackage::NotAvailable, SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -1927,9 +1912,7 @@ namespace RTC
      * @endif
      */
     CORBA::Any* get_status(const char* name)
-      throw (CORBA::SystemException,
-             SDOPackage::InvalidParameter, SDOPackage::NotAvailable,
-             SDOPackage::InternalError) override;
+      noexcept(false) override;
 
     //============================================================
     // Local interfaces

--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -617,8 +617,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t initialize()
-      noexcept(false) override;
+    ReturnCode_t initialize() override;
 
     /*!
      * @if jp
@@ -665,8 +664,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t finalize()
-      noexcept(false) override;
+    ReturnCode_t finalize() override;
 
     /*!
      * @if jp
@@ -711,8 +709,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t exit()
-      noexcept(false) override;
+    ReturnCode_t exit() override;
 
     /*!
      * @if jp
@@ -747,8 +744,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Boolean is_alive(ExecutionContext_ptr exec_context)
-      noexcept(false) override;
+    CORBA::Boolean is_alive(ExecutionContext_ptr exec_context) override;
 
     /*!
      * @if jp
@@ -777,8 +773,7 @@ namespace RTC
      *
      * @endif
      */
-    ExecutionContext_ptr get_context(UniqueId ec_id)
-      noexcept(false) override;
+    ExecutionContext_ptr get_context(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -798,8 +793,7 @@ namespace RTC
      *
      * @endif
      */
-    ExecutionContextList* get_owned_contexts()
-      noexcept(false) override;
+    ExecutionContextList* get_owned_contexts() override;
 
     /*!
      * @if jp
@@ -819,8 +813,7 @@ namespace RTC
      *
      * @endif
      */
-    ExecutionContextList* get_participating_contexts()
-      noexcept(false) override;
+    ExecutionContextList* get_participating_contexts() override;
 
     /*!
      * @if jp
@@ -837,8 +830,7 @@ namespace RTC
      * @endif
      */
     ExecutionContextHandle_t
-    get_context_handle(ExecutionContext_ptr cxt)
-      noexcept(false) override;
+    get_context_handle(ExecutionContext_ptr cxt) override;
 
     /*!
      * @if jp
@@ -870,8 +862,7 @@ namespace RTC
      *
      * @endif
      */
-    UniqueId attach_context(ExecutionContext_ptr exec_context)
-      noexcept(false) override;
+    UniqueId attach_context(ExecutionContext_ptr exec_context) override;
 
     UniqueId bindContext(ExecutionContext_ptr exec_context);
 
@@ -916,8 +907,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t detach_context(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t detach_context(UniqueId ec_id) override;
 
     //============================================================
     // RTC::RTObject
@@ -941,8 +931,7 @@ namespace RTC
      *
      * @endif
      */
-    ComponentProfile* get_component_profile()
-      noexcept(false) override;
+    ComponentProfile* get_component_profile() override;
 
     /*!
      * @if jp
@@ -963,8 +952,7 @@ namespace RTC
      *
      * @endif
      */
-    PortServiceList* get_ports()
-      noexcept(false) override;
+    PortServiceList* get_ports() override;
 
     /*!
      * @if jp
@@ -1018,8 +1006,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_initialize()
-      noexcept(false) override;
+    ReturnCode_t on_initialize() override;
 
     /*!
      * @if jp
@@ -1045,8 +1032,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_finalize()
-      noexcept(false) override;
+    ReturnCode_t on_finalize() override;
 
     /*!
      * @if jp
@@ -1076,8 +1062,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_startup(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_startup(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1107,8 +1092,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_shutdown(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_shutdown(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1136,8 +1120,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_activated(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_activated(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1166,8 +1149,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_deactivated(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_deactivated(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1201,8 +1183,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_aborting(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_aborting(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1247,8 +1228,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_error(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_error(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1284,8 +1264,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_reset(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_reset(UniqueId ec_id) override;
 
     //============================================================
     // RTC::DataFlowComponentAction
@@ -1332,8 +1311,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_execute(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_execute(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1378,8 +1356,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_state_update(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_state_update(UniqueId ec_id) override;
 
     /*!
      * @if jp
@@ -1417,8 +1394,7 @@ namespace RTC
      *
      * @endif
      */
-    ReturnCode_t on_rate_changed(UniqueId ec_id)
-      noexcept(false) override;
+    ReturnCode_t on_rate_changed(UniqueId ec_id) override;
 
     //============================================================
     // SDOPackage::SdoSystemElement
@@ -1460,8 +1436,7 @@ namespace RTC
      *
      * @endif
      */
-    SDOPackage::OrganizationList* get_owned_organizations()
-      noexcept(false) override;
+    SDOPackage::OrganizationList* get_owned_organizations() override;
 
     //============================================================
     // SDOPackage::SDO
@@ -1499,8 +1474,7 @@ namespace RTC
      *
      * @endif
      */
-    char* get_sdo_id()
-      noexcept(false) override;
+    char* get_sdo_id() override;
 
     /*!
      * @if jp
@@ -1535,8 +1509,7 @@ namespace RTC
      *
      * @endif
      */
-    char* get_sdo_type()
-      noexcept(false) override;
+    char* get_sdo_type() override;
 
     /*!
      * @if jp
@@ -1574,8 +1547,7 @@ namespace RTC
      *
      * @endif
      */
-    SDOPackage::DeviceProfile* get_device_profile()
-      noexcept(false) override;
+    SDOPackage::DeviceProfile* get_device_profile() override;
 
     /*!
      * @if jp
@@ -1613,8 +1585,7 @@ namespace RTC
      *
      * @endif
      */
-    SDOPackage::ServiceProfileList* get_service_profiles()
-      noexcept(false) override;
+    SDOPackage::ServiceProfileList* get_service_profiles() override;
 
     /*!
      * @if jp
@@ -1657,8 +1628,7 @@ namespace RTC
      *
      * @endif
      */
-    SDOPackage::ServiceProfile* get_service_profile(const char* id)
-      noexcept(false) override;
+    SDOPackage::ServiceProfile* get_service_profile(const char* id) override;
 
     /*!
      * @if jp
@@ -1707,8 +1677,7 @@ namespace RTC
      *
      * @endif
      */
-    SDOPackage::SDOService_ptr get_sdo_service(const char* id)
-      noexcept(false) override;
+    SDOPackage::SDOService_ptr get_sdo_service(const char* id) override;
 
     /*!
      * @if jp
@@ -1754,8 +1723,7 @@ namespace RTC
      *                          completely due to some internal error.
      * @endif
      */
-    SDOPackage::Configuration_ptr get_configuration()
-      noexcept(false) override;
+    SDOPackage::Configuration_ptr get_configuration() override;
 
     /*!
      * @if jp
@@ -1800,8 +1768,7 @@ namespace RTC
      *                          completely due to some internal error.
      * @endif
      */
-    SDOPackage::Monitoring_ptr get_monitoring()
-      noexcept(false) override;
+    SDOPackage::Monitoring_ptr get_monitoring() override;
 
     /*!
      * @if jp
@@ -1838,8 +1805,7 @@ namespace RTC
      *                          completely due to some internal error.
      * @endif
      */
-    SDOPackage::OrganizationList* get_organizations()
-      noexcept(false) override;
+    SDOPackage::OrganizationList* get_organizations() override;
 
     /*!
      * @if jp
@@ -1872,8 +1838,7 @@ namespace RTC
      *
      * @endif
      */
-    SDOPackage::NVList* get_status_list()
-      noexcept(false) override;
+    SDOPackage::NVList* get_status_list() override;
 
     /*!
      * @if jp
@@ -1911,8 +1876,7 @@ namespace RTC
      *
      * @endif
      */
-    CORBA::Any* get_status(const char* name)
-      noexcept(false) override;
+    CORBA::Any* get_status(const char* name) override;
 
     //============================================================
     // Local interfaces

--- a/src/lib/rtm/SdoConfiguration.cpp
+++ b/src/lib/rtm/SdoConfiguration.cpp
@@ -132,7 +132,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::set_device_profile(const DeviceProfile& dProfile)
-    noexcept(false)
   {
     RTC_TRACE(("set_device_profile()"));
     try
@@ -158,7 +157,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::add_service_profile(const ServiceProfile& sProfile)
-    noexcept(false)
   {
     RTC_TRACE(("add_service_profile()"));
     // SDO specification defines that InvalidParameter() exception
@@ -186,7 +184,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::add_organization(Organization_ptr org)
-    noexcept(false)
   {
     RTC_TRACE(("add_organization()"));
     try
@@ -212,7 +209,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::remove_service_profile(const char* id)
-    noexcept(false)
   {
     RTC_TRACE(("remove_service_profile(%s)", id));
     try
@@ -235,7 +231,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::remove_organization(const char* organization_id)
-    noexcept(false)
   {
     RTC_TRACE(("remove_organization(%s)", organization_id));
     try
@@ -264,7 +259,6 @@ namespace SDOPackage
    */
   ParameterList*
   Configuration_impl::get_configuration_parameters()
-    noexcept(false)
   {
     RTC_TRACE(("get_configuration_parameters()"));
     try
@@ -292,7 +286,6 @@ namespace SDOPackage
    */
   NVList*
   Configuration_impl::get_configuration_parameter_values()
-    noexcept(false)
   {
     RTC_TRACE(("get_configuration_parameter_values()"));
     Guard guard(m_config_mutex);
@@ -319,7 +312,6 @@ namespace SDOPackage
    */
   CORBA::Any*
   Configuration_impl::get_configuration_parameter_value(const char* name)
-    noexcept(false)
   {
     RTC_TRACE(("get_configuration_parameter_value(%s)", name));
     if (std::string(name).empty()) throw InvalidParameter("Name is empty.");
@@ -351,7 +343,6 @@ namespace SDOPackage
   CORBA::Boolean
   Configuration_impl::set_configuration_parameter(const char* name,
                                                   const CORBA::Any&  /*value*/)
-    noexcept(false)
   {
     RTC_TRACE(("set_configuration_parameter(%s, value)", name));
     /*
@@ -379,7 +370,6 @@ namespace SDOPackage
    */
   ConfigurationSetList*
   Configuration_impl::get_configuration_sets()
-    noexcept(false)
   {
     RTC_TRACE(("get_configuration_sets()"));
     try
@@ -431,7 +421,6 @@ namespace SDOPackage
    */
   ConfigurationSet*
   Configuration_impl::get_configuration_set(const char* id)
-    noexcept(false)
   {
     RTC_TRACE(("get_configuration_set(%s)", id));
     if (std::string(id).empty()) throw InternalError("ID is empty");
@@ -484,7 +473,6 @@ namespace SDOPackage
   CORBA::Boolean
   Configuration_impl::
   set_configuration_set_values(const ConfigurationSet& configuration_set)
-    noexcept(false)
   {
     RTC_TRACE(("set_configuration_set_values()"));
     std::string id(configuration_set.id);
@@ -542,7 +530,6 @@ namespace SDOPackage
    */
   ConfigurationSet*
   Configuration_impl::get_active_configuration_set()
-    noexcept(false)
   {
     RTC_TRACE(("get_active_configuration_set()"));
     // activeなConfigurationSetは無い
@@ -575,7 +562,6 @@ namespace SDOPackage
   CORBA::Boolean
   Configuration_impl::
   add_configuration_set(const ConfigurationSet& configuration_set)
-    noexcept(false)
   {
     RTC_TRACE(("add_configuration_set()"));
     try
@@ -603,7 +589,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::remove_configuration_set(const char* id)
-    noexcept(false)
   {
     RTC_TRACE(("remove_configuration_set(%s)", id));
     if (std::string(id).empty())
@@ -631,7 +616,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::activate_configuration_set(const char* id)
-    noexcept(false)
   {
     RTC_TRACE(("activate_configuration_set(%s)", id));
     if (std::string(id).empty())

--- a/src/lib/rtm/SdoConfiguration.cpp
+++ b/src/lib/rtm/SdoConfiguration.cpp
@@ -132,8 +132,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::set_device_profile(const DeviceProfile& dProfile)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("set_device_profile()"));
     try
@@ -159,8 +158,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::add_service_profile(const ServiceProfile& sProfile)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("add_service_profile()"));
     // SDO specification defines that InvalidParameter() exception
@@ -188,8 +186,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::add_organization(Organization_ptr org)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("add_organization()"));
     try
@@ -215,8 +212,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::remove_service_profile(const char* id)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("remove_service_profile(%s)", id));
     try
@@ -239,8 +235,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::remove_organization(const char* organization_id)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("remove_organization(%s)", organization_id));
     try
@@ -269,8 +264,7 @@ namespace SDOPackage
    */
   ParameterList*
   Configuration_impl::get_configuration_parameters()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_configuration_parameters()"));
     try
@@ -298,8 +292,7 @@ namespace SDOPackage
    */
   NVList*
   Configuration_impl::get_configuration_parameter_values()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_configuration_parameter_values()"));
     Guard guard(m_config_mutex);
@@ -326,8 +319,7 @@ namespace SDOPackage
    */
   CORBA::Any*
   Configuration_impl::get_configuration_parameter_value(const char* name)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_configuration_parameter_value(%s)", name));
     if (std::string(name).empty()) throw InvalidParameter("Name is empty.");
@@ -359,8 +351,7 @@ namespace SDOPackage
   CORBA::Boolean
   Configuration_impl::set_configuration_parameter(const char* name,
                                                   const CORBA::Any&  /*value*/)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("set_configuration_parameter(%s, value)", name));
     /*
@@ -388,8 +379,7 @@ namespace SDOPackage
    */
   ConfigurationSetList*
   Configuration_impl::get_configuration_sets()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_configuration_sets()"));
     try
@@ -441,8 +431,7 @@ namespace SDOPackage
    */
   ConfigurationSet*
   Configuration_impl::get_configuration_set(const char* id)
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_configuration_set(%s)", id));
     if (std::string(id).empty()) throw InternalError("ID is empty");
@@ -495,8 +484,7 @@ namespace SDOPackage
   CORBA::Boolean
   Configuration_impl::
   set_configuration_set_values(const ConfigurationSet& configuration_set)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("set_configuration_set_values()"));
     std::string id(configuration_set.id);
@@ -554,8 +542,7 @@ namespace SDOPackage
    */
   ConfigurationSet*
   Configuration_impl::get_active_configuration_set()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_active_configuration_set()"));
     // activeなConfigurationSetは無い
@@ -588,8 +575,7 @@ namespace SDOPackage
   CORBA::Boolean
   Configuration_impl::
   add_configuration_set(const ConfigurationSet& configuration_set)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("add_configuration_set()"));
     try
@@ -617,8 +603,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::remove_configuration_set(const char* id)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("remove_configuration_set(%s)", id));
     if (std::string(id).empty())
@@ -646,8 +631,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Configuration_impl::activate_configuration_set(const char* id)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("activate_configuration_set(%s)", id));
     if (std::string(id).empty())

--- a/src/lib/rtm/SdoConfiguration.h
+++ b/src/lib/rtm/SdoConfiguration.h
@@ -242,8 +242,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean set_device_profile(const DeviceProfile& dProfile)
-      noexcept(false) override;
+    CORBA::Boolean set_device_profile(const DeviceProfile& dProfile) override;
 
     /*!
      * @if jp
@@ -290,8 +289,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean add_service_profile(const ServiceProfile& sProfile)
-      noexcept(false) override;
+    CORBA::Boolean add_service_profile(const ServiceProfile& sProfile) override;
 
     /*!
      * @if jp
@@ -328,8 +326,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean add_organization(Organization_ptr org)
-      noexcept(false) override;
+    CORBA::Boolean add_organization(Organization_ptr org) override;
 
     /*!
      * @if jp
@@ -373,8 +370,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean remove_service_profile(const char* id)
-      noexcept(false) override;
+    CORBA::Boolean remove_service_profile(const char* id) override;
 
     /*!
      * @if jp
@@ -415,8 +411,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean remove_organization(const char* organization_id)
-      noexcept(false) override;
+    CORBA::Boolean remove_organization(const char* organization_id) override;
 
     /*!
      * @if jp
@@ -450,8 +445,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    ParameterList* get_configuration_parameters()
-      noexcept(false) override;
+    ParameterList* get_configuration_parameters() override;
 
     /*!
      * @if jp
@@ -483,8 +477,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    NVList* get_configuration_parameter_values()
-      noexcept(false) override;
+    NVList* get_configuration_parameter_values() override;
 
     /*!
      * @if jp
@@ -526,8 +519,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Any* get_configuration_parameter_value(const char* name)
-      noexcept(false) override;
+    CORBA::Any* get_configuration_parameter_value(const char* name) override;
 
     /*!
      * @if jp
@@ -572,8 +564,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean set_configuration_parameter(const char* name,
-                                                       const CORBA::Any& value)
-      noexcept(false) override;
+                                                       const CORBA::Any& value) override;
 
     /*!
      * @if jp
@@ -609,8 +600,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    ConfigurationSetList* get_configuration_sets()
-      noexcept(false) override;
+    ConfigurationSetList* get_configuration_sets() override;
 
     /*!
      * @if jp
@@ -652,8 +642,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    ConfigurationSet* get_configuration_set(const char* id)
-      noexcept(false) override;
+    ConfigurationSet* get_configuration_set(const char* id) override;
 
     /*!
      * @if jp
@@ -703,8 +692,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    ConfigurationSet* get_active_configuration_set()
-      noexcept(false) override;
+    ConfigurationSet* get_active_configuration_set() override;
 
     /*!
      * @if jp
@@ -748,8 +736,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean
-    add_configuration_set(const ConfigurationSet& configuration_set)
-      noexcept(false) override;
+    add_configuration_set(const ConfigurationSet& configuration_set) override;
 
     /*!
      * @if jp
@@ -803,8 +790,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean
-    set_configuration_set_values(const ConfigurationSet& configuration_set)
-      noexcept(false) override;
+    set_configuration_set_values(const ConfigurationSet& configuration_set) override;
 
     /*!
      * @if jp
@@ -844,8 +830,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean remove_configuration_set(const char* id)
-      noexcept(false) override;
+    CORBA::Boolean remove_configuration_set(const char* id) override;
 
     /*!
      * @if jp
@@ -897,8 +882,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean activate_configuration_set(const char* id)
-      noexcept(false) override;
+    CORBA::Boolean activate_configuration_set(const char* id) override;
 
     // end of CORBA interface definition
     //============================================================

--- a/src/lib/rtm/SdoConfiguration.h
+++ b/src/lib/rtm/SdoConfiguration.h
@@ -243,8 +243,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean set_device_profile(const DeviceProfile& dProfile)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -292,8 +291,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean add_service_profile(const ServiceProfile& sProfile)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -331,8 +329,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean add_organization(Organization_ptr org)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -377,8 +374,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean remove_service_profile(const char* id)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -420,8 +416,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean remove_organization(const char* organization_id)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -456,8 +451,7 @@ namespace SDOPackage
      * @endif
      */
     ParameterList* get_configuration_parameters()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -490,8 +484,7 @@ namespace SDOPackage
      * @endif
      */
     NVList* get_configuration_parameter_values()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -534,8 +527,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Any* get_configuration_parameter_value(const char* name)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -581,8 +573,7 @@ namespace SDOPackage
      */
     CORBA::Boolean set_configuration_parameter(const char* name,
                                                        const CORBA::Any& value)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -619,8 +610,7 @@ namespace SDOPackage
      * @endif
      */
     ConfigurationSetList* get_configuration_sets()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -663,8 +653,7 @@ namespace SDOPackage
      * @endif
      */
     ConfigurationSet* get_configuration_set(const char* id)
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -715,8 +704,7 @@ namespace SDOPackage
      * @endif
      */
     ConfigurationSet* get_active_configuration_set()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -761,8 +749,7 @@ namespace SDOPackage
      */
     CORBA::Boolean
     add_configuration_set(const ConfigurationSet& configuration_set)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -817,8 +804,7 @@ namespace SDOPackage
      */
     CORBA::Boolean
     set_configuration_set_values(const ConfigurationSet& configuration_set)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -859,8 +845,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean remove_configuration_set(const char* id)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -913,8 +898,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean activate_configuration_set(const char* id)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     // end of CORBA interface definition
     //============================================================

--- a/src/lib/rtm/SdoOrganization.cpp
+++ b/src/lib/rtm/SdoOrganization.cpp
@@ -81,7 +81,6 @@ namespace SDOPackage
    * @endif
    */
   char* Organization_impl::get_organization_id()
-    noexcept(false)
   {
     RTC_TRACE(("get_organization_id() = %s", m_pId.c_str()));
     return CORBA::string_dup(m_pId.c_str());
@@ -95,7 +94,6 @@ namespace SDOPackage
    * @endif
    */
   OrganizationProperty* Organization_impl::get_organization_property()
-    noexcept(false)
   {
     RTC_TRACE(("get_organization_property()"));
     Guard guard(m_org_mutex);
@@ -113,7 +111,6 @@ namespace SDOPackage
    */
   CORBA::Any*
   Organization_impl::get_organization_property_value(const char* name)
-    noexcept(false)
   {
     RTC_TRACE(("get_organization_property_value(%s)", name));
     if (std::string(name).empty())
@@ -149,7 +146,6 @@ namespace SDOPackage
   CORBA::Boolean
   Organization_impl::
   add_organization_property(const OrganizationProperty& organization_property)
-    noexcept(false)
   {
     RTC_TRACE(("add_organization_property()"));
     try
@@ -175,7 +171,6 @@ namespace SDOPackage
   CORBA::Boolean
   Organization_impl::set_organization_property_value(const char* name,
                                                      const CORBA::Any& value)
-    noexcept(false)
   {
     RTC_TRACE(("set_organization_property_value(name=%s)", name));
     if (std::string(name).empty())
@@ -209,7 +204,6 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Organization_impl::remove_organization_property(const char* name)
-    noexcept(false)
   {
     RTC_TRACE(("remove_organization_property(%s)", name));
     if (std::string(name).empty())
@@ -240,7 +234,6 @@ namespace SDOPackage
    * @endif
    */
   SDOSystemElement_ptr Organization_impl::get_owner()
-    noexcept(false)
   {
     RTC_TRACE(("get_owner()"));
     return m_varOwner._retn();
@@ -254,7 +247,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::set_owner(SDOSystemElement_ptr sdo)
-    noexcept(false)
   {
     RTC_TRACE(("set_owner()"));
     if (CORBA::is_nil(sdo))
@@ -279,7 +271,6 @@ namespace SDOPackage
    * @endif
    */
   SDOList* Organization_impl::get_members()
-    noexcept(false)
   {
     RTC_TRACE(("get_members()"));
     try
@@ -302,7 +293,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::set_members(const SDOList& sdos)
-    noexcept(false)
   {
     RTC_TRACE(("set_members()"));
     try
@@ -325,7 +315,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::add_members(const SDOList& sdo_list)
-    noexcept(false)
   {
     RTC_TRACE(("add_members()"));
     if (sdo_list.length() == 0)
@@ -351,7 +340,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::remove_member(const char* id)
-    noexcept(false)
   {
     RTC_TRACE(("remove_member(%s)", id));
 
@@ -391,7 +379,6 @@ namespace SDOPackage
    * @endif
    */
   DependencyType Organization_impl::get_dependency()
-    noexcept(false)
   {
     RTC_TRACE(("get_dependency()"));
     return m_dependency;
@@ -405,7 +392,6 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::set_dependency(DependencyType dependency)
-    noexcept(false)
   {
     RTC_TRACE(("set_dependency()"));
     try

--- a/src/lib/rtm/SdoOrganization.cpp
+++ b/src/lib/rtm/SdoOrganization.cpp
@@ -81,8 +81,7 @@ namespace SDOPackage
    * @endif
    */
   char* Organization_impl::get_organization_id()
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_organization_id() = %s", m_pId.c_str()));
     return CORBA::string_dup(m_pId.c_str());
@@ -96,8 +95,7 @@ namespace SDOPackage
    * @endif
    */
   OrganizationProperty* Organization_impl::get_organization_property()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_organization_property()"));
     Guard guard(m_org_mutex);
@@ -115,8 +113,7 @@ namespace SDOPackage
    */
   CORBA::Any*
   Organization_impl::get_organization_property_value(const char* name)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_organization_property_value(%s)", name));
     if (std::string(name).empty())
@@ -152,8 +149,7 @@ namespace SDOPackage
   CORBA::Boolean
   Organization_impl::
   add_organization_property(const OrganizationProperty& organization_property)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("add_organization_property()"));
     try
@@ -179,8 +175,7 @@ namespace SDOPackage
   CORBA::Boolean
   Organization_impl::set_organization_property_value(const char* name,
                                                      const CORBA::Any& value)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("set_organization_property_value(name=%s)", name));
     if (std::string(name).empty())
@@ -214,8 +209,7 @@ namespace SDOPackage
    */
   CORBA::Boolean
   Organization_impl::remove_organization_property(const char* name)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("remove_organization_property(%s)", name));
     if (std::string(name).empty())
@@ -246,8 +240,7 @@ namespace SDOPackage
    * @endif
    */
   SDOSystemElement_ptr Organization_impl::get_owner()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_owner()"));
     return m_varOwner._retn();
@@ -261,8 +254,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::set_owner(SDOSystemElement_ptr sdo)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("set_owner()"));
     if (CORBA::is_nil(sdo))
@@ -287,8 +279,7 @@ namespace SDOPackage
    * @endif
    */
   SDOList* Organization_impl::get_members()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_members()"));
     try
@@ -311,8 +302,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::set_members(const SDOList& sdos)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("set_members()"));
     try
@@ -335,8 +325,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::add_members(const SDOList& sdo_list)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("add_members()"));
     if (sdo_list.length() == 0)
@@ -362,8 +351,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::remove_member(const char* id)
-    throw (CORBA::SystemException,
-           InvalidParameter, NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("remove_member(%s)", id));
 
@@ -403,8 +391,7 @@ namespace SDOPackage
    * @endif
    */
   DependencyType Organization_impl::get_dependency()
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("get_dependency()"));
     return m_dependency;
@@ -418,8 +405,7 @@ namespace SDOPackage
    * @endif
    */
   CORBA::Boolean Organization_impl::set_dependency(DependencyType dependency)
-    throw (CORBA::SystemException,
-           NotAvailable, InternalError)
+    noexcept(false)
   {
     RTC_TRACE(("set_dependency()"));
     try

--- a/src/lib/rtm/SdoOrganization.h
+++ b/src/lib/rtm/SdoOrganization.h
@@ -152,8 +152,7 @@ namespace SDOPackage
      * @endif
      */
     char* get_organization_id()
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -199,8 +198,7 @@ namespace SDOPackage
      */
     CORBA::Boolean
     add_organization_property(const OrganizationProperty& organization_property)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -235,8 +233,7 @@ namespace SDOPackage
      * @endif
      */
     OrganizationProperty* get_organization_property()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -278,8 +275,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Any* get_organization_property_value(const char* name)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -327,8 +323,7 @@ namespace SDOPackage
      */
     CORBA::Boolean
     set_organization_property_value(const char* name, const CORBA::Any& value)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -371,8 +366,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean remove_organization_property(const char* name)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -412,8 +406,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean add_members(const SDOList& sdo_list)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -448,8 +441,7 @@ namespace SDOPackage
      * @endif
      */
     SDOList* get_members()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -495,8 +487,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean set_members(const SDOList& sdos)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -535,8 +526,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean remove_member(const char* id)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -569,8 +559,7 @@ namespace SDOPackage
      * @endif
      */
     SDOSystemElement_ptr get_owner()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -614,8 +603,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean set_owner(SDOSystemElement_ptr sdo)
-      throw (CORBA::SystemException,
-             InvalidParameter, NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -653,8 +641,7 @@ namespace SDOPackage
      * @endif
      */
     DependencyType get_dependency()
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     /*!
      * @if jp
@@ -699,8 +686,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean set_dependency(DependencyType dependency)
-      throw (CORBA::SystemException,
-             NotAvailable, InternalError) override;
+      noexcept(false) override;
 
     // end of CORBA interface definition
     //============================================================

--- a/src/lib/rtm/SdoOrganization.h
+++ b/src/lib/rtm/SdoOrganization.h
@@ -151,8 +151,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    char* get_organization_id()
-      noexcept(false) override;
+    char* get_organization_id() override;
 
     /*!
      * @if jp
@@ -197,8 +196,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean
-    add_organization_property(const OrganizationProperty& organization_property)
-      noexcept(false) override;
+    add_organization_property(const OrganizationProperty& organization_property) override;
 
     /*!
      * @if jp
@@ -232,8 +230,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    OrganizationProperty* get_organization_property()
-      noexcept(false) override;
+    OrganizationProperty* get_organization_property() override;
 
     /*!
      * @if jp
@@ -274,8 +271,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Any* get_organization_property_value(const char* name)
-      noexcept(false) override;
+    CORBA::Any* get_organization_property_value(const char* name) override;
 
     /*!
      * @if jp
@@ -322,8 +318,7 @@ namespace SDOPackage
      * @endif
      */
     CORBA::Boolean
-    set_organization_property_value(const char* name, const CORBA::Any& value)
-      noexcept(false) override;
+    set_organization_property_value(const char* name, const CORBA::Any& value) override;
 
     /*!
      * @if jp
@@ -365,8 +360,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean remove_organization_property(const char* name)
-      noexcept(false) override;
+    CORBA::Boolean remove_organization_property(const char* name) override;
 
     /*!
      * @if jp
@@ -405,8 +399,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean add_members(const SDOList& sdo_list)
-      noexcept(false) override;
+    CORBA::Boolean add_members(const SDOList& sdo_list) override;
 
     /*!
      * @if jp
@@ -440,8 +433,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    SDOList* get_members()
-      noexcept(false) override;
+    SDOList* get_members() override;
 
     /*!
      * @if jp
@@ -486,8 +478,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean set_members(const SDOList& sdos)
-      noexcept(false) override;
+    CORBA::Boolean set_members(const SDOList& sdos) override;
 
     /*!
      * @if jp
@@ -525,8 +516,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean remove_member(const char* id)
-      noexcept(false) override;
+    CORBA::Boolean remove_member(const char* id) override;
 
     /*!
      * @if jp
@@ -558,8 +548,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    SDOSystemElement_ptr get_owner()
-      noexcept(false) override;
+    SDOSystemElement_ptr get_owner() override;
 
     /*!
      * @if jp
@@ -602,8 +591,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean set_owner(SDOSystemElement_ptr sdo)
-      noexcept(false) override;
+    CORBA::Boolean set_owner(SDOSystemElement_ptr sdo) override;
 
     /*!
      * @if jp
@@ -640,8 +628,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    DependencyType get_dependency()
-      noexcept(false) override;
+    DependencyType get_dependency() override;
 
     /*!
      * @if jp
@@ -685,8 +672,7 @@ namespace SDOPackage
      *                          completely due to some internal error.
      * @endif
      */
-    CORBA::Boolean set_dependency(DependencyType dependency)
-      noexcept(false) override;
+    CORBA::Boolean set_dependency(DependencyType dependency) override;
 
     // end of CORBA interface definition
     //============================================================

--- a/src/lib/rtm/SharedMemoryPort.cpp
+++ b/src/lib/rtm/SharedMemoryPort.cpp
@@ -159,7 +159,7 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::create_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  if (!m_shmem.created())
 	  {
@@ -192,7 +192,7 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::open_memory(::CORBA::ULongLong memory_size, const char * shm_address)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  
 	  m_shmem.open(shm_address, memory_size);
@@ -213,7 +213,7 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::close_memory(::CORBA::Boolean unlink)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  if (!m_shmem.created())
 	  {
@@ -337,7 +337,7 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::setInterface(::OpenRTM::PortSharedMemory_ptr sm)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  m_smInterface = ::OpenRTM::PortSharedMemory::_narrow(sm);
   }
@@ -357,7 +357,7 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::setEndian(::CORBA::Boolean endian)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  m_endian = endian;
 	  if (!CORBA::is_nil(m_smInterface))
@@ -388,7 +388,7 @@ namespace RTC
   * @endif
   */
 	::OpenRTM::PortStatus SharedMemoryPort::put()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  return ::OpenRTM::PORT_OK;
   }
@@ -408,7 +408,7 @@ namespace RTC
   * @endif
   */
 	::OpenRTM::PortStatus SharedMemoryPort::get()
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	  return ::OpenRTM::PORT_OK;
   }

--- a/src/lib/rtm/SharedMemoryPort.cpp
+++ b/src/lib/rtm/SharedMemoryPort.cpp
@@ -159,7 +159,6 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::create_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    noexcept(false)
   {
 	  if (!m_shmem.created())
 	  {
@@ -192,7 +191,6 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::open_memory(::CORBA::ULongLong memory_size, const char * shm_address)
-    noexcept(false)
   {
 	  
 	  m_shmem.open(shm_address, memory_size);
@@ -213,7 +211,6 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::close_memory(::CORBA::Boolean unlink)
-    noexcept(false)
   {
 	  if (!m_shmem.created())
 	  {
@@ -337,7 +334,6 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::setInterface(::OpenRTM::PortSharedMemory_ptr sm)
-    noexcept(false)
   {
 	  m_smInterface = ::OpenRTM::PortSharedMemory::_narrow(sm);
   }
@@ -357,7 +353,6 @@ namespace RTC
   * @endif
   */
 	void SharedMemoryPort::setEndian(::CORBA::Boolean endian)
-    noexcept(false)
   {
 	  m_endian = endian;
 	  if (!CORBA::is_nil(m_smInterface))
@@ -388,7 +383,6 @@ namespace RTC
   * @endif
   */
 	::OpenRTM::PortStatus SharedMemoryPort::put()
-    noexcept(false)
   {
 	  return ::OpenRTM::PORT_OK;
   }
@@ -408,7 +402,6 @@ namespace RTC
   * @endif
   */
 	::OpenRTM::PortStatus SharedMemoryPort::get()
-    noexcept(false)
   {
 	  return ::OpenRTM::PORT_OK;
   }

--- a/src/lib/rtm/SharedMemoryPort.h
+++ b/src/lib/rtm/SharedMemoryPort.h
@@ -126,8 +126,7 @@ namespace RTC
      *
      * @endif
      */
-	void create_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    	noexcept(false) override;
+	void create_memory(::CORBA::ULongLong memory_size, const char *shm_address) override;
      /*!
      * @if jp
      * @brief 共有メモリのマッピングを行う
@@ -145,8 +144,7 @@ namespace RTC
      *
      * @endif
      */
-	void open_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    	noexcept(false) override;
+	void open_memory(::CORBA::ULongLong memory_size, const char *shm_address) override;
      /*!
      * @if jp
      * @brief マッピングした共有メモリをアンマップする
@@ -160,8 +158,7 @@ namespace RTC
      *
      * @endif
      */
-	void close_memory(::CORBA::Boolean unlink = false)
-    	noexcept(false) override;
+	void close_memory(::CORBA::Boolean unlink = false) override;
      /*!
      * @if jp
      * @brief データを書き込む
@@ -211,8 +208,7 @@ namespace RTC
      *
      * @endif
      */
-	void setInterface(::OpenRTM::PortSharedMemory_ptr sm)
-    	noexcept(false) override;
+	void setInterface(::OpenRTM::PortSharedMemory_ptr sm) override;
      /*!
      * @if jp
      * @brief エンディアンを設定する
@@ -228,8 +224,7 @@ namespace RTC
      *
      * @endif
      */
-	void setEndian(::CORBA::Boolean endian)
-    	noexcept(false) override;
+	void setEndian(::CORBA::Boolean endian) override;
      /*!
      * @if jp
      * @brief データの送信を知らせる
@@ -245,8 +240,7 @@ namespace RTC
      *
      * @endif
      */
-    ::OpenRTM::PortStatus put()
-      noexcept(false) override;
+    ::OpenRTM::PortStatus put() override;
      /*!
      * @if jp
      * @brief データの送信を要求する
@@ -262,8 +256,7 @@ namespace RTC
      *
      * @endif
      */
-    ::OpenRTM::PortStatus get()
-      noexcept(false) override;
+    ::OpenRTM::PortStatus get() override;
 
 	virtual ::OpenRTM::PortSharedMemory_ptr getObjRef();
 

--- a/src/lib/rtm/SharedMemoryPort.h
+++ b/src/lib/rtm/SharedMemoryPort.h
@@ -127,7 +127,7 @@ namespace RTC
      * @endif
      */
 	void create_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    	throw (CORBA::SystemException) override;
+    	noexcept(false) override;
      /*!
      * @if jp
      * @brief 共有メモリのマッピングを行う
@@ -146,7 +146,7 @@ namespace RTC
      * @endif
      */
 	void open_memory(::CORBA::ULongLong memory_size, const char *shm_address)
-    	throw (CORBA::SystemException) override;
+    	noexcept(false) override;
      /*!
      * @if jp
      * @brief マッピングした共有メモリをアンマップする
@@ -161,7 +161,7 @@ namespace RTC
      * @endif
      */
 	void close_memory(::CORBA::Boolean unlink = false)
-    	throw (CORBA::SystemException) override;
+    	noexcept(false) override;
      /*!
      * @if jp
      * @brief データを書き込む
@@ -212,7 +212,7 @@ namespace RTC
      * @endif
      */
 	void setInterface(::OpenRTM::PortSharedMemory_ptr sm)
-    	throw (CORBA::SystemException) override;
+    	noexcept(false) override;
      /*!
      * @if jp
      * @brief エンディアンを設定する
@@ -229,7 +229,7 @@ namespace RTC
      * @endif
      */
 	void setEndian(::CORBA::Boolean endian)
-    	throw (CORBA::SystemException) override;
+    	noexcept(false) override;
      /*!
      * @if jp
      * @brief データの送信を知らせる
@@ -246,7 +246,7 @@ namespace RTC
      * @endif
      */
     ::OpenRTM::PortStatus put()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
      /*!
      * @if jp
      * @brief データの送信を要求する
@@ -263,7 +263,7 @@ namespace RTC
      * @endif
      */
     ::OpenRTM::PortStatus get()
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
 	virtual ::OpenRTM::PortSharedMemory_ptr getObjRef();
 

--- a/src/lib/rtm/SimulatorExecutionContext.cpp
+++ b/src/lib/rtm/SimulatorExecutionContext.cpp
@@ -79,7 +79,6 @@ namespace RTC
    */
   RTC::ReturnCode_t SimulatorExecutionContext::
 	  activate_component(RTC::LightweightRTObject_ptr comp)
-	  noexcept(false)
   {
 	Guard guard(m_tickmutex);
 
@@ -130,7 +129,6 @@ namespace RTC
    */
   RTC::ReturnCode_t SimulatorExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
 	Guard guard(m_tickmutex);
 
@@ -183,7 +181,6 @@ namespace RTC
    */
   RTC::ReturnCode_t SimulatorExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    noexcept(false)
   {
 	Guard guard(m_tickmutex);
 

--- a/src/lib/rtm/SimulatorExecutionContext.cpp
+++ b/src/lib/rtm/SimulatorExecutionContext.cpp
@@ -79,7 +79,7 @@ namespace RTC
    */
   RTC::ReturnCode_t SimulatorExecutionContext::
 	  activate_component(RTC::LightweightRTObject_ptr comp)
-	  throw (CORBA::SystemException)
+	  noexcept(false)
   {
 	Guard guard(m_tickmutex);
 
@@ -130,7 +130,7 @@ namespace RTC
    */
   RTC::ReturnCode_t SimulatorExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	Guard guard(m_tickmutex);
 
@@ -183,7 +183,7 @@ namespace RTC
    */
   RTC::ReturnCode_t SimulatorExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
-    throw (CORBA::SystemException)
+    noexcept(false)
   {
 	Guard guard(m_tickmutex);
 

--- a/src/lib/rtm/SimulatorExecutionContext.h
+++ b/src/lib/rtm/SimulatorExecutionContext.h
@@ -93,8 +93,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    activate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    activate_component(RTC::LightweightRTObject_ptr comp) override;
     /*!
      * @if jp
      * @brief RTコンポーネントを非アクティブ化する
@@ -118,8 +117,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    deactivate_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    deactivate_component(RTC::LightweightRTObject_ptr comp) override;
     /*!
      * @if jp
      * @brief RTコンポーネントをリセットする
@@ -143,8 +141,7 @@ namespace RTC
      * @endif
      */
     RTC::ReturnCode_t
-    reset_component(RTC::LightweightRTObject_ptr comp)
-      noexcept(false) override;
+    reset_component(RTC::LightweightRTObject_ptr comp) override;
 
   private:
 

--- a/src/lib/rtm/SimulatorExecutionContext.h
+++ b/src/lib/rtm/SimulatorExecutionContext.h
@@ -94,7 +94,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     activate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
     /*!
      * @if jp
      * @brief RTコンポーネントを非アクティブ化する
@@ -119,7 +119,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     deactivate_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
     /*!
      * @if jp
      * @brief RTコンポーネントをリセットする
@@ -144,7 +144,7 @@ namespace RTC
      */
     RTC::ReturnCode_t
     reset_component(RTC::LightweightRTObject_ptr comp)
-      throw (CORBA::SystemException) override;
+      noexcept(false) override;
 
   private:
 


### PR DESCRIPTION
## Identify the Bug
#252 

## Description of the Change
C++11 から関数の例外仕様から throw() が廃止され、noexcept() に置き換わった。
そのため、以下のように置き換える。 f611096
-  throw() -> noexcept
-  throw(...) -> noexcept(false)

一方で、MSVCがこの仕様に対応出来ているのは、 MSVC 2015 以降のみである。
MSVC 2013 は、 独自仕様 _NOEXCEPT を持つ。MSVC 2012 は、何もない。
よって、上記コミットから以下の対応を取る。 9a6ae11
- (少しもったいないが) noexcept(false) はすべて削除
- MSVC 2013以前 は noexcept を _NOEXCEPT に置き換え


今後の実装における注意点:
- noexcept(...) を使ってはいけない
- 引数なしの noexcept は使うべき

## Verification 
ビルド確認のみ。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  