### PR TITLE
SdoServiceConsumerを内部からremoveする場合の問題修正

### DIFF
--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
@@ -196,7 +196,7 @@ namespace RTC
         }
       catch (...)
         {
-          m_rtobj->removeSdoServiceConsumer(m_profile.id);
+          m_rtobj->removeSdoServiceConsumerStartThread(m_profile.id);
         }
     }
 

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -3022,8 +3022,22 @@ namespace RTC
   */
   void RTObject_impl::setINSObjRef(RTC::LightweightRTObject_ptr obj)
   {
-	  m_insref = obj;
+      m_insref = obj;
   }
+
+  RTObject_impl::SdoServiceConsumerTerminator::SdoServiceConsumerTerminator()
+    {
+    }
+  void RTObject_impl::SdoServiceConsumerTerminator::setSdoServiceConsumer(SdoServiceAdmin* sdoservice, const char* id)
+    {
+      m_sdoservice = sdoservice;
+      m_id = id;
+    }
+  int RTObject_impl::SdoServiceConsumerTerminator::svc()
+    {
+      m_sdoservice->removeSdoServiceConsumer(m_id.c_str());
+      return 0;
+    }
 
 
 } // namespace RTC

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -72,7 +72,7 @@ namespace RTC
       m_sdoservice(*this),
       m_readAll(false), m_writeAll(false),
       m_readAllCompletion(false), m_writeAllCompletion(false),
-	  m_insref(RTC::LightweightRTObject::_nil())
+	  m_insref(RTC::LightweightRTObject::_nil()), m_sdoconterm(nullptr)
   {
     m_objref = this->_this();
     m_pSdoConfigImpl = new SDOPackage::Configuration_impl(m_configsets,
@@ -851,6 +851,7 @@ namespace RTC
       {
         m_sdoconterm->wait();
         delete m_sdoconterm;
+        m_sdoconterm = nullptr;
       }
     return ret;
   }
@@ -1971,6 +1972,7 @@ namespace RTC
       {
         m_sdoconterm->wait();
         delete m_sdoconterm;
+        m_sdoconterm = nullptr;
       }
     m_sdoconterm = new SdoServiceConsumerTerminator();
     m_sdoconterm->setSdoServiceConsumer(&m_sdoservice, id);

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -846,6 +846,12 @@ namespace RTC
         ret = RTC::RTC_ERROR;
       }
     postOnFinalize(0, ret);
+
+    if (m_sdoconterm != nullptr)
+      {
+        m_sdoconterm->wait();
+        delete m_sdoconterm;
+      }
     return ret;
   }
 

--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -5436,20 +5436,9 @@ namespace RTC
 		: public coil::Task
     {
     public:
-        SdoServiceConsumerTerminator()
-          {
-
-          }
-        void setSdoServiceConsumer(SdoServiceAdmin* sdoservice, const char* id)
-          {
-            m_sdoservice = sdoservice;
-            m_id = id;
-          }
-        int svc() override
-          {
-            m_sdoservice->removeSdoServiceConsumer(m_id.c_str());
-            return 0;
-          }
+        SdoServiceConsumerTerminator();
+        void setSdoServiceConsumer(SdoServiceAdmin* sdoservice, const char* id);
+        int svc() override;
     private:
         SdoServiceAdmin *m_sdoservice;
         std::string m_id;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ComponentObserverConsumerでは、以下のように内部から自身のSdoServiceConsumerを削除する処理がある。

```CPP
    inline void updateStatus(RTC::StatusKind statuskind, const char* msg)
    {
      try
        {
          m_observer->update_status(statuskind, msg);
        }
      catch (...)
        {
          m_rtobj->removeSdoServiceConsumerStartThread(m_profile.id);
        }
    }
```

`removeSdoServiceConsumerStartThread`関数は別スレッドでSDOConsumerを削除する関数であり、updateStatus関数内で削除するとupdateStatus関数内で自身のオブジェクトをdeleteしてしまうため、このように別スレッドで処理するようになっている。

updateStatus内で`removeSdoServiceConsumerStartThread`関数が呼ばれたときに、以下の場合にプロセスが強制終了する可能性がある。

1. 2回以上`removeSdoServiceConsumerStartThread`関数が呼ばれる
1.  RTObjectの終了処理完了後にSdoServiceConsumerの削除処理を開始する

## Description of the Change
1についてはポインタにNULLを設定していなかったことが原因だったため修正した。
2についてはpostOnFinalize直後に削除処理のスレッドが終了するまで待機する記述を追加した



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
