### PR TITLE
modernize source code on Linux.

### DIFF
--- a/examples/StaticFsm/Display.h
+++ b/examples/StaticFsm/Display.h
@@ -41,7 +41,7 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(const char* name) : m_name(name) {}
-  virtual ~DataListener()
+  ~DataListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
@@ -70,7 +70,7 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(const char* name) : m_name(name) {}
-  virtual ~ConnListener()
+  ~ConnListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
@@ -96,7 +96,7 @@ class Display
 {
  public:
   Display(RTC::Manager* manager);
-  ~Display();
+  ~Display() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry()

--- a/examples/StaticFsm/Inputbutton.h
+++ b/examples/StaticFsm/Inputbutton.h
@@ -38,7 +38,7 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(const char* name) : m_name(name) {}
-  virtual ~DataListener()
+  ~DataListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
@@ -67,7 +67,7 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(const char* name) : m_name(name) {}
-  virtual ~ConnListener()
+  ~ConnListener() override
   {
     std::cout << "dtor of " << m_name << std::endl;
   }
@@ -93,7 +93,7 @@ class Inputbutton
 {
  public:
   Inputbutton(RTC::Manager* manager);
-  ~Inputbutton();
+  ~Inputbutton() override;
 
   // The initialize action (on CREATED->ALIVE transition)
   // formaer rtc_init_entry()

--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -24,7 +24,7 @@
 namespace RTC
 {
   // Static variables initialization
-  flb_ctx_t* FluentBitStream::s_flbContext = NULL;
+  flb_ctx_t* FluentBitStream::s_flbContext = nullptr;
   int FluentBitStream::s_instance = 0;
 
   //============================================================
@@ -32,8 +32,8 @@ namespace RTC
   FluentBitStream::FluentBitStream()
     : m_pos(0)
   {
-    for (size_t i(0); i < BUFFER_LEN; ++i) { m_buf[i] = '\0'; }
-    if (s_flbContext == NULL)
+    for (char & i : m_buf) { i = '\0'; }
+    if (s_flbContext == nullptr)
       {
         s_flbContext = flb_create();
       }
@@ -56,7 +56,7 @@ namespace RTC
 
 
     // Default lib-input setting
-    FlbHandler flbhandler = flb_input(s_flbContext, (char*)"lib", NULL);
+    FlbHandler flbhandler = flb_input(s_flbContext, (char*)"lib", nullptr);
     flb_input_set(s_flbContext, flbhandler, "tag", prop.getName(), NULL);
     m_flbIn.push_back(flbhandler);
 
@@ -98,7 +98,7 @@ namespace RTC
   {
     std::string plugin = prop["plugin"];
     FlbHandler flbout = flb_output(s_flbContext,
-                                   (char*)plugin.c_str(), NULL);
+                                   (char*)plugin.c_str(), nullptr);
 
     m_flbOut.push_back(flbout);
     const std::vector<Properties*>& leaf = prop.getLeaf();
@@ -115,7 +115,7 @@ namespace RTC
     std::string plugin = prop["plugin"];
     
     FlbHandler flbin = flb_input(s_flbContext,
-                                 (char*)plugin.c_str(), NULL);
+                                 (char*)plugin.c_str(), nullptr);
     m_flbIn.push_back(flbin);
     const std::vector<Properties*>& leaf = prop.getLeaf();
     for(auto & lprop : leaf)
@@ -134,7 +134,7 @@ namespace RTC
       {
 
         n = snprintf(tmp, sizeof(tmp) - 1,
-                     "[%ld, {\"message\": \"%s\", \"time\":\"%s\",\"name\":\"%s\",\"level\":\"%s\"}]", time(NULL), mes, date.c_str(), name.c_str(), Logger::getLevelString(level).c_str());
+                     R"([%ld, {"message": "%s", "time":"%s","name":"%s","level":"%s"}])", time(nullptr), mes, date.c_str(), name.c_str(), Logger::getLevelString(level).c_str());
 
         flb_lib_push(s_flbContext, flb, tmp, n);
       }

--- a/src/ext/logger/fluentbit_stream/FluentBit.h
+++ b/src/ext/logger/fluentbit_stream/FluentBit.h
@@ -243,7 +243,7 @@ namespace RTC
      *
      * @endif
      */
-    ~FluentBit(void) override;
+    ~FluentBit() override;
 
     /*!
      * @if jp


### PR DESCRIPTION
## Description of the Change

主に fluent-bit サポートに対する C++11 対応。
- 0 or NULL -> nullptr
- Range-based for
- Raw string literals
- func(void) -> func()

StaticFsm のサンプルコンポーネントの修正。
- virtual -> override
  virtual つけ忘れが是正されているので動作が変わる可能性あることに注意。

## Verification 
ビルド確認のみ。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
