### PR TITLE
[compat, modify] use version info to apply diagnostic pragma

### DIFF
--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -227,7 +227,7 @@ namespace RTC
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #endif
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
@@ -236,7 +236,7 @@ namespace RTC
     virtual RTC::ReturnCode_t onEntry() { return RTC::RTC_OK; }
     virtual RTC::ReturnCode_t onInit()  { return RTC::RTC_OK; }
     virtual RTC::ReturnCode_t onExit()  { return RTC::RTC_OK; }
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 #if defined(__clang__)


### PR DESCRIPTION

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#304

## Description of the Change

"-Wsuggest-override” オプションは gcc 5 以上で有効なため、
gcc 5 以上の場合に 対象オプションの diagnostic pragma を有効にする


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
