### PR TITLE
コンポーネントオブザーバーのタイマースレッドをonFinalizeで終了する処理に変更(1.2)

### DIFF
--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -153,7 +153,6 @@ namespace RTC
     unsetPortProfileListeners();
     unsetExecutionContextListeners();
     unsetConfigurationListeners();
-    unsetHeartbeat();
   }
 
   //============================================================
@@ -271,7 +270,10 @@ namespace RTC
    */
   void ComponentObserverConsumer::heartbeat()
   {
-    updateStatus(OpenRTM::HEARTBEAT, "");
+    if (m_heartbeat)
+      {
+        updateStatus(OpenRTM::HEARTBEAT, "");
+      }
   }
 
   /*!
@@ -300,6 +302,7 @@ namespace RTC
         tm = m_interval;
         m_hblistenerid = m_timer.
           registerListenerObj(this, &ComponentObserverConsumer::heartbeat, tm);
+        m_heartbeat = true;
         m_timer.start();
       }
     else
@@ -348,6 +351,7 @@ namespace RTC
     m_heartbeat = false;
     m_hblistenerid = 0;
     m_timer.stop();
+    m_timer.wait();
   }
 
 

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -343,6 +343,7 @@ namespace RTC
       }
       void onFinalize(UniqueId ec_id, ReturnCode_t ret)
       {
+        m_coc.unsetHeartbeat();
         onGeneric("FINALIZE:", ec_id, ret);
       }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#408 の修正をRELENG_1_2に適用。


## Description of the Change



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
