### PR TITLE
Replace coil::clock() with std::chrono::high_resolution_clock.

### DIFF
--- a/src/lib/coil/common/coil/TimeMeasure.cpp
+++ b/src/lib/coil/common/coil/TimeMeasure.cpp
@@ -37,7 +37,7 @@ namespace coil
    * @endif
    */
   TimeMeasure::TimeMeasure(unsigned long buflen)
-    : m_begin(0.0), m_interval(0.0),
+    : m_interval(0.0),
       m_count(0), m_countMax(buflen + 1),
       m_recurred(false)
   {
@@ -57,7 +57,7 @@ namespace coil
    */
   void TimeMeasure::tick()
   {
-    m_begin = clock();  // [TimeValue]
+    m_begin = std::chrono::high_resolution_clock::now();
   }
 
   /*!
@@ -69,9 +69,10 @@ namespace coil
    */
   void TimeMeasure::tack()
   {
-    if (m_begin.sec() == 0) { return; }
-
-    m_interval = clock() - m_begin;
+    auto interval = std::chrono::high_resolution_clock::now() - m_begin;
+    auto sec = std::chrono::duration_cast<std::chrono::seconds>(interval);
+    auto usec = std::chrono::duration_cast<std::chrono::microseconds>(interval - sec);
+    m_interval = coil::TimeValue(static_cast<long>(sec.count()), static_cast<long>(usec.count()));
     m_record.at(m_count) = m_interval;
     ++m_count;
     if (m_count == m_countMax)
@@ -104,7 +105,7 @@ namespace coil
   {
     m_count = 0;
     m_recurred = false;
-    m_begin = 0.0;
+    m_begin = std::chrono::high_resolution_clock::time_point();
   }
 
   /*!

--- a/src/lib/coil/common/coil/TimeMeasure.h
+++ b/src/lib/coil/common/coil/TimeMeasure.h
@@ -235,7 +235,7 @@ namespace coil
 
   private:
     std::vector<coil::TimeValue> m_record;
-    coil::TimeValue m_begin;
+    std::chrono::high_resolution_clock::time_point m_begin;
     coil::TimeValue m_interval;
 
     unsigned long int m_count;

--- a/src/lib/coil/common/coil/TimeValue.h
+++ b/src/lib/coil/common/coil/TimeValue.h
@@ -19,6 +19,8 @@
 #ifndef COIL_TIMEVALUE_H
 #define COIL_TIMEVALUE_H
 
+#include <chrono>
+
 namespace coil
 {
 
@@ -129,6 +131,31 @@ namespace coil
      * @endif
      */
     inline long int usec() const {return m_usec;}
+
+    /*!
+     * @if jp
+     *
+     * @brief std::chrono::microseconds型で値を取得する
+     *
+     * マイクロ秒単位の値を取得する
+     *
+     * @return 値
+     *
+     * @else
+     *
+     * @brief Get std::chrono::microseconds value
+     *
+     * Get value of micro second time scale.
+     *
+     * @return value
+     *
+     * @endif
+     */
+    inline std::chrono::microseconds microseconds() const
+      {
+        return std::chrono::seconds(sec())
+               + std::chrono::microseconds(usec());
+      }
 
     /*!
      * @if jp

--- a/src/lib/coil/posix/coil/Time.h
+++ b/src/lib/coil/posix/coil/Time.h
@@ -132,29 +132,6 @@ namespace coil
   {
     return ::settimeofday(tv, tz);
   }
-
-  /*!
-   * @if jp
-   * @brief 高分解能パフォーマンスカウンタから時間を取得する
-   *
-   *
-   * @return TimeValueオブジェクト
-   *
-   * @else
-   * @brief 
-   *
-   *
-   *
-   * @return TimeValue object
-   *
-   * @endif
-   */
-  inline TimeValue clock()
-  {
-    return coil::gettimeofday();
-  }
-
-
 } // namespace coil
 
 #endif  // COIL_TIME_H

--- a/src/lib/coil/posix/coil/Time.h
+++ b/src/lib/coil/posix/coil/Time.h
@@ -54,9 +54,7 @@ namespace coil
    */
   inline int sleep(TimeValue interval)
   {
-    auto t = std::chrono::seconds(interval.sec())
-             + std::chrono::microseconds(interval.usec());
-    std::this_thread::sleep_for(t);
+    std::this_thread::sleep_for(interval.microseconds());
     return 0;
   }
 

--- a/src/lib/coil/win32/coil/Time.cpp
+++ b/src/lib/coil/win32/coil/Time.cpp
@@ -82,38 +82,4 @@ namespace coil
 
     return 0;
   }
-
-  int clock(TimeValue &tv)
-  {
-      LARGE_INTEGER frequency;
-      BOOL ret = QueryPerformanceFrequency(&frequency);
-
-      if (ret == 0)
-      {
-          return 1;
-      }
-      else
-      {
-          LARGE_INTEGER current;
-          QueryPerformanceCounter(&current);
-          LONGLONG current_time = (current.QuadPart * 1000000) / frequency.QuadPart;
-          tv = TimeValue(static_cast<long>(current_time / 1000000), static_cast<long>(current_time % 1000000));
-          return 0;
-      }
-  }
-
-  TimeValue clock()
-  {
-    TimeValue ret;
-    if(coil::clock(ret) != 0)
-    {
-      timeval tv;
-      coil::gettimeofday(&tv, nullptr);
-      return TimeValue(tv.tv_sec, tv.tv_usec);
-    }
-    else
-    {
-      return ret;
-    }
-  }
 } // namespace coil

