### PR TITLE
実行コンテキストに複数のRTCをアタッチしたときのRTC終了処理見直し

### DIFF
--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -376,6 +376,10 @@ namespace CORBA_RTCUtil
   CORBA::Double get_default_rate(const RTC::RTObject_ptr rtc)
   {
     RTC::ExecutionContext_var ec = get_actual_ec(rtc);
+    if (CORBA::is_nil(ec))
+    {
+        return RTC::BAD_PARAMETER;
+    }
     return ec->get_rate();
   }
   /*!
@@ -395,6 +399,10 @@ namespace CORBA_RTCUtil
   RTC::ReturnCode_t set_default_rate(RTC::RTObject_ptr rtc, const CORBA::Double rate)
   {
     RTC::ExecutionContext_var ec = get_actual_ec(rtc);
+    if (CORBA::is_nil(ec))
+    {
+        return RTC::BAD_PARAMETER;
+    }
     return ec->set_rate(rate);
   }
   /*!
@@ -413,6 +421,10 @@ namespace CORBA_RTCUtil
   CORBA::Double get_current_rate(const RTC::RTObject_ptr rtc, RTC::UniqueId ec_id)
   {
     RTC::ExecutionContext_var ec = get_actual_ec(rtc, ec_id);
+    if (CORBA::is_nil(ec))
+    {
+        return RTC::BAD_PARAMETER;
+    }
     return ec->get_rate();
   }
   /*!
@@ -434,6 +446,10 @@ namespace CORBA_RTCUtil
   RTC::ReturnCode_t set_current_rate(RTC::RTObject_ptr rtc, RTC::UniqueId ec_id, const CORBA::Double rate)
   {
     RTC::ExecutionContext_var ec = get_actual_ec(rtc, ec_id);
+    if (CORBA::is_nil(ec))
+    {
+        return RTC::BAD_PARAMETER;
+    }
     return ec->set_rate(rate);
   }
   /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#248 
そもそもECがデタッチされないだけではなく、exit実行中に例外が発生して処理が途中で終わる問題がある。

## Description of the Change

まずexit関数の以下の部分で外部のEC側が既に終了している場合は例外が発生する。

```CPP
  ReturnCode_t RTObject_impl::exit()
  {
    (省略)
    // detach myself from other EC
    for (CORBA::ULong ic(0), size(m_ecOther.length()); ic < size; ++ic)
      {
        //        m_ecOther[ic]->stop();
        RTC::LightweightRTObject_var comp(this->_this());
        if (!::CORBA::is_nil(m_ecOther[ic]))
          {
            m_ecOther[ic]->remove_component(comp.in());
          }
      }

```

この部分ではECが終了していてもログを残すだけでexit関数自体は終了させないようにした。
ただし、「RTCとECの関連付けを必ず解除してからexitを呼ばなければならない」という仕様だったのであれば、この修正は間違っているため取り下げます。

finalize関数の一部処理について、意図が不明だったため削除しました。

またEC終了時に全てのRTCをデタッチする処理を追加しました。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
