### PR TITLE
Modify bugs of ExtTrigger.

### DIFF
--- a/examples/ExtTrigger/ConnectorComp.cpp
+++ b/examples/ExtTrigger/ConnectorComp.cpp
@@ -120,7 +120,7 @@ int main (int argc, char** argv)
 
 
   CORBA::ORB_var orb = CORBA::ORB_init(_argc, _argv);
-  CorbaNaming naming(orb, "localhost:9876");
+  CorbaNaming naming(orb, "localhost");
 
   CorbaConsumer<RTObject> conin, conout;
   CorbaConsumer<OpenRTM::ExtTrigExecutionContextService> ec0, ec1;

--- a/examples/ExtTrigger/rtc.conf
+++ b/examples/ExtTrigger/rtc.conf
@@ -1,5 +1,7 @@
 corba.nameservers: localhost
-naming.formats: %h.host_cxt/%n.rtc
+exec_cxt.periodic.type: ExtTrigExecutionContext
+exec_cxt.periodic.rate: 100
+naming.formats: %n.rtc
 logger.enable: NO
 example.ConsoleOut.config_file: consout.conf
 example.ConsoleIn.config_file: consin.conf


### PR DESCRIPTION
## Identify the Bug
examples の External Trigger が正しく動作しない。
- naming server が見つからない
- tick() を指示するとエラーになる

## Description of the Change

- naming server を探索する際のポートをデフォルトに変更
- rtc.conf で ExtTrigExecutionContext を指定

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
