### PR TITLE
ManagerのpreShutdownでFastRTPSTransportの終了処理を行う

### DIFF
--- a/src/ext/transport/FastRTPS/FastRTPSManager.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSManager.cpp
@@ -265,5 +265,26 @@ namespace RTC
     }
     return *manager;
   }
+
+  /*!
+   * @if jp
+   * @brief FastRTPManagerが初期化されている場合に終了処理を呼び出す
+   *
+   *
+   * @else
+   * @brief
+   *
+   * @return
+   *
+   *
+   * @endif
+   */
+  void FastRTPSManager::shutdown_global()
+  {
+      if (manager)
+      {
+          manager->shutdown();
+      }
+  }
 }
 

--- a/src/ext/transport/FastRTPS/FastRTPSManager.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSManager.cpp
@@ -123,7 +123,6 @@ namespace RTC
    */
   void FastRTPSManager::shutdown()
   {
-      Guard guard(mutex);
       eprosima::fastrtps::Domain::removeParticipant(m_participant);
       manager = nullptr;
   }
@@ -143,6 +142,7 @@ namespace RTC
    */
   eprosima::fastrtps::Participant* FastRTPSManager::getParticipant()
   {
+      Guard guard(mutex);
       return m_participant;
   }
 
@@ -163,6 +163,7 @@ namespace RTC
    */
   bool FastRTPSManager::registerType(eprosima::fastrtps::TopicDataType* type)
   {
+      Guard guard(mutex);
       if (registeredType(type->getName()))
       {
           return true;
@@ -187,6 +188,7 @@ namespace RTC
    */
   bool FastRTPSManager::registeredType(const char* name)
   {
+      Guard guard(mutex);
       eprosima::fastrtps::TopicDataType* type_;
       return eprosima::fastrtps::Domain::getRegisteredType(m_participant, name, &type_);
   }
@@ -208,6 +210,7 @@ namespace RTC
    */
   bool FastRTPSManager::unregisterType(const char* name)
   {
+      Guard guard(mutex);
       if (!registeredType(name))
       {
           return false;
@@ -281,11 +284,11 @@ namespace RTC
    */
   void FastRTPSManager::shutdown_global()
   {
+      Guard guard(mutex);
       if (manager)
       {
           manager->shutdown();
       }
-      manager = nullptr;
   }
 }
 

--- a/src/ext/transport/FastRTPS/FastRTPSManager.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSManager.cpp
@@ -285,6 +285,7 @@ namespace RTC
       {
           manager->shutdown();
       }
+      manager = nullptr;
   }
 }
 

--- a/src/ext/transport/FastRTPS/FastRTPSManager.h
+++ b/src/ext/transport/FastRTPS/FastRTPSManager.h
@@ -216,6 +216,20 @@ namespace RTC
          * @endif
          */
         static FastRTPSManager& instance(std::string xml_profile_file = "");
+        /*!
+         * @if jp
+         * @brief FastRTPManagerが初期化されている場合に終了処理を呼び出す
+         *
+         *
+         * @else
+         * @brief
+         *
+         * @return
+         *
+         *
+         * @endif
+         */
+        static void shutdown_global();
     private:
         static FastRTPSManager* manager;
         static Mutex mutex;

--- a/src/ext/transport/FastRTPS/FastRTPSTransport.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSTransport.cpp
@@ -20,7 +20,34 @@
 #include "FastRTPSTransport.h"
 #include "FastRTPSOutPort.h"
 #include "FastRTPSInPort.h"
+#include "FastRTPSManager.h"
 
+
+ManagerActionListener::ManagerActionListener()
+{
+
+}
+ManagerActionListener::~ManagerActionListener()
+{
+
+}
+void ManagerActionListener::preShutdown()
+{
+
+}
+void ManagerActionListener::postShutdown()
+{
+    RTC::FastRTPSManager::shutdown_global();
+}
+void ManagerActionListener::postReinit()
+{
+
+}
+
+void ManagerActionListener::preReinit()
+{
+
+}
 
 extern "C"
 {
@@ -33,7 +60,7 @@ extern "C"
    */
   void FastRTPSTransportInit(RTC::Manager* manager)
   {
-    (void)manager;
+
     {
         
       RTC::InPortProviderFactory& factory(RTC::InPortProviderFactory::instance());
@@ -52,6 +79,9 @@ extern "C"
                         ::coil::Destructor< ::RTC::InPortConsumer,
                                             ::RTC::FastRTPSOutPort>);
     }
+
+    ManagerActionListener *listener = new ManagerActionListener();
+    manager->addManagerActionListener(listener);
     
   }
   

--- a/src/ext/transport/FastRTPS/FastRTPSTransport.h
+++ b/src/ext/transport/FastRTPS/FastRTPSTransport.h
@@ -23,6 +23,16 @@
 
 #include <rtm/Manager.h>
 
+class ManagerActionListener : public RTM::ManagerActionListener
+{
+public:
+    ManagerActionListener();
+    ~ManagerActionListener() override;
+    void preShutdown() override;
+    void postShutdown() override;
+    void postReinit() override;
+    void preReinit() override;
+};
 
 
 extern "C"


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

FastRTPSTransportではParticipantの初期化は一度しか実行せず、また同じデータ型を2回登録しない、同じTopicを2回初期化しない等するために、FastRTPSManagerクラスは1つしかインスタンスを生成しないようにしている。
FastRTPSManagerの初期化はFastRTPsで通信するコネクタ生成時に実行されるが、終了処理は実行される仕組みがなかった。

## Description of the Change

ManagerのpreShutdownで終了処理を実行するようにリスナを定義、Managerへの登録を記述した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
