### PR TITLE
Add verbose mode to rtm-skelwrapper and make it silent on OpenRTM build time.

### DIFF
--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -132,7 +132,7 @@ def main():
 		opts, args = getopt.getopt(sys.argv[1:], "f:I:o:c:h",
 					   opt_args_fmt)
 	except getopt.GetoptError:
-		print("Error: Invalid options.", getopt.GetoptError)
+		print("Error: Invalid options.", getopt.GetoptError, file=sys.stderr)
 		usage()
 		sys.exit(-1)
 
@@ -174,7 +174,7 @@ def main():
 			stub_suffix = arg
 
 	if not idl_file:
-		print("Error: IDL file is not given.")
+		print("Error: IDL file is not given.", file=sys.stderr)
 		usage()
 		sys.exit(-1)
 

--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -49,7 +49,8 @@ opt_args_fmt = ["help",
 		"skel-suffix=",
 		"stub-suffix=",
 		"category=",
-		"dependencies="]
+		"dependencies=",
+		"verbose"]
 
 
 config_inc = """
@@ -76,6 +77,7 @@ Options:
     [--output-dir[=dir] or -o]            output directory
     [--category[=name] or -c]             set category name
     [--dependencies[=namelist] or -d]     set dependent idls
+    [--verbose or -v]                     verbose mode
 
 Example:
 $ rtm-skelwrapper --idl=file=<IDL path>/<IDL basename>.idl
@@ -85,6 +87,7 @@ $ rtm-skelwrapper --idl=file=<IDL path>/<IDL basename>.idl
                   --stub-suffix=<stub suffix>
                   --category=<category name>
                   --dependencies=<dependent idl list>
+                  -v
 
 In this case, the following files are generated under <output dir>.
 
@@ -129,7 +132,7 @@ following include guard will be defined.
 
 def main():
 	try:
-		opts, args = getopt.getopt(sys.argv[1:], "f:I:o:c:h",
+		opts, args = getopt.getopt(sys.argv[1:], "f:I:o:c:hv",
 					   opt_args_fmt)
 	except getopt.GetoptError:
 		print("Error: Invalid options.", getopt.GetoptError, file=sys.stderr)
@@ -147,6 +150,7 @@ def main():
 	category = "OpenRTM"
 	dependencies = ""
 	idl_file    = None
+	verbose     = False
 
 	for opt, arg in opts:
 		if opt in ("-h", "--help"):
@@ -173,6 +177,9 @@ def main():
 		if opt in ("--stub-suffix"):
 			stub_suffix = arg
 
+		if opt in ("-v", "--verbose"):
+			verbose=True
+
 	if not idl_file:
 		print("Error: IDL file is not given.", file=sys.stderr)
 		usage()
@@ -182,7 +189,8 @@ def main():
 	import skel_wrapper
 
 	s = skel_wrapper.skel_wrapper(idl_file, skel_suffix, stub_suffix,
-				      include_dir, config_inc, output_dir, category, dependencies)
+				      include_dir, config_inc, output_dir,
+				      category, dependencies, verbose)
 	s.generate()
 
 

--- a/utils/rtm-skelwrapper/skel_wrapper.py
+++ b/utils/rtm-skelwrapper/skel_wrapper.py
@@ -233,7 +233,7 @@ config_inc = """
 class skel_wrapper:
 	def __init__(self, idl_fname, skel_suffix = "Skel",
 		     stub_suffix = "Stub", include_dir = "",
-		     config_inc = "", output_dir = "./", category = "OpenRTM", dependencies=""):
+		     config_inc = "", output_dir = "./", category = "OpenRTM", dependencies="", verbose=True):
 		self.data = {}
 		self.data["include_dir"] = include_dir
 		self.data["output_dir"] = output_dir
@@ -244,6 +244,7 @@ class skel_wrapper:
 		else:
 			includes = ["#    include<"+s+"Skel.h>\n" for s in dependencies.split(":")]
 			self.data["dependencies"] = ''.join(includes)