--- a/src/lib/coil/win32/coil/Time.h
+++ b/src/lib/coil/win32/coil/Time.h
@@ -140,49 +140,6 @@ namespace coil
    * @endif
    */
   int settimeofday(const struct timeval *tv , const struct timezone *tz);
-
-
-  /*!
-  * @if jp
-  * @brief 高分解能パフォーマンスカウンタから時間を取得する
-  * 高分解能パフォーマンスカウンタが利用できない場合はgettimeofday関数から取得する
-  *
-  * @param tv 時間
-  *
-  * @return 0: 成功
-  *
-  * @else
-  * @brief
-  *
-  *
-  * @param tv
-  *
-  * @return 0: successful
-  *
-  * @endif
-  */
-  int clock(TimeValue &tv);
-
-  /*!
-   * @if jp
-   * @brief 高分解能パフォーマンスカウンタから時間を取得する
-   *
-   *
-   * @return TimeValueオブジェクト
-   *
-   * @else
-   * @brief 
-   *
-   *
-   *
-   * @return TimeValue object
-   *
-   * @endif
-   */
-  TimeValue clock();
-
-
-
 } // namespace coil
 
 #endif  // COIL_TIME_H

--- a/src/lib/coil/win32/coil/Time.h
+++ b/src/lib/coil/win32/coil/Time.h
@@ -64,9 +64,7 @@ namespace coil
    */
   inline int sleep(TimeValue interval)
   {
-    auto t = std::chrono::seconds(interval.sec())
-             + std::chrono::microseconds(interval.usec());
-    std::this_thread::sleep_for(t);
+    std::this_thread::sleep_for(interval.microseconds());
     return 0;
   }
 

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -76,31 +76,31 @@ namespace RTC
     std::lock_guard<std::mutex> guard(m_tickmutex);
 
     ExecutionContextBase::invokeWorkerPreDo();  // update state
-    coil::TimeValue t0(coil::clock());
+    auto t0 = std::chrono::high_resolution_clock::now();
     ExecutionContextBase::invokeWorkerDo();
-    coil::TimeValue t1(coil::clock());
+    auto t1 = std::chrono::high_resolution_clock::now();
     ExecutionContextBase::invokeWorkerPostDo();
-    coil::TimeValue t2(coil::clock());
+    auto t2 = std::chrono::high_resolution_clock::now();
 
     coil::TimeValue period(getPeriod());
+    auto rest = period.microseconds() - (t2 - t0);
     if (m_count > 1000)
       {
         RTC_PARANOID(("Period:      %f [s]", static_cast<double>(period)));
-        RTC_PARANOID(("Exec-Do:     %f [s]", static_cast<double>(t1 - t0)));
-        RTC_PARANOID(("Exec-PostDo: %f [s]", static_cast<double>(t2 - t1)));
-        RTC_PARANOID(("Sleep:       %f [s]",
-                                static_cast<double>(period - (t2 - t0))));
+        RTC_PARANOID(("Exec-Do:     %f [s]", std::chrono::duration<double>(t1 - t0).count()));
+        RTC_PARANOID(("Exec-PostDo: %f [s]", std::chrono::duration<double>(t2 - t1).count()));
+        RTC_PARANOID(("Sleep:       %f [s]", std::chrono::duration<double>(rest).count()));
       }
-    coil::TimeValue t3(coil::clock());
-    if (period > (t2 - t0))
+    auto t3 = std::chrono::high_resolution_clock::now();
+    if (rest > std::chrono::seconds::zero())
       {
         if (m_count > 1000) { RTC_PARANOID(("sleeping...")); }
-        coil::sleep(coil::TimeValue(period - (t2 - t0)));
+        std::this_thread::sleep_until(t0 + period.microseconds());
       }
     if (m_count > 1000)
       {
-        coil::TimeValue t4(coil::clock());
-        RTC_PARANOID(("Slept:       %f [s]", static_cast<double>(t4 - t3)));
+        auto t4 = std::chrono::high_resolution_clock::now();
+        RTC_PARANOID(("Slept:       %f [s]", std::chrono::duration<double>(t4 - t3).count()));
         m_count = 0;
       }
     ++m_count;

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -168,29 +168,29 @@ namespace RTC_exp
               m_workerthread.cond_.wait(guard);
             }
         }
-        coil::TimeValue t0(coil::clock());
+        auto t0 = std::chrono::high_resolution_clock::now();
         ExecutionContextBase::invokeWorkerDo();
         ExecutionContextBase::invokeWorkerPostDo();
-        coil::TimeValue t1(coil::clock());
+        auto t1 = std::chrono::high_resolution_clock::now();
 
         coil::TimeValue period(getPeriod());
