### PR TITLE
コンポーネントオブザーバーのタイマースレッドをonFinalizeで終了する処理に変更

### DIFF
--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
@@ -302,6 +302,15 @@ namespace RTC
      */
     void unsetECHeartbeat();
 
+    /*!
+     * @if jp
+     * @brief タイマースレッドを停止する
+     * @else
+     * @brief stop timer thread
+     * @endif
+     */
+    void stopTimer();
+
     //============================================================
     // Component status related functions
     /*!
@@ -507,6 +516,9 @@ namespace RTC
       }
       void onFinalize(UniqueId ec_id, ReturnCode_t ret)
       {
+        m_coc.unsetRTCHeartbeat();
+        m_coc.unsetECHeartbeat();
+        m_coc.stopTimer();
         onGeneric("FINALIZE:", ec_id, ret);
       }
 
@@ -698,9 +710,9 @@ namespace RTC
 
     /*!
      * @if jp
-     * @brief ConfigActionListener
+     * @brief FSMActionListener
      * @else
-     * @brief ConfigActionListener
+     * @brief FSMActionListener
      * @endif
      */
     class FSMAction

--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -153,7 +153,6 @@ namespace RTC
     unsetPortProfileListeners();
     unsetExecutionContextListeners();
     unsetConfigurationListeners();
-    unsetHeartbeat();
   }
 
   //============================================================
@@ -271,7 +270,10 @@ namespace RTC
    */
   void ComponentObserverConsumer::heartbeat()
   {
-    updateStatus(OpenRTM::HEARTBEAT, "");
+    if (m_heartbeat)
+      {
+        updateStatus(OpenRTM::HEARTBEAT, "");
+      }
   }
 
   /*!
@@ -300,6 +302,7 @@ namespace RTC
         tm = m_interval;
         m_hblistenerid = m_timer.
           registerListenerObj(this, &ComponentObserverConsumer::heartbeat, tm);
+        m_heartbeat = true;
         m_timer.start();
       }
     else
@@ -348,6 +351,7 @@ namespace RTC
     m_heartbeat = false;
     m_hblistenerid = nullptr;
     m_timer.stop();
+    m_timer.wait();
   }
 
 

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -345,6 +345,7 @@ namespace RTC
       }
       void onFinalize(UniqueId ec_id, ReturnCode_t ret)
       {
+        m_coc.unsetHeartbeat();
         onGeneric("FINALIZE:", ec_id, ret);
       }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

コンポーネントオブザーバーのRTC終了通知(`RTC_STATUS ,  FINALIZE:0`)よりも後にハートビートが送信されるRTSEで不具合が発生する。

## Description of the Change

onFinalize関数内でタイマースレッドを終了する処理に変更した。
このため終了通知後にハートビートが送信されなくなった。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
