### PR TITLE
win32/coil/Process.cppのcreate_process関数の修正

### DIFF
--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -134,7 +134,7 @@ namespace coil
 
       for(auto & o : out)
       {
-          if (0 < o.size() && o.back() == '\r')
+          if (!o.empty() && o.back() == '\r')
           {
               o.erase(o.size() - 1);
           }

--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -125,10 +125,10 @@ namespace coil
 
 
       DWORD len;
-      DWORD size = GetFileSize(rPipe, NULL);
+      DWORD size = GetFileSize(rPipe, nullptr);
       std::unique_ptr<CHAR[]> Buf(new CHAR[size + 1]);
       Buf[size] = '\0';
-      ReadFile(rPipe, Buf.get(), size, &len, NULL);
+      ReadFile(rPipe, Buf.get(), size, &len, nullptr);
 
       out = coil::split(std::string(Buf.get()), "\n");
 

--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -127,7 +127,7 @@ namespace coil
       DWORD len;
       DWORD size = GetFileSize(rPipe, NULL);
       std::unique_ptr<CHAR> Buf(new CHAR[size+1]);
-      Buf.get()[size] = 0;
+      Buf.get()[size] = '\0';
       ReadFile(rPipe, Buf.get(), size, &len, NULL);
 
       out = coil::split(std::string(Buf.get()), "\n");

--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -126,8 +126,8 @@ namespace coil
 
       DWORD len;
       DWORD size = GetFileSize(rPipe, NULL);
-      std::unique_ptr<CHAR> Buf(new CHAR[size+1]);
-      Buf.get()[size] = '\0';
+      std::unique_ptr<CHAR[]> Buf(new CHAR[size + 1]);
+      Buf[size] = '\0';
       ReadFile(rPipe, Buf.get(), size, &len, NULL);
 
       out = coil::split(std::string(Buf.get()), "\n");

--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -126,15 +126,15 @@ namespace coil
 
       DWORD len;
       DWORD size = GetFileSize(rPipe, NULL);
-      std::unique_ptr<CHAR> Buf(new CHAR[size]);
+      std::unique_ptr<CHAR> Buf(new CHAR[size+1]);
+      Buf.get()[size] = 0;
       ReadFile(rPipe, Buf.get(), size, &len, NULL);
-
 
       out = coil::split(std::string(Buf.get()), "\n");
 
       for(auto & o : out)
       {
-          if (0 < o.size())
+          if (0 < o.size() && o.back() == '\r')
           {
               o.erase(o.size() - 1);
           }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug


1. Windows用coilのcreate_process関数でコマンドの実行結果が正しく取得できない場合がある。
2. コマンドの出力結果の一部が削除される場合がある。

## Description of the Change

以下の内容で修正した。

1. 出力結果を格納する文字列の最後に'\0'を設定
2. '\r'を削除する処理にミスがあったため修正


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
