### PR TITLE
place crc16 table to ROM.

### DIFF
--- a/src/lib/coil/common/coil/crc.cpp
+++ b/src/lib/coil/common/coil/crc.cpp
@@ -46,7 +46,7 @@ namespace coil
    */
   unsigned short crc16(const char* str, size_t len)
   {
-    static unsigned short crc16tab[256] =
+    static const unsigned short crc16tab[256] =
       {
         0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,
         0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,


### PR DESCRIPTION
## Identify the Bug

RAM を消費する大きなテーブルが存在する。

## Description of the Change

static const にして ROM に配置する。

## Verification 
未使用関数に見えるので、動作に問題ない。
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
