### PR TITLE
ログをファイルに出力する場合に標準出力をしないようにする

### DIFF
--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -364,7 +364,6 @@ namespace RTC
 
     for (auto & file : files)
       {
-        std::cout << "#### file: " << file << std::endl;
         if (std::count(s_files.begin(), s_files.end(), file) > 0) { continue; }
         m_fileName = file;
         s_files.push_back(file);
@@ -373,6 +372,7 @@ namespace RTC
         coil::normalize(fname);
         if (fname == "stdout")
           {
+            std::cout << "#### file: " << file << std::endl;
             std::cout << "##### STDOUT!! #####" << std::endl;
             m_stdout = new StdoutStream();
             if (escape_sequence)
@@ -387,6 +387,7 @@ namespace RTC
           }
         else if (fname == "stderr")
           {
+            std::cout << "#### file: " << file << std::endl;
             std::cout << "##### STDOUT!! #####" << std::endl;
             m_stdout = new StderrStream();
             if (escape_sequence)
@@ -401,7 +402,6 @@ namespace RTC
           }
         else
           {
-            std::cout << "##### file #####" << std::endl;
             m_fileout = new FileStream(file);
             if (escape_sequence)
             {


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
OpenRTM-aist 1.2からログファイル名などを標準出力するようになっているが、ファイル出力する場合は標準出力は出ないようにしたい。

```
#### file: ./rtc1172.log
##### file #####
```


## Description of the Change

ログをファイルに出力する場合は何も標準出力しないようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
