### PR TITLE
意図しない標準出力を削除

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -359,7 +359,6 @@ namespace RTC
 	  }
 	if (filename.find_first_of('.') == std::string::npos)
 	  {
-	    std::cout <<  m_config["manager.modules.C++.suffixes"] << std::endl;
 	    if (m_config.findNode("manager.modules.C++.suffixes") != 0)
 	      {
 		filename += "." + m_config["manager.modules.C++.suffixes"];
@@ -2901,7 +2900,6 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 		  PortProfile_var prof = ports[i]->get_port_profile();
 		  coil::Properties prop;
 		  NVUtil::copyToProperties(prop, prof->properties);
-		  std::cout << prop;
 		  if ((prop.hasKey("publish_topic") == 0 ||
 			  prop["publish_topic"] == "") &&
 			  (prop.hasKey("subscribe_topic") == 0 ||

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -601,7 +601,6 @@ namespace RTC_exp
   void PeriodicExecutionContext::setCpuAffinity(coil::Properties& props)
   {
     RTC_TRACE(("setCpuAffinity()"));
-    std::cout << props;
     std::string affinity;
     getProperty(props, "cpu_affinity", affinity);
     RTC_DEBUG(("CPU affinity property: %s", affinity.c_str()));


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change

Manager.cpp、PeriodicExecutionContext.cppにポートのプロファイルを標準出力する記述があるが、意図していない処理のため削除した。masterには元々この記述は無かったため1.2のみ修正。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