+		self.verbose_print = print if verbose else lambda *a, **k: None
 
 		m = re.search("\.[iI][dD][lL]$", idl_fname)
 		if m:
@@ -304,18 +305,18 @@ class skel_wrapper:
 			newtext = re.sub(" \@date.*?\n", "", text)
 			oldtext2 = re.sub(" \@date.*?\n", "", oldtext)
 			if newtext == oldtext2:
-				print("\"" + fname + \
+				self.verbose_print("\"" + fname + \
 			    "\" exists and contents is same.")
-				print("No need to generate the file.")
+				self.verbose_print("No need to generate the file.")
 				return
 			else:
-				print("\"", fname, \
+				self.verbose_print("\"", fname, \
 			    "\" already exists but contents are not same")
 
 		f = open(fname, "w")
 		f.write(text)
 		f.close()
-		print("\"" + fname + "\"" " was generated.")
+		self.verbose_print("\"" + fname + "\"" " was generated.")
 		return
 
 	def print_skel_h(self):

--- a/utils/rtm-skelwrapper/yat.py
+++ b/utils/rtm-skelwrapper/yat.py
@@ -166,6 +166,7 @@
 # result:
 # [bracket]
 #
+from __future__ import print_function
 import string
 import re
 #from types import StringType, IntType, FloatType, DictType, ListType, ClassType
@@ -531,19 +532,19 @@ class Template:
     #------------------------------------------------------------
 
     def __print_error(self, e):
-        print("Parse Error: line", e.lineno, "in input data")
-        print("  " + ''.join(nesteditem(e.value)))
+        print("Parse Error: line", e.lineno, "in input data", file=sys.stderr)
+        print("  " + ''.join(nesteditem(e.value)), file=sys.stderr)
         lines = self.template.split("\n")
         length = len(lines)
-        print("------------------------------------------------------------")
+        print("------------------------------------------------------------", file=sys.stderr)
         for i in range(1,10):
             l = e.lineno - 6 + i
             if l > 0 and l < length:
-                print(lines[l])
+                print(lines[l], file=sys.stderr)
                 if i == 5:
                     uline = '~'*len(lines[l])
-                    print(uline)
-        print("------------------------------------------------------------")
+                    print(uline, file=sys.stderr)
+        print("------------------------------------------------------------", file=sys.stderr)
     
     def del_nl_after_cmd(self):
         # next text index after command
@@ -597,8 +598,8 @@ class GeneratorBase:
         self.text = ""
 
     def print_error(self, e):
-        print("\nTemplate Generation Error: line", e.lineno, "in input data")
-        print("  " + ''.join(nesteditem(e.value)))
+        print("\nTemplate Generation Error: line", e.lineno, "in input data", file=sys.stderr)
+        print("  " + ''.join(nesteditem(e.value)), file=sys.stderr)
         temp = ""
         for i, s in enumerate(self.token):
             if s != None:
@@ -608,15 +609,15 @@ class GeneratorBase:
                     temp += s
         lines = temp.split("\n")
         length = len(lines)
-        print("------------------------------------------------------------")
+        print("------------------------------------------------------------", file=sys.stderr)
         for i in range(1,10):
             l = e.lineno - 6 + i
             if l > 0 and l < length:
-                print(lines[l])
+                print(lines[l], file=sys.stderr)
                 if i == 5:
                     uline = '~'*len(lines[l])
-                    print(uline)
-        print("------------------------------------------------------------")
+                    print(uline, file=sys.stderr)
+        print("------------------------------------------------------------", file=sys.stderr)
         
     def set_index(self, index):
         self.index = index


### PR DESCRIPTION
## Description of the Change

rtm-skelwrapper を実行すると、標準出力にファイルを生成した旨のメッセージが流れる。
OpenRTM ビルド時に生成されるファイル名は、 CMake により make, ms-build, ninja が表示している。
よって、 -v or --verbose をつけない限りは情報を出さないように変更し、ログが高速に流れることを抑制する。
なお、エラー情報は stderr に出力するように変更した。

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
