### PR TITLE
Visual Studio、omniORBでのビルドで発生する警告の修正

### DIFF
--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -94,9 +94,9 @@ RTC::ReturnCode_t Inputbutton::onExecute(RTC::UniqueId  /*ec_id*/)
   if (cmds.size() > 1)
     {
       std::cout << "  [args]: ";
-      for(auto & cmd : cmds)
+      for(auto & c : cmds)
         {
-          std::cout << cmd << " ";
+          std::cout << c << " ";
         }
    }
   std::cout << std::endl;

--- a/src/lib/coil/CMakeLists.txt
+++ b/src/lib/coil/CMakeLists.txt
@@ -115,7 +115,6 @@ set(coil_srcs
 	common/coil/crc.cpp
 	common/coil/stringutil.cpp
 	common/coil/Logger.cpp
-	${COIL_OS_DIR}/coil/Condition.cpp
 	${COIL_OS_DIR}/coil/DynamicLib.cpp
 	${COIL_OS_DIR}/coil/Mutex.cpp
 	${COIL_OS_DIR}/coil/Routing.cpp

--- a/src/lib/coil/common/Logger.h
+++ b/src/lib/coil/common/Logger.h
@@ -32,6 +32,17 @@
 #include <vector>
 
 
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#   ifdef COIL_LIBRARY_EXPORTS
+#      define COIL_DLL_PLUGIN __declspec(dllexport)
+#   else
+#      define COIL_DLL_PLUGIN __declspec(dllimport)
+#   endif
+#else
+#   define COIL_DLL_PLUGIN
+#endif /* Windows */
+
+
 
 namespace coil
 {
@@ -603,8 +614,8 @@ namespace coil
 
       
   public:
-      static bool m_lockEnable;
-      static Mutex m_mutex;
+      static COIL_DLL_PLUGIN bool m_lockEnable;
+      static COIL_DLL_PLUGIN Mutex m_mutex;
 
   };
 

--- a/src/lib/coil/common/Properties.cpp
+++ b/src/lib/coil/common/Properties.cpp
@@ -705,7 +705,6 @@ namespace coil
       {
         return next;
       }
-    return nullptr;
   }
 
   /*!

--- a/src/lib/rtm/CORBA_IORUtil.cpp
+++ b/src/lib/rtm/CORBA_IORUtil.cpp
@@ -240,8 +240,9 @@ namespace CORBA_IORUtil
       {
         return false;
       }
-#endif  // ORB_IS_RTORB
+#else
     return false;
+#endif  // ORB_IS_RTORB
   }
 
   /*!

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -965,8 +965,6 @@ namespace RTC
         RTC_ERROR(("InPortPushConnector creation failed"));
         return nullptr;
       }
-    RTC_FATAL(("never comes here: createConnector()"));
-    return nullptr;
   }
 
   /*!
@@ -1045,8 +1043,6 @@ namespace RTC
         RTC_ERROR(("InPortPullConnector creation failed"));
         return nullptr;
       }
-    RTC_FATAL(("never comes here: createConnector()"));
-    return nullptr;
   }
 
   ConnectorListeners& InPortBase::getListeners()

--- a/src/lib/rtm/InPortSHMConsumer.cpp
+++ b/src/lib/rtm/InPortSHMConsumer.cpp
@@ -137,7 +137,6 @@ namespace RTC
 		{
 			return CONNECTION_LOST;
 		}
-		return UNKNOWN_ERROR;
 	}
 
   

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1376,8 +1376,6 @@ namespace RTM
         RTC_ERROR(("Unknown non-CORBA exception cought."));
         return RTC::RTObject::_nil();
       }
-      
-    return RTC::RTObject::_nil();
   }
   
   /*

--- a/src/lib/rtm/NumberingPolicy.cpp
+++ b/src/lib/rtm/NumberingPolicy.cpp
@@ -86,7 +86,6 @@ namespace RTM
         if (m_objects[i] == obj) return static_cast<int>(i);
       }
     throw ObjectNotFound();
-    return static_cast<int>(i);
   }
 } //namespace RTM 
 

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -1009,8 +1009,6 @@ namespace RTC
         RTC_ERROR(("OutPortPushConnector creation failed"));
         return nullptr;
       }
-    RTC_FATAL(("never comes here: createConnector()"));
-    return nullptr;
   }
 
   /*!
@@ -1067,8 +1065,6 @@ namespace RTC
         RTC_ERROR(("OutPortPullConnector creation failed"));
         return nullptr;
       }
-    RTC_FATAL(("never comes here: createConnector()"));
-    return nullptr;
   }
 
   /*!

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
@@ -138,8 +138,6 @@ namespace RTC
         RTC_WARN(("Exception caought from OutPort::get()."));
         return CONNECTION_LOST;
       }
-    RTC_ERROR(("OutPortCorbaCdrConsumer::get(): Never comes here."));
-    return UNKNOWN_ERROR;
   }
 
   /*!

--- a/src/lib/rtm/OutPortDSConsumer.cpp
+++ b/src/lib/rtm/OutPortDSConsumer.cpp
@@ -135,8 +135,6 @@ namespace RTC
         RTC_WARN(("Exception caought from OutPort::get()."));
         return CONNECTION_LOST;
       }
-    RTC_ERROR(("OutPortDSConsumer::get(): Never comes here."));
-    return UNKNOWN_ERROR;
   }
 
   /*!

--- a/src/lib/rtm/OutPortSHMConsumer.cpp
+++ b/src/lib/rtm/OutPortSHMConsumer.cpp
@@ -158,8 +158,6 @@ namespace RTC
         RTC_WARN(("Exception caought from OutPort::get()."));
         return CONNECTION_LOST;
       }
-    RTC_ERROR(("OutPortSHMConsumer::get(): Never comes here."));
-    return UNKNOWN_ERROR;
   }
     
   /*!

--- a/src/lib/rtm/PortAdmin.cpp
+++ b/src/lib/rtm/PortAdmin.cpp
@@ -58,7 +58,6 @@ namespace RTC
         {
           return false;
         }
-      return false;
     }
     const std::string m_name;
   };

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -222,7 +222,6 @@ namespace RTC
       {
         return RTC::BAD_PARAMETER;
       }
-    return RTC::RTC_ERROR;
   }
 
   /*!

--- a/src/lib/rtm/PublisherFlush.cpp
+++ b/src/lib/rtm/PublisherFlush.cpp
@@ -178,7 +178,6 @@ namespace RTC
         onReceiverError(data_);
         return ret;
       }
-    return ret;
   }
 
   /*!

--- a/src/lib/rtm/PublisherPeriodic.cpp
+++ b/src/lib/rtm/PublisherPeriodic.cpp
@@ -91,12 +91,6 @@ namespace RTC
         return INVALID_ARGS;
       }
     return PORT_OK;
-
-
-
-
-
-    return PORT_OK;
   }
 
   /*!

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -1125,7 +1125,6 @@ namespace RTC
       {
         throw SDOPackage::NotAvailable();
       }
-    return new SDOPackage::OrganizationList();
   }
 
   // SDOPackage::SDO
@@ -1171,8 +1170,6 @@ namespace RTC
       {
         throw SDOPackage::InternalError("get_sdo_type()");
       }
-    sdo_type = "";
-    return sdo_type._retn();
   }
 
   /*!
@@ -1196,7 +1193,6 @@ namespace RTC
       {
         throw SDOPackage::InternalError("get_device_profile()");
       }
-    return new SDOPackage::DeviceProfile();
   }
 
   //------------------------------------------------------------
@@ -1358,7 +1354,6 @@ namespace RTC
       {
         throw SDOPackage::InternalError("get_organizations()");
       }
-    return new SDOPackage::OrganizationList(0);
   }
 
   /*!
@@ -1408,7 +1403,6 @@ namespace RTC
       {
         throw SDOPackage::InternalError("get_status()");
       }
-    return new CORBA::Any();
   }
 
   //============================================================

--- a/src/lib/rtm/SdoConfiguration.cpp
+++ b/src/lib/rtm/SdoConfiguration.cpp
@@ -172,7 +172,6 @@ namespace SDOPackage
       {
         throw InternalError("Configuration::set_service_profile");
       }
-    return false;
   }
 
   /*!
@@ -219,7 +218,6 @@ namespace SDOPackage
       {
         throw InternalError("Configuration::remove_service_profile");
       }
-    return false;
   }
 
   /*!
@@ -273,8 +271,6 @@ namespace SDOPackage
         throw InternalError("Configuration::get_configuration_parameters()");
         // never reach here
       }
-    // never reach here
-    return new ParameterList(0);
   }
 
   /*!
@@ -408,8 +404,6 @@ namespace SDOPackage
         RTC_ERROR(("Unknown exception cought."));
         throw InternalError("Configuration::get_configuration_sets()");
       }
-    // never reach here
-    return new ConfigurationSetList(0);
   }
 
   /*!
@@ -457,10 +451,6 @@ namespace SDOPackage
       {
         throw InternalError("Configuration::get_configuration_set()");
       }
-
-    // never reach here
-    RTC_FATAL(("never reach here"));
-    return new ConfigurationSet();
   }
 
   /*!
@@ -548,8 +538,6 @@ namespace SDOPackage
       {
         throw InternalError("Configuration::get_active_configuration_set()");
       }
-    // never reach here
-    return new ConfigurationSet();
   }
 
   /*!
@@ -577,7 +565,6 @@ namespace SDOPackage
         throw InternalError("Configuration::add_configuration_set()");
         return false;
       }
-    return true;
   }
 
   /*!
@@ -604,7 +591,6 @@ namespace SDOPackage
         throw InternalError("Configuration::remove_configuration_set()");
         return false;
       }
-    return false;
   }
 
   /*!
@@ -640,7 +626,6 @@ namespace SDOPackage
         return false;
       }
 */
