### PR TITLE
ConnectorInfoのコピーコンストラクタの処理が空のためメンバ変数がコピーされない

### DIFF
--- a/src/lib/rtm/ConnectorBase.cpp
+++ b/src/lib/rtm/ConnectorBase.cpp
@@ -36,14 +36,8 @@ namespace RTC
    *
    * @endif
    */
-  ConnectorInfo::ConnectorInfo(const ConnectorInfo& info)
+  ConnectorInfo::ConnectorInfo(const ConnectorInfo& info) : name(info.name), id(info.id), ports(info.ports), properties(info.properties)
   {
-      name = info.name;
-      id = info.id;
-      ports = info.ports;
-      properties = info.properties;
-
-
   }
 
   /*!

--- a/src/lib/rtm/ConnectorBase.cpp
+++ b/src/lib/rtm/ConnectorBase.cpp
@@ -36,8 +36,14 @@ namespace RTC
    *
    * @endif
    */
-  ConnectorInfo::ConnectorInfo(const ConnectorInfo&)
+  ConnectorInfo::ConnectorInfo(const ConnectorInfo& info)
   {
+      name = info.name;
+      id = info.id;
+      ports = info.ports;
+      properties = info.properties;
+
+
   }
 
   /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#390 でConnectorInfoのコピーコンストラクタを定義したが、値を設定する処理がないためコネクタのIDやプロパティがコピーされずエラーになる。これ以前はデフォルトコピーコンストラクタで値がすべてコピーされていたので問題がなかったみたいです。


## Description of the Change

メンバ変数をコピーするように修正した。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
