### PR TITLE
Use std::min & std::max on MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,6 +559,7 @@ function(openrtm_common_set_compile_definitions target)
 				noexcept=_NOEXCEPT
 			>
 		>
+		$<$<PLATFORM_ID:Windows>:NOMINMAX> # disable min/max macro in Windows.h
 	)
 endfunction()
 
@@ -767,7 +768,7 @@ endfunction()
 
 function(openrtm_gencode_set_compile_definitions target)
   target_compile_definitions(${target} PRIVATE
-		# none
+		$<$<PLATFORM_ID:Windows>:NOMINMAX> # disable min/max macro in Windows.h
 	)
 endfunction()
 


### PR DESCRIPTION
## Description of the Change

Windws.h のマクロ min, max を無効化して、std:min, std:max を使用する。
C++標準の通りに動作するように、Linux 側に合わせる。

## Verification 
ビルド確認のみ。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?