### PR TITLE
createComponentで実行コンテキストの名前を空に設定した場合にログを出力する

### DIFF
--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -2785,6 +2785,10 @@ namespace RTC
                 RTC_DEBUG(("p_name none"));
               }
           }
+        else
+          {
+            RTC_DEBUG(("p_name is empty"));
+          }
         ec_args.push_back(p);
         RTC_DEBUG(("New EC properties stored:"));
         RTC_DEBUG_STR((p));


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#307


## Description of the Change

実行コンテキストの名前を設定した場合は`ec.{ec_name}`のプロパティが設定に反映されるが、名前が空でも特に問題は起こらないことが分かった。
念のために名前が空の時にログにメッセージを出力するようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
