### PR TITLE
The base OS on Travis CI is changed to Ubuntu 16.04.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
+dist: xenial
+language: minimal
 sudo: required
 
 services:
   - docker
 
 before_install:
-  # install newer docker
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  # enable buildkit (only 18.09 or later)
-  ## - export DOCKER_BUILDKIT=1
+  # none
 
 addons:
   apt:
@@ -21,10 +17,6 @@ env:
   - TARGET_DIST=ubuntu TARGET_VER=1804
   - TARGET_DIST=ubuntu TARGET_VER=1604
   - TARGET_DIST=debian TARGET_VER=8
-
-#branches:
-#  only:
-#  - master
 
 script:
   - mkdir ../workdir


### PR DESCRIPTION
## Description of the Change
Travis CI の docker 実行環境を Ubuntu 14.04 から 16.04 に変更する
- Ubuntu 14.04 はサポート期限切れ
- Travis CI も Ubuntu 16.04 に移行中
- Travis CI は未だに Ubuntu 18.04 をサポートしていない

## Verification 
- [x] Did you succeed the build? 
- [x] No warnings for the build?  無関係
- [x] Have you passed the unit tests?  無関係