### PR TITLE
[installer] Added rtshell-aist to installation script for Linux. #320

### DIFF
--- a/build/pkg_install_debian.sh
+++ b/build/pkg_install_debian.sh
@@ -442,7 +442,7 @@ install_branch()
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] install"
     install_packages python-pip
-    rtshell_ret=`pip install rtshell`
+    rtshell_ret=`pip install rtshell-aist`
   fi
 }
 
@@ -500,7 +500,7 @@ uninstall_branch()
 
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] uninstall"
-    rtshell_ret=`pip uninstall -y rtshell`
+    rtshell_ret=`pip uninstall -y rtshell-aist rtctree-aist rtsprofile-aist`
   fi
 }
 

--- a/build/pkg_install_fedora.sh
+++ b/build/pkg_install_fedora.sh
@@ -18,15 +18,15 @@ usage()
 
     $(basename ${0}) [-l all/c++] [-r/-d/-s/-c] [-u]
     $(basename ${0}) [-l python/java] [-r/-d/-c] [-u]
-    $(basename ${0}) [-l openrtp] [-d] [-u]                           
+    $(basename ${0}) [-l openrtp/rtshell] [-d] [-u]                           
 
   Example:
     $(basename ${0})  [= $(basename ${0}) -l c++ -d]
-    $(basename ${0}) -l all -d  [= -l c++ -l python -l java -l openrtp -d]
+    $(basename ${0}) -l all -d  [= -l c++ -l python -l java -l openrtp -l rtshell -d]
     $(basename ${0}) -l c++ -l python -c --yes
 
   Options:
-    -l <argument>  language or tool [c++/python/java/openrtp]
+    -l <argument>  language or tool [c++/python/java/openrtp/rtshell]
     -r             install robot component runtime
     -d             install robot component developer [default]
     -s             install tool_packages for build source packages
@@ -135,7 +135,6 @@ OPT_CORE=false
 OPT_FLG=true
 install_pkgs=""
 uninstall_pkgs=""
-arg_rtshell=false
 }
 
 check_arg()
@@ -149,7 +148,7 @@ check_arg()
     python ) arg_python=true ;;
     java ) arg_java=true ;;
     openrtp ) arg_openrtp=true ;;
-#    rtshell ) arg_rtshell=true ;;
+    rtshell ) arg_rtshell=true ;;
     *) arg_err=-1 ;;
   esac
 }
@@ -422,7 +421,12 @@ install_branch()
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] install"
     install_packages python-pip
-    rtshell_ret=`pip install rtshell`
+    if [ $version_num -lt 29 ] ; then
+      PIP_CMD=pip
+    else
+      PIP_CMD=pip3
+    fi
+    rtshell_ret=`$PIP_CMD install rtshell-aist`
   fi
 }
 
@@ -480,7 +484,12 @@ uninstall_branch()
 
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] uninstall"
-    rtshell_ret=`pip uninstall -y rtshell`
+    if [ $version_num -lt 29 ] ; then
+      PIP_CMD=pip
+    else
+      PIP_CMD=pip3
+    fi
+    rtshell_ret=`$PIP_CMD uninstall -y rtshell-aist rtctree-aist rtsprofile-aist`
   fi
 }
 
@@ -582,7 +591,7 @@ if test "x$arg_all" = "xtrue" ; then
   arg_python=true
   arg_java=true
   arg_openrtp=true
-#  arg_rtshell=true
+  arg_rtshell=true
 
   if test "x$OPT_RT" != "xtrue" && 
      test "x$OPT_DEV" != "xtrue" &&

--- a/build/pkg_install_ubuntu.sh
+++ b/build/pkg_install_ubuntu.sh
@@ -455,7 +455,7 @@ install_branch()
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] install"
     install_packages python-pip
-    rtshell_ret=`pip install rtshell`
+    rtshell_ret=`pip install rtshell-aist`
   fi
 }
 
@@ -513,7 +513,7 @@ uninstall_branch()
 
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] uninstall"
-    rtshell_ret=`pip uninstall -y rtshell`
+    rtshell_ret=`pip uninstall -y rtshell-aist rtctree-aist rtsprofile-aist`
   fi
 }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

close #320

## Identify the Bug

Link to #320


## Description of the Change

- Debian, Ubuntu用スクリプトは「rtshell」->「rtshell-aist」への変更
  - アンインストール時の指定パッケージ不足を修正 
- Fedora用スクリプトは「rtshell-aist」のインストールに対応
  - Python3環境はpip3コマンドを使うように対応

## Verification 

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- 修正スクリプトを使い、下記環境へのrtshellのインストール、コマンドとしてrtpwdの動作確認、rtctreeを使っているサンプルRTCのC++テスト動作が問題ないことを確認
  - Debian 8, 9 (各32/64bit）
  - Ubuntu 14.04, 16.04 (各32/64bit),  18.04, 18.10 (各64bit)
  - Fedora 27, 28, 29  (各32/64bit)
```
sudo sh pkg_install_***.sh -l c++ -l python -l java -l openrtp -l rtshell -d --yes
```
