### PR TITLE
Replacce coil::gettimeofday with std::chrono.

### DIFF
--- a/examples/Analyzer/Analyzer_test.cpp
+++ b/examples/Analyzer/Analyzer_test.cpp
@@ -130,11 +130,11 @@ RTC::ReturnCode_t Analyzer_test::onExecute(RTC::UniqueId  /*ec_id*/)
 {
 	if (m_inIn.isNew())
 	{
-		coil::TimeValue start(coil::gettimeofday());
+		auto start = std::chrono::system_clock::now();
 		m_inIn.read();
 		m_out = m_in;
-		coil::TimeValue end(coil::gettimeofday());
-		double diff = (double)(end - start);
+		auto end = std::chrono::system_clock::now();
+		double diff = std::chrono::duration<double>(end - start).count();
 		if (diff < m_sleep_time)
 		{
 			coil::sleep(coil::TimeValue(m_sleep_time - diff));

--- a/examples/Throughput/Throughput.cpp
+++ b/examples/Throughput/Throughput.cpp
@@ -401,7 +401,7 @@ void Throughput::receiveData(const RTC::Time &tm, const CORBA::ULong seq_length)
   static size_t record_ptr(0);
 
   // data arrived -> getting time
-  coil::TimeValue received_time(coil::gettimeofday());
+  auto received_time = std::chrono::system_clock::now().time_since_epoch();
   if (size == 0) { size = seq_length; }
 
   // calculate latency statistics
@@ -429,7 +429,7 @@ void Throughput::receiveData(const RTC::Time &tm, const CORBA::ULong seq_length)
 
       for (size_t i(0); i < record_len; ++i)
         {
-          double tmp(m_record[i]);
+          double tmp(std::chrono::duration<double>(m_record[i]).count());
           sum += tmp;
           sq_sum += tmp * tmp;
           if      (tmp > max_latency) { max_latency = tmp; }
@@ -465,7 +465,7 @@ void Throughput::receiveData(const RTC::Time &tm, const CORBA::ULong seq_length)
         }
     }
   // measuring latency
-  coil::TimeValue send_time(tm.sec, tm.nsec/1000);
+  auto send_time = std::chrono::seconds(tm.sec) + std::chrono::nanoseconds(tm.nsec);
   m_record[record_ptr] = received_time - send_time;
   size = seq_length;
   record_ptr++; record_num++;

--- a/examples/Throughput/Throughput.h
+++ b/examples/Throughput/Throughput.h
@@ -411,7 +411,7 @@ class Throughput
   // Time measurement statistics data
   // data size to be send
   unsigned long m_datasize;
-  std::vector<coil::TimeValue> m_record;
+  std::vector<std::chrono::nanoseconds> m_record;
 
   // received data store
   size_t m_sendcount;

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -425,7 +425,7 @@ namespace RTC
                      std::string  msg,
                      coil::TimeValue interval)
         : m_coc(coc), m_msg(std::move(msg)), m_interval(interval),
-          m_last(coil::gettimeofday())
+          m_last(std::chrono::steady_clock::now())
       {
       }
       ~DataPortAction() override {}
@@ -433,9 +433,9 @@ namespace RTC
       ReturnCode operator()(ConnectorInfo&  /*info*/,
                             ByteData&  /*data*/) override
       {
-        coil::TimeValue curr = coil::gettimeofday();
-        coil::TimeValue intvl = curr - m_last;
-        if (intvl > m_interval)
+        auto curr = std::chrono::steady_clock::now();
+        auto intvl = curr - m_last;
+        if (intvl > m_interval.microseconds())
           {
             m_last = curr;
             m_coc.updateStatus(OpenRTM::PORT_PROFILE, m_msg.c_str());
@@ -447,7 +447,7 @@ namespace RTC
       ComponentObserverConsumer& m_coc;
       std::string m_msg;
       coil::TimeValue m_interval;
-      coil::TimeValue m_last;
+      std::chrono::steady_clock::time_point m_last;
     };
     
     /*!

--- a/src/lib/coil/common/coil/ClockManager.h
+++ b/src/lib/coil/common/coil/ClockManager.h
@@ -149,7 +149,7 @@ namespace coil
     coil::TimeValue gettime() const override;
     bool settime(coil::TimeValue clocktime) override;
   private:
-    coil::TimeValue m_offset;
+    std::chrono::steady_clock::time_point m_offset;
     mutable std::mutex m_offsetMutex;
   };
 

--- a/src/lib/coil/posix/coil/Time.cpp
+++ b/src/lib/coil/posix/coil/Time.cpp
@@ -17,31 +17,3 @@
  */
 
 #include <coil/Time.h>
-
-  /*!
-   * @if jp
-   * @brief 時刻を取得する
-   *
-   * 時刻を取得する。
-   *
-   * @return TimeValueオブジェクト
-   *
-   * @else
-   * @brief Get the time
-   *
-   * Get the time
-   *
-   * @return TimeValue object
-   *
-   * @endif
-   */
-namespace coil
-{
-  TimeValue gettimeofday()
-  {
-    timeval tv;
-    ::gettimeofday(&tv, nullptr);
-    return TimeValue(tv.tv_sec, tv.tv_usec);
-  }
-}
-

--- a/src/lib/coil/posix/coil/Time.h
+++ b/src/lib/coil/posix/coil/Time.h
@@ -60,53 +60,6 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief 時刻とタイムゾーンを取得する
-   *
-   * 時刻とタイムゾーンを取得する。
-   *
-   * @param tv 時刻構造体
-   * @param tz タイムゾーン構造体
-   *
-   * @return 0: 成功, -1: 失敗
-   *
-   * @else
-   * @brief Get the time and timezone
-   *
-   * Get the time and timezone
-   *
-   * @param tv Structure of time
-   * @param tz Structure of timezone
-   *
-   * @return 0: successful, -1: failed
-   *
-   * @endif
-   */
-  inline int gettimeofday(struct timeval *tv, struct timezone *tz)
-  {
-    return ::gettimeofday(tv, tz);
-  }
-
-  /*!
-   * @if jp
-   * @brief 時刻を取得する
-   *
-   * 時刻を取得する。
-   *
-   * @return TimeValueオブジェクト
-   *
-   * @else
-   * @brief Get the time
-   *
-   * Get the time
-   *
-   * @return TimeValue object
-   *
-   * @endif
-   */
-  TimeValue gettimeofday();
-
-  /*!
-   * @if jp
    * @brief 時刻とタイムゾーンを設定する
    *
    * 時刻とタイムゾーンを設定する。

--- a/src/lib/coil/win32/coil/Time.cpp
+++ b/src/lib/coil/win32/coil/Time.cpp
@@ -20,40 +20,6 @@
 
 namespace coil
 {
-  int gettimeofday(struct timeval *tv, struct timezone *tz)
-  {
-      FILETIME        ftime;
-      LARGE_INTEGER   lint;
-      __int64         val64;
-      static int      tzflag;
-      if (tv != nullptr)
-      {
-          ::GetSystemTimeAsFileTime(&ftime);
-          lint.LowPart = ftime.dwLowDateTime;
-          lint.HighPart = static_cast<LONG>(ftime.dwHighDateTime);
-          val64 = lint.QuadPart;
-          val64 = val64 - EPOCHFILETIME;
-          val64 = val64 / 10;
-          tv->tv_sec = static_cast<long>(val64 / 1000000);
-          tv->tv_usec = static_cast<long>(val64 % 1000000);
-      }
-      if (tz != nullptr)
-      {
-          if (tzflag == 0)
-          {
-             ::_tzset();
-              ++tzflag;
-          }
-          long tzone = 0;
-          ::_get_timezone(&tzone);
-          tz->tz_minuteswest = tzone / 60;
-          int dlight = 0;
-          ::_get_daylight(&dlight);
-          tz->tz_dsttime = dlight;
-      }
-      return 0;
-  }
-
   int settimeofday(const struct timeval *tv , const struct timezone *tz)
   {
 

--- a/src/lib/coil/win32/coil/Time.h
+++ b/src/lib/coil/win32/coil/Time.h
@@ -70,54 +70,6 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief 時刻とタイムゾーンを取得する
-   *
-   * 時刻とタイムゾーンを取得する。
-   *
-   * @param tv 時刻構造体
-   * @param tz タイムゾーン構造体
-   *
-   * @return 0: 成功
-   *
-   * @else
-   * @brief Get the time and timezone
-   *
-   * Get the time and timezone
-   *
-   * @param tv Structure of time
-   * @param tz Structure of timezone
-   *
-   * @return 0: successful
-   *
-   * @endif
-   */
-  int gettimeofday(struct timeval *tv, struct timezone *tz);
-  /*!
-   * @if jp
-   * @brief 時刻を取得する
-   *
-   * 時刻を取得する。
-   *
-   * @return TimeValueオブジェクト
-   *
-   * @else
-   * @brief Get the time
-   *
-   * Get the time
-   *
-   * @return TimeValue object
-   *
-   * @endif
-   */
-  inline TimeValue gettimeofday()
-  {
-    timeval tv;
-    coil::gettimeofday(&tv, 0);
-    return TimeValue(tv.tv_sec, tv.tv_usec);
-  }
-
-  /*!
-   * @if jp
    * @brief 時刻とタイムゾーンを設定する
    *
    * 時刻とタイムゾーンを設定する。

--- a/src/lib/rtm/ExecutionContextBase.cpp
+++ b/src/lib/rtm/ExecutionContextBase.cpp
@@ -390,7 +390,7 @@ namespace RTC
     RTC_DEBUG(("Timeout is %f [s] (%f [s] in %d times)",
                static_cast<double>(m_activationTimeout), getRate(), cycle));
     // Wating INACTIVE -> ACTIVE
-    coil::TimeValue starttime(coil::gettimeofday());
+    auto starttime = std::chrono::steady_clock::now();
     while (rtobj->isCurrentState(RTC::INACTIVE_STATE))
       {
         ret = onWaitingActivated(rtobj, count);  // Template method
@@ -400,11 +400,11 @@ namespace RTC
             return ret;
           }
         coil::sleep(getPeriod());
-        coil::TimeValue delta(coil::gettimeofday() - starttime);
+        auto delta = std::chrono::steady_clock::now() - starttime;
         RTC_DEBUG(("Waiting to be ACTIVE state. %f [s] slept (%d/%d)",
-                   static_cast<double>(delta), count, cycle));
+                   std::chrono::duration<double>(delta).count(), count, cycle));
         ++count;
-        if (delta > m_activationTimeout || count > cycle)
+        if (delta > m_activationTimeout.microseconds() || count > cycle)
           {
             RTC_WARN(("The component is not responding."));
             break;
@@ -479,7 +479,7 @@ namespace RTC
     RTC_DEBUG(("Timeout is %f [s] (%f [s] in %d times)",
                static_cast<double>(m_deactivationTimeout), getRate(), cycle));
     // Wating ACTIVE -> INACTIVE
-    coil::TimeValue starttime(coil::gettimeofday());
+    auto starttime = std::chrono::steady_clock::now();
     while (rtobj->isCurrentState(RTC::ACTIVE_STATE))
       {
         ret = onWaitingDeactivated(rtobj, count);  // Template method
@@ -489,11 +489,11 @@ namespace RTC
             return ret;
           }
         coil::sleep(getPeriod());
-        coil::TimeValue delta(coil::gettimeofday() - starttime);
+        auto delta = std::chrono::steady_clock::now() - starttime;
         RTC_DEBUG(("Waiting to be INACTIVE state. Sleeping %f [s] (%d/%d)",
-               static_cast<double>(delta), count, cycle));
+                   std::chrono::duration<double>(delta).count(), count, cycle));
         ++count;
-        if (delta > m_deactivationTimeout || count > cycle)
+        if (delta > m_deactivationTimeout.microseconds() || count > cycle)
           {
             RTC_ERROR(("The component is not responding."));
             break;
@@ -567,7 +567,7 @@ namespace RTC
     RTC_DEBUG(("Timeout is %f [s] (%f [s] in %d times)",
                static_cast<double>(m_resetTimeout), getRate(), cycle));
     // Wating ERROR -> INACTIVE
-    coil::TimeValue starttime(coil::gettimeofday());
+    auto starttime = std::chrono::steady_clock::now();
     while (rtobj->isCurrentState(RTC::ERROR_STATE))
       {
         ret = onWaitingReset(rtobj, count);  // Template
@@ -577,11 +577,11 @@ namespace RTC
             return ret;
           }
         coil::sleep(getPeriod());
-        coil::TimeValue delta(coil::gettimeofday() - starttime);
+        std::chrono::duration<double> delta = std::chrono::steady_clock::now() - starttime;
         RTC_DEBUG(("Waiting to be INACTIVE state. Sleeping %f [s] (%d/%d)",
-                   static_cast<double>(delta), count, cycle));
+                   delta.count(), count, cycle));
         ++count;
-        if (delta > m_resetTimeout || count > cycle)
+        if (delta.count() > m_resetTimeout || count > cycle)
           {
             RTC_ERROR(("The component is not responding."));
             break;

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -20,8 +20,6 @@
 #ifndef RTC_OUTPORT_H
 #define RTC_OUTPORT_H
 
-#include <coil/TimeValue.h>
-#include <coil/Time.h>
 #include <coil/TimeMeasure.h>
 #include <coil/OS.h>
 
@@ -37,37 +35,6 @@
 #include <functional>
 #include <string>
 #include <vector>
-
-
-/*!
- * @if jp
- * @brief データにタイムスタンプをセットする
- *
- * データポートのデータに対してタイムスタンプをセットする。データポート
- * のデータは構造体のメンバーとして tm.sec, tm.nsec を持つ必要がある。
- *
- * @param data タイムスタンプをセットするデータ。実行後実行時のタイムス
- *             タンプがセットされる
- *
- * @else
- * @brief Setting timestamp to data
- *
- * This function sets timestamp to data of data port. This data should
- * have tm.sec, tm.nsec as members of the structure.
- *
- * @param data Data to be set timestamp. After executing this
- *             function, current timestamp is set to the data.
- *
- * @endif
- */
-template <class DataType>
-void setTimestamp(DataType& data)
-{
-      // set timestamp
-      coil::TimeValue tm(coil::gettimeofday());
-      data.tm.sec  = tm.sec();
-      data.tm.nsec = tm.usec() * 1000;
-}
 
 namespace RTC
 {

--- a/src/lib/rtm/Timestamp.h
+++ b/src/lib/rtm/Timestamp.h
@@ -19,6 +19,39 @@
 #define RTM_TIMESTAMP_H
 
 #include <rtm/ConnectorListener.h>
+#include <chrono>
+
+/*!
+ * @if jp
+ * @brief データにタイムスタンプをセットする
+ *
+ * データポートのデータに対してタイムスタンプをセットする。データポート
+ * のデータは構造体のメンバーとして tm.sec, tm.nsec を持つ必要がある。
+ *
+ * @param data タイムスタンプをセットするデータ。実行後実行時のタイムス
+ *             タンプがセットされる
+ *
+ * @else
+ * @brief Setting timestamp to data
+ *
+ * This function sets timestamp to data of data port. This data should
+ * have tm.sec, tm.nsec as members of the structure.
+ *
+ * @param data Data to be set timestamp. After executing this
+ *             function, current timestamp is set to the data.
+ *
+ * @endif
+ */
+template <class DataType>
+void setTimestamp(DataType& data)
+{
+  auto now = std::chrono::system_clock::now().time_since_epoch();
+  auto sec = std::chrono::duration_cast<std::chrono::seconds>(now);
+  auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(now - sec);
+// We do not consider overflow of tm.sec.
+  data.tm.sec  = static_cast<decltype(data.tm.sec)>(sec.count());
+  data.tm.nsec = static_cast<decltype(data.tm.nsec)>(nsec.count());
+}
 
 namespace RTC
 {
@@ -36,9 +69,7 @@ namespace RTC
         {
           return NO_CHANGE;
         }
-      coil::TimeValue tm(coil::gettimeofday());
-      data.tm.sec  = tm.sec();
-      data.tm.nsec = tm.usec() * 1000;
+      setTimestamp<DataType>(data);
       return DATA_CHANGED;
     }
     std::string m_tstype;


### PR DESCRIPTION
## Description of the Change
保守性向上のために時間管理は std::chrono を使用する。
置き換えの方針
* coil::TimeValue は極力置き換えない。
   基本的に std::chrono から取得した値を TimeValue に変換して利用する。
   ただし、TimeValueにすることでマイクロ秒未満の値は失われる。
* double 型に極力頼らない
   情報の欠損を減らすためにdouble/std::chrono::duration<double>に極力頼らない。
* 内部でしかつかわないものには std::chrono::steady_clock 使用する。
* 外部と通信するものには std::system_clock を使用する。

レビューにおいてはコミット一つずつ見るほうが見やすいです。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?
 examples/Analyzer, examples/Throughputの動作は変わらないことを確認。
 