### PR TITLE
1.2のRTCビルド時に警告が出ないようにする

### DIFF
--- a/src/lib/coil/win32/coil/OS.h
+++ b/src/lib/coil/win32/coil/OS.h
@@ -37,6 +37,9 @@
 #include <stdlib.h>
 #include <winbase.h>
 
+#pragma warning(push)
+#pragma warning(disable:4996)
+
 extern "C"
 {
   extern char *optarg;
@@ -458,5 +461,7 @@ namespace coil
   };
     
 };
+
+#pragma warning(pop)
 
 #endif // COIL_OS_H

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1051,7 +1051,7 @@ namespace RTC
     {
       Guard guard(m_mutex);
       ReturnCode ret(NO_CHANGE);
-      for (int i(0), len(m_listeners.size()); i < len; ++i)
+      for (size_t i(0), len(m_listeners.size()); i < len; ++i)
         {
           ConnectorDataListenerT<DataType>* listener(0);
           listener =

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -250,7 +250,7 @@ namespace RTC
             return true;
           }
       }
-      int r(0);
+      size_t r(0);
       {
         Guard guard(m_connectorsMutex);
         if (m_connectors.size() == 0)
@@ -298,7 +298,7 @@ namespace RTC
     {
       RTC_TRACE(("isEmpty()"));
       if (m_directNewData == true) { return false; }
-      int r(0);
+      size_t r(0);
 
       {
         Guard guard(m_connectorsMutex);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#323 

## Description of the Change

RTCのビルド時に発生しそうな警告だけ場当たり的に対応。



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
