### PR TITLE
Visual Studio 2015でエラーになる問題の修正

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -64,6 +64,7 @@
 #include <fstream>
 #include <iostream>
 #include <utility>
+#include <iterator>
 
 #if defined(minor)
 #undef minor


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#334 の変更でVisual Studio 2015でビルドできなくなった。

## Description of the Change

Visual Studio 2010、2015でstd::back_inserterを使うためには＜iterator＞をインクルードしなければならないため修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
