### PR TITLE
don't move const-argument.

### DIFF
--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -1273,7 +1273,7 @@ namespace CORBA_RTCUtil
     if (CORBA::is_nil(port1)) { return RTC::BAD_PARAMETER; }
 
     // Connect
-    return connect(std::move(name), prop, port0, port1);
+    return connect(name, prop, port0, port1);
   }
   /*!
    * @if jp


### PR DESCRIPTION
## Description of the Change
他の修正ルールによって引数の型が const & になったことで move は不要になったので削除する。

## Verification 
ビルド確認のみ。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests? 
