### PR TITLE
State machine behavior bug fixed. #417

### DIFF
--- a/src/lib/rtm/RTObjectStateMachine.cpp
+++ b/src/lib/rtm/RTObjectStateMachine.cpp
@@ -246,6 +246,7 @@ namespace RTC_impl
 
   void RTObjectStateMachine::onDeactivated(const ExecContextStates&  /*st*/)
   {
+    if (isNextState(RTC::ERROR_STATE)) { return; }
     // call Servant
     if (m_rtobjPtr != nullptr)
       {
@@ -307,6 +308,7 @@ namespace RTC_impl
   // RTC::DataflowComponentAction
   void RTObjectStateMachine::onExecute(const ExecContextStates&  /*st*/)
   {
+    if (isNextState(RTC::ERROR_STATE)) { return; }
     static int count;
     double max_interval, min_interval, mean_interval, stddev;
     // call Servant
@@ -367,6 +369,7 @@ namespace RTC_impl
 
   void RTObjectStateMachine::onStateUpdate(const ExecContextStates&  /*st*/)
   {
+    if (isNextState(RTC::ERROR_STATE)) { return; }
     // call Servant
     if (m_rtobjPtr != nullptr)
       {

--- a/src/lib/rtm/RTObjectStateMachine.cpp
+++ b/src/lib/rtm/RTObjectStateMachine.cpp
@@ -246,7 +246,6 @@ namespace RTC_impl
 
   void RTObjectStateMachine::onDeactivated(const ExecContextStates&  /*st*/)
   {
-    if (isNextState(RTC::ERROR_STATE)) { return; }
     // call Servant
     if (m_rtobjPtr != nullptr)
       {


### PR DESCRIPTION
When RTC callback returned an error in the Active state, onExecute/onStateUpdate/onDeactivated must be skipped.

## Identify the Bug
onActivated() でエラーを返したときに、onExecute/onStateUpdate/onDeactivated が実行されてからonAborting/onErrorが順に実行される。
OMG RTC Specification p.14 ( https://www.omg.org/spec/RTC/1.1/PDF ) より、Active->Error 遷移のガード条件は [ReturnCode != OK]/on_aborting であるので、図の通り解釈するならば、いかなるイベント時も戻り値がOK以外であれば、即座に on_aborting を実行し、Error状態に遷移しなければならない。

## Description of the Change

1.1->1.2 でRTCのStateMachineの実装を大幅に変更したが、その際にこれらのコールバックをスキップする処理を入れるのを忘れていた。以下のコールバック実行時に、次の状態がERROR状態の場合処理を実行せずスキップするロジックを挿入したことで、このバグが解決した。

* onExecute
* onStateUpdate
* onDeactivate

## Verification 

テストコードを作成し検証済み。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
