### PR TITLE
already_connected関数に同一のポートを2個指定した場合にfalseを返すようにする

### DIFF
--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -858,6 +858,10 @@ namespace CORBA_RTCUtil
   bool already_connected(const RTC::PortService_ptr localport,
                          const RTC::PortService_ptr otherport)
   {
+    if (localport->_is_equivalent(otherport))
+      {
+        return false;
+      }
     RTC::ConnectorProfileList_var conprof;
     conprof = localport->get_connector_profiles();
     for (CORBA::ULong i(0); i < conprof->length(); ++i)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

already_connected関数に同じポートを2個入力した場合に、コネクタが1つでもあるとtrueを返す。
同じポート同士を接続するという事は通常あり得ないのでfalseを返すべき。

## Description of the Change

同一のポートを入力した場合はfalseを返すようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