-    return false;
   }
 
   //============================================================

--- a/src/lib/rtm/SdoOrganization.cpp
+++ b/src/lib/rtm/SdoOrganization.cpp
@@ -132,8 +132,6 @@ namespace SDOPackage
       {
         throw InternalError("get_organization_property_value()");
       }
-    // never reach here
-    return new CORBA::Any();
   }
 
   /*!
@@ -158,7 +156,6 @@ namespace SDOPackage
       {
         throw InternalError("set_organization_property()");
       }
-    return false;
   }
 
   /*!
@@ -223,7 +220,6 @@ namespace SDOPackage
       {
         throw InternalError("remove_organization_property()");
       }
-    return false;
   }
 
   /*!
@@ -260,7 +256,6 @@ namespace SDOPackage
       {
         throw InternalError("set_owner()");
       }
-    return true;
   }
 
   /*!
@@ -304,7 +299,6 @@ namespace SDOPackage
       {
         throw InternalError("set_members()");
       }
-    return true;
   }
 
   /*!
@@ -329,7 +323,6 @@ namespace SDOPackage
       {
         throw InternalError("add_members()");
       }
-    return false;
   }
 
   /*!
@@ -368,7 +361,6 @@ namespace SDOPackage
         RTC_ERROR(("unknown exception"));
         throw InternalError("remove_member(): Not found.");
       }
-    return false;
   }
 
   /*!
@@ -403,6 +395,5 @@ namespace SDOPackage
       {
         throw InternalError("set_dependency(): Unknown.");
       }
-    return false;
   }
 } // namespace SDOPackage

--- a/src/lib/rtm/SdoServiceAdmin.cpp
+++ b/src/lib/rtm/SdoServiceAdmin.cpp
@@ -232,7 +232,6 @@ namespace RTC
           }
       }
     throw SDOPackage::InvalidParameter();
-    return new SDOPackage::ServiceProfile();
   }
 
   /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change

以下の警告を修正した。

```
重大度レベル	コード	説明	プロジェクト	ファイル	行	抑制状態C:\workspace\openrtm12\build_omni\src\lib\rtm\idl\RTCSkel200_vc141d.exp	1	
警告	C4702	制御が渡らないコードです。	coil200_vc141_objlib	c:\workspace\openrtm12\src\lib\coil\common\coil\properties.cpp	708	
警告	LNK4221	このオブジェクト ファイルは、以前に未定義であったパブリック シンボルを定義していないため、このライブラリを使用するリンク操作では使用されません	coil200_vc141_objlib	C:\workspace\openrtm12\build_omni\src\lib\coil\Condition.obj	1	
警告	LNK4221	このオブジェクト ファイルは、以前に未定義であったパブリック シンボルを定義していないため、このライブラリを使用するリンク操作では使用されません	coil200_vc141-static	C:\workspace\openrtm12\build_omni\src\lib\coil\Condition.obj	1	
警告	C4456	'cmd' を宣言すると、以前のローカル宣言が隠蔽されます	Inputbutton_objlib	c:\workspace\openrtm12\examples\staticfsm\inputbutton.cpp	97	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\managerservant.cpp	1380	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\corba_iorutil.cpp	244	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\outportcorbacdrconsumer.cpp	141	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\publisherperiodic.cpp	99	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\portadmin.cpp	61	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	161	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	136	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	226	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	263	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	307	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	332	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	406	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoorganization.cpp	371	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\inportbase.cpp	968	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\inportbase.cpp	1048	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\rtobject.cpp	1128	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\rtobject.cpp	1174	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\rtobject.cpp	1199	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\rtobject.cpp	1361	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\rtobject.cpp	1411	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	175	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	222	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	277	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	552	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	412	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	462	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	463	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	580	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	607	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoconfiguration.cpp	643	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\publisherflush.cpp	181	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\portbase.cpp	225	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\numberingpolicy.cpp	89	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\sdoserviceadmin.cpp	235	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\outportbase.cpp	1012	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\outportbase.cpp	1070	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\outportdsconsumer.cpp	138	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\outportshmconsumer.cpp	161	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\outportshmconsumer.cpp	162	
警告	C4702	制御が渡らないコードです。	RTC200_vc141_objlib	c:\workspace\openrtm12\src\lib\rtm\inportshmconsumer.cpp	140	
```


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
