### PR TITLE
Use sleep_for instead of sleep/usleep.

### DIFF
--- a/examples/Analyzer/Analyzer.cpp
+++ b/examples/Analyzer/Analyzer.cpp
@@ -210,7 +210,7 @@ RTC::ReturnCode_t Analyzer::onExecute(RTC::UniqueId  /*ec_id*/)
 	}
 	
 	//coil::TimeValue start1(coil::gettimeofday());
-	//coil::sleep(coil::TimeValue(0.3));
+	//std::this_thread::sleep_for(std::chrono::milliseconds(300));
 	//coil::TimeValue end1(coil::gettimeofday());
 	//std::cout << "Analyzer: " << (double)(end1 - start1) << std::endl;
 	//std::cout << "Analyzer: " << m_sleep_time - (double)(end - start) << std::endl;

--- a/examples/AutoTest/AutoTestOut.cpp
+++ b/examples/AutoTest/AutoTestOut.cpp
@@ -124,7 +124,7 @@ RTC::ReturnCode_t AutoTestOut::onDeactivated(RTC::UniqueId ec_id)
 RTC::ReturnCode_t AutoTestOut::onExecute(RTC::UniqueId ec_id)
 {
 
-  coil::usleep(100000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   //onexecuteでファイルから3行ずつ読み込み送る
   std::vector<std::string> vstr;

--- a/examples/ConfigSample/ConfigSample.cpp
+++ b/examples/ConfigSample/ConfigSample.cpp
@@ -172,11 +172,11 @@ RTC::ReturnCode_t ConfigSample::onExecute(RTC::UniqueId  /*ec_id*/)
     }
   if (m_int_param0 > 1000 && m_int_param0 < 1000000)
     {
-      coil::usleep(m_int_param0);
+      std::this_thread::sleep_for(std::chrono::microseconds(m_int_param0));
     }
   else
     {
-      coil::usleep(100000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
   return RTC::RTC_OK;
 }

--- a/examples/ExtTrigger/ConsoleOut.cpp
+++ b/examples/ExtTrigger/ConsoleOut.cpp
@@ -70,7 +70,7 @@ RTC::ReturnCode_t ConsoleOut::onExecute(RTC::UniqueId  /*ec_id*/)
       std::cout << "TimeStamp: " << m_in.tm.sec << "[s] ";
       std::cout << m_in.tm.nsec << "[ns]" << std::endl;
     }
-  coil::usleep(1000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
   return RTC::RTC_OK;
 }

--- a/examples/HelloWorld/HelloRTWorldComp.cpp
+++ b/examples/HelloWorld/HelloRTWorldComp.cpp
@@ -41,7 +41,7 @@ void MyModuleInit(RtcManager* manager)
   std::string name;
   RtcBase* comp;
   comp = manager->createComponent("HelloRTWorld", "example", name);
-  coil::usleep(10000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   comp->rtc_start();
 
 }

--- a/examples/SeqIO/SeqOut.cpp
+++ b/examples/SeqIO/SeqOut.cpp
@@ -338,11 +338,11 @@ RTC::ReturnCode_t SeqOut::onExecute(RTC::UniqueId  /*ec_id*/)
   // Connector Listener Dump check
   if(g_Listener_dump_enabled)
     {
-      coil::usleep(1000000);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
   else
     {
-      coil::usleep(200000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
   return RTC::RTC_OK;

--- a/examples/SimpleIO/ConsoleOut.cpp
+++ b/examples/SimpleIO/ConsoleOut.cpp
@@ -106,7 +106,7 @@ RTC::ReturnCode_t ConsoleOut::onExecute(RTC::UniqueId  /*ec_id*/)
       std::cout << "TimeStamp: " << m_in.tm.sec << "[s] ";
       std::cout << m_in.tm.nsec << "[ns]" << std::endl;
     }
-  coil::usleep(1000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
   return RTC::RTC_OK;
 }

--- a/examples/SimpleService/MyServiceSVC_impl.cpp
+++ b/examples/SimpleService/MyServiceSVC_impl.cpp
@@ -48,7 +48,7 @@ char* MyServiceSVC_impl::echo(const char* msg)
   for (int i(0); i < 10; ++i)
     {
       std::cout << "Message: " << msg << std::endl;
-      coil::sleep(1);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
   std::cout << "MyService::echo() was finished" << std::endl;
 
@@ -76,7 +76,7 @@ void MyServiceSVC_impl::set_value(CORBA::Float value)
     {
       std::cout << "Input value: " << value;
       std::cout << ", Current value: " << m_value << std::endl;
-      coil::sleep(1);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
   std::cout << "MyService::set_value() was finished" << std::endl;
 

--- a/examples/StaticFsm/Display.cpp
+++ b/examples/StaticFsm/Display.cpp
@@ -107,7 +107,7 @@ RTC::ReturnCode_t Display::onExecute(RTC::UniqueId  /*ec_id*/)
       std::cout << "TimeStamp: " << m_in.tm.sec << "[s] ";
       std::cout << m_in.tm.nsec << "[ns]" << std::endl;
     }
-  coil::usleep(1000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
   return RTC::RTC_OK;
 }

--- a/examples/StaticFsm/Microwave.cpp
+++ b/examples/StaticFsm/Microwave.cpp
@@ -74,7 +74,7 @@ RTC::ReturnCode_t Microwave::onInitialize()
 
 RTC::ReturnCode_t Microwave::onExecute(RTC::UniqueId  /*ec_id*/)
 {
-  //coil::usleep(1000000);
+  //std::this_thread::sleep_for(std::chrono::seconds(1));
     m_fsm.run_event();
 
   return RTC::RTC_OK;

--- a/examples/StringIO/StringIn.cpp
+++ b/examples/StringIO/StringIn.cpp
@@ -82,7 +82,7 @@ RtmRes StringIn::rtc_active_entry()
 
 RtmRes StringIn::rtc_active_do()
 {
-  while (!m_string_inIn.isNew()) coil::usleep(100000);
+  while (!m_string_inIn.isNew()) std::this_thread::sleep_for(std::chrono::milliseconds(100));
   m_string_inIn.read();
   std::cout << m_string_in.data << std::endl;
   return RTM_OK;

--- a/src/ext/ec/logical_time/example/LTTSampleComp.cpp
+++ b/src/ext/ec/logical_time/example/LTTSampleComp.cpp
@@ -152,7 +152,7 @@ int main (int argc, char** argv)
       std::cout << "getting time   (time: " << sec;
       std::cout << " [s], " << usec << " [usec])" << std::endl;
       std::cout << std::endl;
-      coil::usleep(500000);
+      std::this_thread::sleep_for(std::chrono::millisecconds(500));
     }
   manager->shutdown();
   return 0;

--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -66,7 +66,7 @@ namespace RTC
       }
 
       {
-        coil::sleep(coil::TimeValue(1.0));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         std::lock_guard<std::mutex> guard(mutex);
       }
   }

--- a/src/lib/coil/posix/coil/Time.h
+++ b/src/lib/coil/posix/coil/Time.h
@@ -26,7 +26,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <ctime>
-#include <iostream>
+#include <chrono>
+#include <thread>
 
 namespace coil
 {
@@ -53,10 +54,10 @@ namespace coil
    */
   inline int sleep(TimeValue interval)
   {
-    timeval tv;
-    tv.tv_sec = interval.sec();
-    tv.tv_usec = interval.usec();
-    return ::select(0, nullptr, nullptr, nullptr, &tv);
+    auto t = std::chrono::seconds(interval.sec())
+             + std::chrono::microseconds(interval.usec());
+    std::this_thread::sleep_for(t);
+    return 0;
   }
 
   /*!

--- a/src/lib/coil/posix/coil/Time.h
+++ b/src/lib/coil/posix/coil/Time.h
@@ -30,33 +30,6 @@
 
 namespace coil
 {
-
-  /*!
-   * @if jp
-   * @brief 指定された秒間は処理を休止する
-   *
-   * 指定された秒間は処理を休止する。
-   *
-   * @param seconds 秒数
-   *
-   * @return 0: 成功, >0: 失敗
-   *
-   * @else
-   * @brief Stop a processing at specified second time
-   *
-   * Stop a processing at specified second time.
-   *
-   * @param seconds Second time
-   *
-   * @return 0: successful, >0: failed
-   *
-   * @endif
-   */
-  inline unsigned int sleep(unsigned int seconds)
-  {
-    return ::sleep(seconds);
-  }
-
   /*!
    * @if jp
    * @brief 指定された秒間は処理を休止する
@@ -84,32 +57,6 @@ namespace coil
     tv.tv_sec = interval.sec();
     tv.tv_usec = interval.usec();
     return ::select(0, nullptr, nullptr, nullptr, &tv);
-  }
-
-  /*!
-   * @if jp
-   * @brief 指定されたマイクロ秒間は処理を休止する
-   *
-   * 指定されたマイクロ秒間は処理を休止する。
-   *
-   * @param usec マイクロ秒数
-   *
-   * @return 0: 成功, -1: 失敗
-   *
-   * @else
-   * @brief Stop a processing at specified micro second time
-   *
-   * Stop a processing at specified micro second time.
-   *
-   * @param usec Micro second time
-   *
-   * @return 0: successful, -1: failed
-   *
-   * @endif
-   */
-  inline int usleep(useconds_t usec)
-  {
-    return ::usleep(usec);
   }
 
   /*!

--- a/src/lib/coil/win32/coil/Time.cpp
+++ b/src/lib/coil/win32/coil/Time.cpp
@@ -20,64 +20,6 @@
 
 namespace coil
 {
-  int sleep(TimeValue interval)
-  {
-    struct timeval tv;
-    WSADATA wsa;
-    SOCKET ssoc;
-    fd_set mask;
-    WORD ver;
-    int iret;
-
-    // The WSAStartup function initiates use of the Winsock DLL by a process.
-    ver = MAKEWORD(2, 2);
-    iret = ::WSAStartup(ver, &wsa);
-    if ( iret != 0 )
-      {
-        return iret;
-      }
-
-    // The socket function creates a socket that is bound to
-    // a specific transport service provider.
-    // It is assumed AF_INET because there is no AF_UNIX for Windows.
-    ssoc = ::socket(AF_INET,
-                    SOCK_STREAM,
-                    0);
-    if (ssoc == INVALID_SOCKET)
-      {
-        iret = ::WSAGetLastError();
-        ::WSACleanup();
-        return iret;
-      }
-
-
-    // Initialize fd_set.
-    FD_ZERO(&mask);
-    // Register the reading socket.
-    FD_SET(ssoc, &mask);
-
-    tv.tv_sec = interval.sec();
-    tv.tv_usec = interval.usec();
-    iret = ::select(static_cast<int>(ssoc+1), &mask, nullptr, nullptr, &tv);
-    if ( iret == SOCKET_ERROR )
-      {
-        iret = ::WSAGetLastError();
-        // The closesocket function closes an existing socket.
-        ::closesocket(ssoc);
-        // The WSACleanup function terminates
-        // use of the Winsock 2 DLL (Ws2_32.dll).
-        ::WSACleanup();
-        return iret;
-      }
-
-    // The closesocket function closes an existing socket.
-    ::closesocket(ssoc);
-
-    // The WSACleanup function terminates use of the Winsock 2 DLL (Ws2_32.dll).
-    ::WSACleanup();
-    return iret;
-  }
-
   int gettimeofday(struct timeval *tv, struct timezone *tz)
   {
       FILETIME        ftime;

--- a/src/lib/coil/win32/coil/Time.cpp
+++ b/src/lib/coil/win32/coil/Time.cpp
@@ -20,8 +20,6 @@
 
 namespace coil
 {
-  // no implementation
-
   int sleep(TimeValue interval)
   {
     struct timeval tv;
@@ -75,55 +73,6 @@ namespace coil
     // The closesocket function closes an existing socket.
     ::closesocket(ssoc);
 
-    // The WSACleanup function terminates use of the Winsock 2 DLL (Ws2_32.dll).
-    ::WSACleanup();
-    return iret;
-  }
-
-  int usleep(unsigned int usec)
-  {
-    struct timeval tv;
-    int iret;
-    WORD ver;
-    WSADATA wsa;
-    fd_set mask;
-    SOCKET ssoc;
-
-    // The WSAStartup function initiates use of the Winsock DLL by a process.
-    ver = MAKEWORD(2, 2);
-    iret = ::WSAStartup(ver, &wsa);
-    if ( iret != 0 )
-      {
-        return iret;
-      }
-
-    // The socket function creates a socket that is
-    // bound to a specific transport service provider.
-    ssoc = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (ssoc == INVALID_SOCKET)
-      {
-        iret = ::WSAGetLastError();
-        ::WSACleanup();
-        return iret;
-      }
-    FD_ZERO(&mask);
-    FD_SET(ssoc, &mask);
-
-    tv.tv_sec = static_cast<long>(usec) / 1000000;
-    tv.tv_usec = static_cast<long>(usec) % 1000000;
-    iret = ::select(static_cast<int>(ssoc+1), &mask, nullptr, nullptr, &tv);
-    if ( iret == SOCKET_ERROR )
-      {
-        iret = ::WSAGetLastError();
-        // The closesocket function closes an existing socket.
-        ::closesocket(ssoc);
-        // The WSACleanup function terminates
-        // use of the Winsock 2 DLL (Ws2_32.dll).
-        ::WSACleanup();
-        return iret;
-      }
-    // The closesocket function closes an existing socket.
-    ::closesocket(ssoc);
     // The WSACleanup function terminates use of the Winsock 2 DLL (Ws2_32.dll).
     ::WSACleanup();
     return iret;

--- a/src/lib/coil/win32/coil/Time.h
+++ b/src/lib/coil/win32/coil/Time.h
@@ -31,6 +31,8 @@
 #include <time.h>
 #include <coil/config_coil.h>
 #include <coil/TimeValue.h>
+#include <chrono>
+#include <thread>
 
 namespace coil
 {
@@ -62,7 +64,13 @@ namespace coil
    *
    * @endif
    */
-  int sleep(TimeValue interval);
+  inline int sleep(TimeValue interval)
+  {
+    auto t = std::chrono::seconds(interval.sec())
+             + std::chrono::microseconds(interval.usec());
+    std::this_thread::sleep_for(t);
+    return 0;
+  }
 
   /*!
    * @if jp

--- a/src/lib/coil/win32/coil/Time.h
+++ b/src/lib/coil/win32/coil/Time.h
@@ -41,37 +41,7 @@ namespace coil
     int tz_dsttime;
   };
 
-  /*!
-   * @if jp
-   * @brief 指定された秒間は処理を休止する
-   *
-   * 指定された秒間は処理を休止する。
-   *
-   * @param seconds 秒数
-   *
-   * @return 0: 成功
-   *
-   * @else
-   * @brief Stop a processing at specified second time
-   *
-   * Stop a processing at specified second time.
-   *
-   * @param seconds Second time
-   *
-   * @return 0: successful
-   *
-   * @endif
-   */
-  inline unsigned int sleep(unsigned int seconds)
-  {
-
-    ::Sleep(seconds *1000);
-    return 0;
-  }
-
-//static short m_time_DLLinit_count = 0;
-
-  /*!
+/*!
    * @if jp
    * @brief 指定された秒間は処理を休止する
    *
@@ -93,29 +63,6 @@ namespace coil
    * @endif
    */
   int sleep(TimeValue interval);
-
-  /*!
-   * @if jp
-   * @brief 指定されたマイクロ秒間は処理を休止する
-   *
-   * 指定されたマイクロ秒間は処理を休止する。
-   *
-   * @param usec マイクロ秒数
-   *
-   * @return 0: 成功, != 0: 失敗
-   *
-   * @else
-   * @brief Stop a processing at specified micro second time
-   *
-   * Stop a processing at specified micro second time.
-   *
-   * @param usec Micro second time
-   *
-   * @return 0: successful, != 0: failed
-   *
-   * @endif
-   */
-  int usleep(unsigned int usec);
 
   /*!
    * @if jp

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -248,7 +248,7 @@ namespace RTC
           std::lock_guard<std::mutex> guard(m_terminate.mutex);
           if (m_terminate.waiting > 1) break;
         }
-        coil::usleep(100000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
   }
 

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1318,7 +1318,7 @@ namespace RTM
         
         for (size_t i(0); i < 1000; ++i)
           {
-            coil::sleep(coil::TimeValue(0.01));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
             RTC_DEBUG(("Detecting new slave manager (%s).", mgrstr.c_str()));
             if (mgrstr == "manager_%p")
               {
@@ -1349,7 +1349,7 @@ namespace RTM
                 break;
               }
             RTC_DEBUG(("Waiting for slave manager started."));
-            coil::sleep(coil::TimeValue(0.01));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
           }
       }
 
@@ -1446,7 +1446,7 @@ namespace RTM
             return RTC::RTObject::_nil();
           }
 
-        coil::sleep(coil::TimeValue(0.01));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
         for (size_t i(0); i < 1000; ++i)
           {
             RTC_DEBUG(("Detecting new slave manager (%s).", mgrstr.c_str()))
@@ -1457,7 +1457,7 @@ namespace RTM
                 break;
               }
             RTC_DEBUG(("Waiting for slave manager started."));
-            coil::sleep(coil::TimeValue(0.01));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
           }
 
         if (CORBA::is_nil(mgrobj))


### PR DESCRIPTION
## Description of the Change

保守性・可読性・性能向上のために、 C++11 より標準となった sleep 機能に置き換える。
* 従来から固定時間でスリープをしていたところは、直接 sleep_for に置き換える。
* 従来から TimeVal 指定でスリープしていたところは、coil の int sleep(TimeVal) 関数の中身を置き換える。
TimeVal を通したSleepの指定は double型を指定やsec/nsec指定などのバリエーションがある。そのため、文字列置換による関数の置き換えは時間がかかりそうなので、関数を消さずに中を書き換えての対応となった。

制限事項
* sleep関数の実装を置き換えた結果、 win32 と posix は全く同じとなるが、その他の関数が共通化できないために .h/.cpp を common に 持って行くことができていない。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
   ConsoleIn/ConsoleOutの動作は見たが、すべてのsleep箇所をチェックしたわけではない。
   sleep関数についてはその関数だけをコンパイルして、動作を確認した。
