### PR TITLE
[compat] modify compile option settings to select option using compil…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,13 +605,13 @@ function(openrtm_common_set_compile_options target)
 		-pedantic
 		-Wall
 		-Wextra
-		-Walloc-zero
-		-Walloca
-		-Warray-bounds=2
-		-Wcast-align=strict
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Walloc-zero>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Walloca>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},4.9.9>: -Warray-bounds=2>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wcast-align=strict>
 		-Wcast-qual
-		-Wcatch-value=3
-		-Wclass-memaccess
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wcatch-value=3>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wclass-memaccess>
 		-Wcomments
 		-Wconditionally-supported
 		-Wconversion
@@ -620,22 +620,22 @@ function(openrtm_common_set_compile_options target)
 		-Wdelete-non-virtual-dtor
 		-Wdisabled-optimization
 		-Wdouble-promotion
-		-Wduplicated-branches
-		-Wduplicated-cond
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wduplicated-branches>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},5.9.9>: -Wduplicated-cond>
 		-Werror-implicit-function-declaration
-		-Wextra-semi
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wextra-semi>
 		-Wfloat-conversion
 		-Wfloat-equal
 		-Wformat
 		-Wformat-nonliteral
-		-Wformat-overflow=2
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wformat-overflow=2>
 		-Wformat-security
-		-Wformat-signedness
-		-Wformat-truncation=2
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},4.9.9>: -Wformat-signedness>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wformat-truncation=2>
 		-Wformat-y2k
 		-Wformat=2
 		-Wframe-larger-than=4000
-		-Wimplicit-fallthrough=3
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wimplicit-fallthrough=3>
 		-Winit-self
 		-Winline
 		-Winvalid-pch
@@ -646,42 +646,42 @@ function(openrtm_common_set_compile_options target)
 		-Wmissing-noreturn
 		-Wmultichar
 		-Wnoexcept
-		-Wnoexcept-type
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wnoexcept-type>
 		-Wnon-virtual-dtor
-		-Wnull-dereference
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},5.9.9>: -Wnull-dereference>
 		-Wold-style-cast
 		-Woverlength-strings
 		-Woverloaded-virtual
 		-Wpacked
 		-Wpedantic
-		-Wplacement-new=1
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},5.9.9>: -Wplacement-new=1>
 		-Wpointer-arith
 		-Wredundant-decls
-		-Wregister
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wregister>
 		-Wreorder
-		-Wscalar-storage-order
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},5.9.9>: -Wscalar-storage-order>
 		-Wshadow
-		-Wshadow-compatible-local
-		-Wshadow-local
-		-Wshadow=compatible-local
-		-Wshadow=global
-		-Wshadow=local
-		-Wshift-overflow=1
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wshadow-compatible-local>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wshadow-local>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wshadow=compatible-local>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wshadow=global>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wshadow=local>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},5.9.9>: -Wshift-overflow=1>
 		-Wsign-conversion
 		-Wsign-promo
 		-Wstack-protector
 		-Wstrict-null-sentinel
 		-Wstrict-overflow=5
-		-Wstringop-overflow=4
-		-Wsuggest-attribute=cold
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wstringop-overflow=4>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wsuggest-attribute=cold>
 		-Wsuggest-attribute=const
 		-Wsuggest-attribute=format
-		-Wsuggest-attribute=malloc
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wsuggest-attribute=malloc>
 		-Wsuggest-attribute=noreturn
 		-Wsuggest-attribute=pure
-		-Wsuggest-final-methods
-		-Wsuggest-final-types
-		-Wsuggest-override
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},4.9.9>: -Wsuggest-final-methods>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},4.9.9>: -Wsuggest-final-types>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},4.9.9>: -Wsuggest-override>
 		-Wswitch-default
 		-Wswitch-enum
 		-Wsynth
@@ -689,7 +689,7 @@ function(openrtm_common_set_compile_options target)
 		-Wundef
 		-Wunreachable-code
 		-Wunsafe-loop-optimizations
-		-Wunused-const-variable=2
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},5.9.9>: -Wunused-const-variable=2>
 		-Wunused-macros
 		-Wuseless-cast
 		-Wvariadic-macros


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#302 

## Description of the Change
- Debugモード時のコンパイルオプションをコンパイラのバージョンによって選択
- バージョンの指定は、例えば「7.1 >= gcc ver」 で有効であれば 「6.9.9 > gcc ver」で指定
これは最近のリリースでは X.0.0系のリリースはないが、4系などではリリースされているため X.9.9 > gcc verとした
- 「>=」 となるような指定が CMake でないため 「>」 を使用する

- gcc のバージョンと有効オプションについては下記のリンクからドキュメントを参照
https://gcc.gnu.org/releases.html

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [X] Did you succeed the build?  
- [X] No warnings for the build?

チケット発行時点で下記のOSでデフォルトでインストールされる gcc でビルドが成功することを確認した
なお、Ubuntu 18.10については、#277 の問題があるためコードを変更して確認、
コード変更したが本チケットはビルドオプションに対する確認のため問題ない。

|OS  |gcc version|  
|:--:|:--:|
|Debian 8 |4.9.2|
|Ubuntu 16.04 | 5.4.0 |
|Debian 9 | 6.3.0 |
|Ubuntu 18.04 | 7.3.0|
|Ubuntu 18.10 | 8.2.0| 
