### PR TITLE
#351の修正に関連する部分でポインタがnullptrに設定されない場合があったため修正

### DIFF
--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -98,7 +98,7 @@ namespace RTC
       m_properties(default_conf), m_configsets(m_properties.getNode("conf")),
       m_sdoservice(*this),
       m_readAll(false), m_writeAll(false),
-      m_readAllCompletion(false), m_writeAllCompletion(false)
+      m_readAllCompletion(false), m_writeAllCompletion(false), m_sdoconterm(nullptr)
   {
     m_objref = this->_this();
     m_pSdoConfigImpl = new SDOPackage::Configuration_impl(m_configsets,


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change

#351 の修正でRTObject_implのm_sdocontermという変数をコンストラクタでnullptrに設定するようにしたが、引数が異なるコンストラクタでnullptrに設定されなかったので修正した。

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
