### PR TITLE
32bit環境でビルドする際に発生する警告の修正

### DIFF
--- a/src/lib/coil/posix/coil/SharedMemory.cpp
+++ b/src/lib/coil/posix/coil/SharedMemory.cpp
@@ -209,7 +209,7 @@ namespace coil
 		  return -1;
 	  }
 
-	  memcpy(&m_shm[pos],&data[0],size);
+	  memcpy(&m_shm[pos],&data[0],static_cast<size_t>(size));
     
 	  return 0;
   }
@@ -242,7 +242,7 @@ namespace coil
 		  return -1;
 	  }
 
-	  memcpy(&data[0],&m_shm[pos],size);
+	  memcpy(&data[0],&m_shm[pos],static_cast<size_t>(size));
 
 	  return 0;
   }

--- a/src/lib/coil/vxworks/coil/SharedMemory.cpp
+++ b/src/lib/coil/vxworks/coil/SharedMemory.cpp
@@ -174,7 +174,7 @@ namespace coil
 	  {
 		  return -1;
 	  }
-	  memcpy(&m_shm[pos],&data[0],size);
+	  memcpy(&m_shm[pos],&data[0],static_cast<size_t>(size));
 
     
 	  return 0;
@@ -207,7 +207,7 @@ namespace coil
 	  {
 		  return -1;
 	  }
-	  memcpy(&data[0],&m_shm[pos],size);
+	  memcpy(&data[0],&m_shm[pos],static_cast<size_t>(size));
 
 	  return 0;
   }

--- a/src/lib/coil/win32/coil/SharedMemory.cpp
+++ b/src/lib/coil/win32/coil/SharedMemory.cpp
@@ -194,7 +194,7 @@ namespace coil
 		  return -1;
 	  }
 
-	  memcpy(&m_shm[pos],&data[0],size);
+	  memcpy(&m_shm[pos],&data[0], static_cast<size_t>(size));
     
 	  return 0;
   }
@@ -227,7 +227,7 @@ namespace coil
 		  return -1;
 	  }
 
-	  memcpy(&data[0],&m_shm[pos],size);
+	  memcpy(&data[0],&m_shm[pos], static_cast<size_t>(size));
 	  return 0;
   }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

32bit環境でビルドするとwin32/coil/SharedMemory.cppで警告が発生する。

## Description of the Change

unsigned long longをsize_tにstatic_cast変換するように修正した。

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
