### PR TITLE
FastRTPSTransportでデータ型の名前を自動的に設定する 

### DIFF
--- a/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.cpp
+++ b/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.cpp
@@ -54,7 +54,8 @@ namespace RTC
         m_endian = endian;
     }
 
-    bool CORBACdrDataPubSubType::serialize(void *data, eprosima::fastrtps::rtps::SerializedPayload_t *payload) {
+    bool CORBACdrDataPubSubType::serialize(void *data, eprosima::fastrtps::rtps::SerializedPayload_t *payload)
+    {
         RTC::ByteData* p_type = (RTC::ByteData*) data;
         if (!m_header_enable)
         {
@@ -122,7 +123,8 @@ namespace RTC
         return true;
     }
 
-    bool CORBACdrDataPubSubType::deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload, void* data) {
+    bool CORBACdrDataPubSubType::deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload, void* data)
+    {
 
         RTC::ByteData* p_type = (RTC::ByteData*) data; 	//Convert DATA to pointer of your type
         eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length); // Object that manages the raw buffer.

--- a/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
@@ -138,7 +138,18 @@ namespace RTC
     }
     else
     {
-        m_dataType = prop.getProperty("data_type", "RTC::CDR_Data");
+        std::string data = prop.getProperty("data_type", "IDL:RTC/CDR_Data:1.0");
+
+        coil::vstring typelist = coil::split(data, ":");
+        if (typelist.size() == 3)
+        {
+            m_dataType = typelist[1];
+            coil::replaceString(m_dataType, "/", "::");
+        }
+        else
+        {
+            m_dataType = data;
+        }
         m_type.init(m_dataType, false);
     }
 
@@ -299,12 +310,9 @@ namespace RTC
    *
    * @endif
    */
-  void FastRTPSInPort::SubListener::onSubscriptionMatched(eprosima::fastrtps::Subscriber* sub, eprosima::fastrtps::rtps::MatchingInfo& info)
+  void FastRTPSInPort::SubListener::onSubscriptionMatched(eprosima::fastrtps::Subscriber* /*sub*/, eprosima::fastrtps::rtps::MatchingInfo& /*info*/)
   {
-      (void)sub;
-      (void)info;
   }
-
   /*!
    * @if jp
    * @brief

--- a/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
@@ -108,7 +108,18 @@ namespace RTC
     }
     else
     {
-        m_dataType = prop.getProperty("data_type", "RTC::CDR_Data");
+        std::string data = prop.getProperty("data_type", "IDL:RTC/CDR_Data:1.0");
+
+        coil::vstring typelist = coil::split(data, ":");
+        if (typelist.size() == 3)
+        {
+            m_dataType = typelist[1];
+            coil::replaceString(m_dataType, "/", "::");
+        }
+        else
+        {
+            m_dataType = data;
+        }
         m_type.init(m_dataType, false);
     }
 

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -52,6 +52,8 @@ namespace RTC
     RTC_DEBUG(("setting dataport.data_type: %s", data_type));
     addProperty("dataport.data_type", data_type);
 
+    m_properties["data_type"] = data_type;
+
     addProperty("dataport.subscription_type", "Any");
   }
 

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -102,6 +102,8 @@ namespace RTC
     // In the FSM4RTC specification, publisher type is defined as "io_mode"
     addProperty("dataport.io_mode", pubs.c_str());
 
+    m_properties["data_type"] = data_type;
+
   }
 
   /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#315 


## Description of the Change

InPortBase、OutPortBaseでプロパティにデータ型名を格納してコネクタプロファイルに反映されるようにした。
FastRTPSInPort、FastRTPSOutPortで文字列を加工して`RTC::Time`のようにfastrtpsgenが生成するファイルと同じ形式にするようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