+        auto rest = period.microseconds() - (t1 - t0);
         if (count > 1000)
           {
             RTC_PARANOID(("Period:    %f [s]", static_cast<double>(period)));
-            RTC_PARANOID(("Execution: %f [s]", static_cast<double>(t1 - t0)));
-            RTC_PARANOID(("Sleep:     %f [s]",
-                                    static_cast<double>(period - (t1 - t0))));
+            RTC_PARANOID(("Execution: %f [s]", std::chrono::duration<double>(t1 - t0).count()));
+            RTC_PARANOID(("Sleep:     %f [s]", std::chrono::duration<double>(rest).count()));
           }
-        coil::TimeValue t2(coil::clock());
-        if (!m_nowait && period > (t1 - t0))
+        auto t2 = std::chrono::high_resolution_clock::now();
+        if (!m_nowait && (rest > std::chrono::seconds::zero()))
           {
             if (count > 1000) { RTC_PARANOID(("sleeping...")); }
-            coil::sleep(coil::TimeValue(period - (t1 - t0)));
+            std::this_thread::sleep_until(t0 + period.microseconds());
           }
         if (count > 1000)
           {
-            coil::TimeValue t3(coil::clock());
-            RTC_PARANOID(("Slept:     %f [s]", static_cast<double>(t3 - t2)));
+            auto t3 = std::chrono::high_resolution_clock::now();
+            RTC_PARANOID(("Slept:     %f [s]", std::chrono::duration<double>(t3 - t2).count()));
             count = 0;
           }
         ++count;

--- a/src/lib/rtm/VxWorksInterruptExecutionContext.cpp
+++ b/src/lib/rtm/VxWorksInterruptExecutionContext.cpp
@@ -157,32 +157,33 @@ namespace RTC
             }
           if (!m_worker.ticked_) { continue; }
         }
-        coil::TimeValue t0(coil::clock());
+        auto t0 = std::chrono::high_resolution_clock::now();
         ExecutionContextBase::invokeWorkerPreDo();
         ExecutionContextBase::invokeWorkerDo();
         ExecutionContextBase::invokeWorkerPostDo();
-        coil::TimeValue t1(coil::clock());
+        auto t1 = std::chrono::high_resolution_clock::now();
         {
           std::lock_guard<coil::Mutex> gurad(m_worker.mutex_);
           m_worker.ticked_ = false;
         }
         coil::TimeValue period(getPeriod());
+        auto rest = period.microseconds() - (t1 - t0);
         if (1) //count > 1000)
           {
             RTC_PARANOID(("Period:    %f [s]", (double)period));
-            RTC_PARANOID(("Execution: %f [s]", (double)(t1 - t0)));
-            RTC_PARANOID(("Sleep:     %f [s]", (double)(period - (t1 - t0))));
+            RTC_PARANOID(("Execution: %f [s]", std::chrono::duration<double>(t1 - t0).count()));
+            RTC_PARANOID(("Sleep:     %f [s]", std::chrono::duration<double>(rest).count()));
           }
-        coil::TimeValue t2(coil::clock());
-        if (period > (t1 - t0))
+        auto t2 = std::chrono::high_resolution_clock::now();
+        if (rest > std::chrono::seconds::zero())
           {
             if (1 /*count > 1000*/) { RTC_PARANOID(("sleeping...")); }
-            coil::sleep((coil::TimeValue)(period - (t1 - t0)));
+            std::this_thread::sleep_until(t0 + period.microseconds());
           }
         if (1) //count > 1000)
           {
-            coil::TimeValue t3(coil::clock());
-            RTC_PARANOID(("Slept:       %f [s]", (double)(t3 - t2)));
+            auto t3 = std::chrono::high_resolution_clock::now();
+            RTC_PARANOID(("Slept:       %f [s]", std::chrono::duration<double>(t3 - t2).count()));
             count = 0;
           }
         ++count;


### PR DESCRIPTION
## Description of the Change

保守性向上のために高解像度タイマーの処理をC++標準に置き換える。
置き換えの方針：
 - coil::TimeValue をできる限り置き換えない。
    coil::TimeValue の置き換えは今後の課題とする。
 - できる限り浮動小数点型 double を経由しないようにし、情報の欠落を防ぐ。
    double にするのは 0.0001 [s] などと std::cout したいときに限る。

コミットは4つに分割しています。
レビューの際は上から順に見る方が、全変更を見るより負荷が低めです。

TimeMeasure::tack() において、元々は sec() ==0 の場合何もしない処理が入っています。
おそらく time_point を新規作成して比較すれば、似たようなことができるはずですが、実装やめました。
そもそも sec() == 0 ということが tick() 未使用を保証できていないからです。

high_resolution_clock よりも steady_clock の方がPC の時計変更に耐性があって良い気がしますが、
精度を求めるべきだろうか。

## Verification 
PeriodicEC, ExtTriggerEC の動作で実行周期が問題無いことを確認した。
それ以外のものは確認の仕方がわからないが、文字列置換のルールは同じ。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?   上記の通りに一部のみ実施。
