### PR TITLE
std::basic_ios::failの戻り値をintにキャストしている箇所の修正

### DIFF
--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -310,7 +310,7 @@ namespace RTC
     std::ifstream infile;
     infile.open(filename.c_str(), std::ios::in);
     // fial() 0: ok, !0: fail
-    if (static_cast<int>(infile.fail()) != 0)
+    if (infile.fail())
       {
         infile.close();
         return false;

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -392,7 +392,7 @@ namespace RTC
     std::ifstream infile;
     infile.open(filename.c_str(), std::ios::in);
     // fial() 0: ok, !0: fail
-    if (static_cast<int>(infile.fail()) != 0)
+    if (infile.fail())
       {
         infile.close();
         return false;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change

以下のようにstd::basic_ios::fail関数の返したbool値をわざわざintにキャストして0と比較している部分があるが無駄なので修正した。

```CPP
if (static_cast<int>(infile.fail()) != 0)
```




## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
