### PR TITLE
unsubscribeInterfaceが呼び出されない問題の修正

### DIFF
--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -73,6 +73,8 @@ namespace RTC
         RTC_ERROR(("connector.size should be 0 in InPortBase's dtor."));
         for (auto & connector : m_connectors)
           {
+            const coil::Properties prop = connector->profile().properties;
+            connector->unsubscribeInterface(prop);
             connector->disconnect();
             delete connector;
           }
@@ -656,6 +658,9 @@ namespace RTC
           {
             // Connector's dtor must call disconnect()
 // RtORB's bug? This causes double delete and segmeentation fault.
+            coil::Properties prop;
+            NVUtil::copyToProperties(prop, connector_profile.properties);
+            (*it)->unsubscribeInterface(prop);
 #ifndef ORB_IS_RTORB
             delete *it;
 #endif

--- a/src/lib/rtm/InPortConnector.cpp
+++ b/src/lib/rtm/InPortConnector.cpp
@@ -173,4 +173,9 @@ namespace RTC
       return BufferStatus::BUFFER_OK;
   }
 
+  void InPortConnector::unsubscribeInterface(const coil::Properties& prop)
+  {
+
+  }
+
 } // namespace RTC

--- a/src/lib/rtm/InPortConnector.cpp
+++ b/src/lib/rtm/InPortConnector.cpp
@@ -173,7 +173,7 @@ namespace RTC
       return BufferStatus::BUFFER_OK;
   }
 
-  void InPortConnector::unsubscribeInterface(const coil::Properties& prop)
+  void InPortConnector::unsubscribeInterface(const coil::Properties& /*prop*/)
   {
 
   }

--- a/src/lib/rtm/InPortConnector.h
+++ b/src/lib/rtm/InPortConnector.h
@@ -358,6 +358,21 @@ namespace RTC
         return false;
     }
 
+    /*!
+     * @if jp
+     * @brief コンシューマのインターフェースの登録を取り消す
+     *
+     * @param prop コネクタプロファイルのプロパティ
+     *
+     * @else
+     * @brief
+     *
+     * @param prop
+     *
+     * @endif
+     */
+    virtual void unsubscribeInterface(const coil::Properties& prop);
+
   protected:
     /*!
      * @if jp

--- a/src/lib/rtm/InPortPullConnector.cpp
+++ b/src/lib/rtm/InPortPullConnector.cpp
@@ -150,5 +150,15 @@ namespace RTC
   {
     m_listeners.connector_[ON_DISCONNECT].notify(m_profile);
   }
+
+  void InPortPullConnector::unsubscribeInterface(const coil::Properties& prop)
+  {
+      if (m_consumer != nullptr)
+      {
+          SDOPackage::NVList nv;
+          NVUtil::copyFromProperties(nv, prop);
+          m_consumer->unsubscribeInterface(nv);
+      }
+  }
 } // namespace RTC
 

--- a/src/lib/rtm/InPortPullConnector.h
+++ b/src/lib/rtm/InPortPullConnector.h
@@ -231,6 +231,20 @@ namespace RTC
      * @endif
      */
     void deactivate() override {}  // do nothing
+    /*!
+     * @if jp
+     * @brief コンシューマのインターフェースの登録を取り消す
+     *
+     * @param prop コネクタプロファイルのプロパティ
+     *
+     * @else
+     * @brief
+     *
+     * @param prop
+     *
+     * @endif
+     */
+    void unsubscribeInterface(const coil::Properties& prop) override;
 
   protected:
     /*!

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -696,6 +696,9 @@ namespace RTC
         if (id == (*it)->id())
           {
             // Connector's dtor must call disconnect()
+            coil::Properties prop;
+            NVUtil::copyToProperties(prop, connector_profile.properties);
+            (*it)->unsubscribeInterface(prop);
             delete *it;
             m_connectors.erase(it);
             RTC_TRACE(("delete connector: %s", id.c_str()));

--- a/src/lib/rtm/OutPortConnector.cpp
+++ b/src/lib/rtm/OutPortConnector.cpp
@@ -183,7 +183,7 @@ namespace RTC
       return CdrBufferBase::BUFFER_OK;
   }
 
-  void OutPortConnector::unsubscribeInterface(const coil::Properties& prop)
+  void OutPortConnector::unsubscribeInterface(const coil::Properties& /*prop*/)
   {
 
   }

--- a/src/lib/rtm/OutPortConnector.cpp
+++ b/src/lib/rtm/OutPortConnector.cpp
@@ -182,4 +182,9 @@ namespace RTC
   {
       return CdrBufferBase::BUFFER_OK;
   }
+
+  void OutPortConnector::unsubscribeInterface(const coil::Properties& prop)
+  {
+
+  }
 } // namespace RTC

--- a/src/lib/rtm/OutPortConnector.h
+++ b/src/lib/rtm/OutPortConnector.h
@@ -300,6 +300,20 @@ namespace RTC
      * @endif
      */
     virtual bool pullDirectMode();
+    /*!
+     * @if jp
+     * @brief コンシューマのインターフェースの登録を取り消す
+     *
+     * @param prop コネクタプロファイルのプロパティ
+     *
+     * @else
+     * @brief
+     *
+     * @param prop
+     *
+     * @endif
+     */
+    virtual void unsubscribeInterface(const coil::Properties& prop);
   protected:
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortPushConnector.cpp
+++ b/src/lib/rtm/OutPortPushConnector.cpp
@@ -242,5 +242,15 @@ namespace RTC
   {
     m_listeners.connector_[ON_DISCONNECT].notify(m_profile);
   }
+
+  void OutPortPushConnector::unsubscribeInterface(const coil::Properties& prop)
+  {
+      if (m_consumer != nullptr)
+      {
+          SDOPackage::NVList nv;
+          NVUtil::copyFromProperties(nv, prop);
+          m_consumer->unsubscribeInterface(nv);
+      }
+  }
 } // namespace RTC
 

--- a/src/lib/rtm/OutPortPushConnector.h
+++ b/src/lib/rtm/OutPortPushConnector.h
@@ -255,6 +255,21 @@ namespace RTC
      */
     CdrBufferBase* getBuffer() override;
 
+    /*!
+     * @if jp
+     * @brief コンシューマのインターフェースの登録を取り消す
+     *
+     * @param prop コネクタプロファイルのプロパティ
+     *
+     * @else
+     * @brief
+     *
+     * @param prop
+     *
+     * @endif
+     */
+    void unsubscribeInterface(const coil::Properties& prop) override;
+
   protected:
     /*!
      * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#373 


## Description of the Change

ROSTransportなどはunsubscribeInterface関数が呼び出されないと異常終了する可能性があるため`unsubscribeInterface`関数が呼び出されるように変更した。

`unsubscribeInterface`関数の引数にコネクタプロファイルが必要のため、OutPortConnector、InPortConnectorに`unsubscribeInterface`関数を追加してInPortBase、OutPortBaseのunsubscribeInterfaces関数内で呼び出すようにした。



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
