### PR TITLE
Fix rtm-skelwrpper: --output-dir option and usage.

### DIFF
--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -45,6 +45,7 @@ import skel_wrapper
 opt_args_fmt = ["help",
 		"idl-file=",
 		"include-dir=",
+		"output-dir=",
 		"skel-suffix=",
 		"stub-suffix=",
 		"category=",
@@ -80,10 +81,10 @@ Example:
 $ rtm-skelwrapper --idl=file=<IDL path>/<IDL basename>.idl
                   --include-dir=<include dir>
                   --output-dir=<output dir>
-                  -skel-suffix=<skel suffix> 
-                  -stub-suffix=<stub suffix> 
-                  -category=<category name>
-                  -dependencies=<dependent idl list> 
+                  --skel-suffix=<skel suffix>
+                  --stub-suffix=<stub suffix>
+                  --category=<category name>
+                  --dependencies=<dependent idl list>
 
 In this case, the following files are generated under <output dir>.
 


### PR DESCRIPTION
## Identify the Bug
rtm-skelwrpper に下記の不具合が存在する。これらはビルド時に使われていない。
- usage を表示すると --output-dir を受け付けるとあるが、実際には受け付けない
- usage の example で、コンフィグの指定間違いがある。

## Description of the Change

引数のパース処理と usage の文書を修正する。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
