### PR TITLE
Visual Stduio 2012でエラーが発生した件の対応

### DIFF
--- a/src/lib/coil/win32/coil/OS.cpp
+++ b/src/lib/coil/win32/coil/OS.cpp
@@ -18,6 +18,7 @@
 
 
 #include <coil/OS.h>
+#include <string>
 
 
 namespace coil


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Visual Studio 2012で以下のエラーが発生していた。

```
std::_Tree<_Traits> &,const std::_Tree<_Traits> &)' : could not deduce template argument for 'const std::_Tree<_Traits> &' from 'const std::string' [C:\workspace\build\src\lib\coil\coil200_vc11_objlib.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\include\xstddef(180): error C2784: 'bool std::operator <(const std::move_iterator<_RanIt> &,const std::move_iterator<_RanIt2> &)' : could not deduce template argument for 'const std::move_iterator<_RanIt> &' from 'const std::string' [C:\workspace\build\src\lib\coil\coil200_vc11_objlib.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\include\xstddef(180): error C2784: 'bool std::operator <(const std::reverse_iterator<_RanIt> &,const std::reverse_iterator<_RanIt2> &)' : could not deduce template argument for 'const std::reverse_iterator<_RanIt> &' from 'const std::string' [C:\workspace\build\src\lib\coil\coil200_vc11_objlib.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\include\xstddef(180): error C2784: 'bool std::operator <(const std::_Revranit<_RanIt,_Base> &,const std::_Revranit<_RanIt2,_Base2> &)' : could not deduce template argument for 'const std::_Revranit<_RanIt,_Base> &' from 'const std::string' [C:\workspace\build\src\lib\coil\coil200_vc11_objlib.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\include\xstddef(180): error C2784: 'bool std::operator <(const std::pair<_Ty1,_Ty2> &,const std::pair<_Ty1,_Ty2> &)' : could not deduce template argument for 'const std::pair<_Ty1,_Ty2> &' from 'const std::string' [C:\workspace\build\src\lib\coil\coil200_vc11_objlib.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\include\xstddef(180): error C2676: binary '<' : 'const std::string' does not define this operator or a conversion to a type acceptable to the predefined operator 
```


## Description of the Change

stringをインクルードしていないことが原因だったようなので修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
