### PR TITLE
Dockerfile for 'devel-rtm:ubuntu18.04' has been updated.

### DIFF
--- a/build/ubuntu_1804/Dockerfile_devel-rtm
+++ b/build/ubuntu_1804/Dockerfile_devel-rtm
@@ -47,7 +47,8 @@ RUN ./configure\
  && make\
  && make install
 
-RUN cp /root/fluent-bit-1.0.4/lib/flb_libco/libco.h /usr/local/include/
+RUN mkdir -p /usr/local/include/lib/flb_libco\
+ && cp /root/fluent-bit-1.0.4/lib/flb_libco/libco.h /usr/local/include/lib/flb_libco/
 
 FROM ubuntu:18.04 as rtm-build
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #359 


## Description of the Change

ご指摘の通り、/usr/local/include/lib/flb_libco/libco.h に配置されるよう修正しました。


## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- ローカル環境にて、このDockerfileで生成するコンテナを起動し、OpenRTMのビルドが通ることを確認
- Dockerイメージは、openrtmのDockerHubへpush済み