### PR TITLE
config_coil.hの_REENTRANTを削除

### DIFF
--- a/src/lib/coil/configure.ac
+++ b/src/lib/coil/configure.ac
@@ -124,7 +124,6 @@ case $system in
 	;;	
 [Linux*)]
 	AC_DEFINE([COIL_OS_LINUX], [TRUE], [OS is Linux])
-	AC_DEFINE([_REENTRANT], [TRUE], [Multi Thread Support])
 	AC_DEFINE([COIL_PLATFORM], [POSIX], [Platform is POSIX])
 	LDFLAGS="$LDFLAGS -luuid -lrt -ldl"
 	COIL_PLATFORM=posix


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#411 


## Description of the Change

config_coil.hで_REENTRANTを定義しないようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
