### PR TITLE
[compat, modify] modify the items pointed out for #233

### DIFF
--- a/src/ext/local_service/nameservice_file/FileNameservice.cpp
+++ b/src/ext/local_service/nameservice_file/FileNameservice.cpp
@@ -240,10 +240,9 @@ namespace RTM
               continue;
             }
           m_files.erase(it);
-          boost::system::error_code error;
           const bool result = fs::remove(filepath);
           RTC_DEBUG(("Removing file: %s", filepath.string().c_str()));
-          if (!result || (error != nullptr))
+          if (!result)
             {
               RTC_ERROR(("Removing a file has been failed. %s",
                          filepath.string().c_str()));
@@ -269,10 +268,9 @@ namespace RTM
       if (!fs::exists(directory))
         {
           RTC_DEBUG(("Directory %s not found", directory.string().c_str()));
-          boost::system::error_code error;
           const bool result = fs::create_directories(directory);
           RTC_DEBUG(("Creating directory: %s", directory.string().c_str()));
-          if (!result || (error != nullptr))
+          if (!result)
             {
               RTC_ERROR(("Creating directory has been failed. %s",
                          directory.string().c_str()));

--- a/src/lib/rtm/CorbaNaming.cpp
+++ b/src/lib/rtm/CorbaNaming.cpp
@@ -939,7 +939,7 @@ namespace RTC
     for (CORBA::ULong i = 0; i < name.length(); ++i)
       {
         // Count string length of id(s)
-        for (const char* id = name[i].id; *id != 0; ++id)
+        for (const char* id = name[i].id; *id != '\0'; ++id)
           {
             // Escape character '/', '.', '\' will convert to "\/", "\.", "\\".
             if (*id == '/' || *id == '.' || *id == '\\') slen++;
@@ -952,7 +952,7 @@ namespace RTC
             slen++;
           }
         // Count string length of kind(s)
-        for (const char* kind = name[i].kind; *kind != 0; kind++)
+        for (const char* kind = name[i].kind; *kind != '\0'; kind++)
           {
             if (*kind == '/' || *kind == '.' || *kind == '\\') slen++;
             slen++;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #233 

## Description of the Change

Issueに記載されている指摘を順に番号づけし、それぞれについて対応方法を記載する。

|番号|指摘内容|対応|
|---|---|---|
|1|引数のflagの扱い|Linux の場合 man マニュアルを確認し第２引数の fllags には「0」か 「TIMER_ABSTIME」が設定できることを確認した<br>ただし、FreeBSD の場合は TIMER_ABSTIME を設定するかしないとなっている<br>上記からFreeBSD も考慮した記載となっていると考えられるため変更は見送る|
|2|未使用のerror変数|未使用なので削除する|
|3|キャラクタ文字比較|同ファイルのnameToString関数と同様に’¥0’へ統一する|
|4|キャラクタ文字比較|同ファイルのnameToString関数と同様に’¥0’へ統一する|
|5|戻り値の型に合わせた処理|2d5f14ba5 で修正済み|
|6|戻り値の型に合わせた処理|2d5f14ba5 で修正済み|

■修正内容の説明
 - No.2
    - FileNameservice::onUnregisterNameservice( ) 
    - FileNameservice::createDirectory( ) 
    上記関数で「boost::system::error_code error;」が定義されているが、
値が格納されずに条件式で使用されているため不要と判断し削除する
 
- No.3, 4
    - CorbaNaming::getNameLength( )
    上記関数で文字列の終端を表すために 0 を使用している。このままでも動作には問題ないが
 同ファイルのnameToString()や他の終端処理では、’¥0’ が使用されているため ’¥0’ で統一する

## Verification 

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
- [x] Have you passed the unit tests?  

■確認手順
レビュー指摘事項の No.3,4 についてはトピック通信で呼ばれる関数であったため、
下記の手順でサンプルコンポーネントが動作することを確認した。
また、下記の手順で変更関数の戻り値に変化がないことも確認済み。

1.  sudo docker build -t test -f OpenRTM-aist/scripts/ubuntu_1604/Dockerfile .
2. sudo docker cp で rtc.conf をコピー
~~~
port.inport.in.subscribe_topic: test_topic
port.outport.out.publish_topic: test_topic
manager.components.preactivation: ConsoleIn0, ConsoleOut0
~~~
3. build_openrtm にある rtm-naming を実行
4. ConsoleInComp を実行
5. ConsoleOutComp を実行
-> データの入出力ができることを確認