### PR TITLE
ROS、ROS2のシリアライザの名前変更

### DIFF
--- a/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
@@ -120,7 +120,9 @@ namespace RTC
     m_topic = prop.getProperty("topic", "chatter");
     
 
-    if (marshaling_type != "corba")
+    const std::string str_corba = "corba";
+
+    if (marshaling_type.compare(0, str_corba.size(), str_corba) != 0)
     {
         FastRTPSMessageInfoBase* info = FastRTPSMessageInfoFactory::instance().createObject(marshaling_type);
 

--- a/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
@@ -91,7 +91,9 @@ namespace RTC
     m_topic = prop.getProperty("topic", "chatter");
 
 
-    if (marshaling_type != "corba")
+    const std::string str_corba = "corba";
+
+    if (marshaling_type.compare(0, str_corba.size(), str_corba) != 0)
     {
         FastRTPSMessageInfoBase* info = FastRTPSMessageInfoFactory::instance().createObject(marshaling_type);
 

--- a/src/ext/transport/OpenSplice/OpenSpliceInPort.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceInPort.cpp
@@ -114,7 +114,9 @@ namespace RTC
     std::string dataname;
     bool corbamode;
     
-    if (marshaling_type != "corba")
+    const std::string str_corba = "corba";
+
+    if (marshaling_type.compare(0, str_corba.size(), str_corba) != 0)
     {
         
         dataname = marshaling_type;

--- a/src/ext/transport/OpenSplice/OpenSpliceOutPort.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceOutPort.cpp
@@ -83,7 +83,9 @@ namespace RTC
     std::string dataname;
     bool corbamode;
 
-    if (marshaling_type != "corba")
+    const std::string str_corba = "corba";
+
+    if (marshaling_type.compare(0, str_corba.size(), str_corba) != 0)
     {
         dataname = marshaling_type;
         corbamode = false;

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
@@ -80,16 +80,16 @@ namespace RTC
   template <class DataType, typename originalType>
   void ROS2SimpleDataInit()
   {
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Float32, originalType, float>("ROS2Float32");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Float64, originalType, double>("ROS2Float64");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int8, originalType, int8_t>("ROS2Int8");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int16, originalType, int16_t>("ROS2Int16");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int32, originalType, int32_t>("ROS2Int32");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int64, originalType, int64_t>("ROS2Int64");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt8, originalType, uint8_t>("ROS2UInt8");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt16, originalType, uint16_t>("ROS2UInt16");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt32, originalType, uint32_t>("ROS2UInt32");
-    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt64, originalType, uint64_t>("ROS2UInt64");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Float32, originalType, float>("ros2:std_msgs/Float32");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Float64, originalType, double>("ros2:std_msgs/Float64");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int8, originalType, int8_t>("ros2:std_msgs/Int8");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int16, originalType, int16_t>("ros2:std_msgs/Int16");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int32, originalType, int32_t>("ros2:std_msgs/Int32");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::Int64, originalType, int64_t>("ros2:std_msgs/Int64");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt8, originalType, uint8_t>("ros2:std_msgs/UInt8");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt16, originalType, uint16_t>("ros2:std_msgs/UInt16");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt32, originalType, uint32_t>("ros2:std_msgs/UInt32");
+    ROS2SimpleDataInitBaseFunc<DataType, std_msgs::msg::UInt64, originalType, uint64_t>("ros2:std_msgs/UInt64");
     
   }
 
@@ -142,16 +142,16 @@ namespace RTC
   template <class DataType, typename originalType>
   void ROS2SequenceDataInit()
   {
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Float32MultiArray, originalType, float>("ROSFloat32MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Float64MultiArray, originalType, double>("ROSFloat64MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int8MultiArray, originalType, int8_t>("ROSInt8MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int16MultiArray, originalType, int16_t>("ROSInt16MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int32MultiArray, originalType, int32_t>("ROSInt32MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int64MultiArray, originalType, int64_t>("ROSInt64MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt8MultiArray, originalType, uint8_t>("ROSUInt8MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt16MultiArray, originalType, uint16_t>("ROSUInt16MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt32MultiArray, originalType, uint32_t>("ROSUInt32MultiArray");
-    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt64MultiArray, originalType, uint64_t>("ROSUInt64MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Float32MultiArray, originalType, float>("ros2:std_msgs/Float32MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Float64MultiArray, originalType, double>("ros2:std_msgs/Float64MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int8MultiArray, originalType, int8_t>("ros2:std_msgs/Int8MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int16MultiArray, originalType, int16_t>("ros2:std_msgs/Int16MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int32MultiArray, originalType, int32_t>("ros2:std_msgs/Int32MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::Int64MultiArray, originalType, int64_t>("ros2:std_msgs/Int64MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt8MultiArray, originalType, uint8_t>("ros2:std_msgs/UInt8MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt16MultiArray, originalType, uint16_t>("ros2:std_msgs/UInt16MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt32MultiArray, originalType, uint32_t>("ros2:std_msgs/UInt32MultiArray");
+    ROS2SequenceDataInitBaseFunc<DataType, std_msgs::msg::UInt64MultiArray, originalType, uint64_t>("ros2:std_msgs/UInt64MultiArray");
   }
 
   /*!
@@ -280,14 +280,14 @@ namespace RTC
   void ROS2StringDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedString> >::
-            instance().addFactory("ROS2String",
+            instance().addFactory("ros2:std_msgs/String",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedString>,
             RTC::ROS2StringData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedString>,
             RTC::ROS2StringData>);
 
     RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ROS2String",
+            instance().addFactory("ros2:std_msgs/String",
             ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
             RTC::ROS2MessageInfo<std_msgs::msg::String> >,
             ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
@@ -430,14 +430,14 @@ namespace RTC
   void ROS2Pont3DDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedPoint3D> >::
-            instance().addFactory("ROS2PointStamped",
+            instance().addFactory("ros2:geometry_msgs/PointStamped",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedPoint3D>,
             RTC::ROS2Point3DData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedPoint3D>,
             RTC::ROS2Point3DData>);
 
     RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ROS2PointStamped",
+            instance().addFactory("ros2:geometry_msgs/PointStamped",
             ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
             RTC::ROS2MessageInfo<geometry_msgs::msg::PointStamped> >,
             ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
@@ -581,14 +581,14 @@ namespace RTC
   void ROS2QuaternionDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedQuaternion> >::
-            instance().addFactory("ROS2QuaternionStamped",
+            instance().addFactory("ros2:geometry_msgs/QuaternionStamped",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedQuaternion>,
             RTC::ROS2QuaternionData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedQuaternion>,
             RTC::ROS2QuaternionData>);
 
     RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ROS2QuaternionStamped",
+            instance().addFactory("ros2:geometry_msgs/QuaternionStamped",
             ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
             RTC::ROS2MessageInfo<geometry_msgs::msg::QuaternionStamped > >,
             ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
@@ -731,14 +731,14 @@ namespace RTC
   void ROS2Vector3DDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedVector3D> >::
-            instance().addFactory("ROS2Vector3Stamped",
+            instance().addFactory("ros2:geometry_msgs/Vector3Stamped",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedVector3D>,
             RTC::ROS2Vector3DData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedVector3D>,
             RTC::ROS2Vector3DData>);
 
     RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ROS2Vector3Stamped",
+            instance().addFactory("ros2:geometry_msgs/Vector3Stamped",
             ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
             RTC::ROS2MessageInfo<geometry_msgs::msg::Vector3Stamped > >,
             ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
@@ -897,14 +897,14 @@ namespace RTC
   void ROS2CameraImageDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::CameraImage> >::
-            instance().addFactory("ROS2Image",
+            instance().addFactory("ros2:sensor_msgs/Image",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::CameraImage>,
             RTC::ROS2CameraImageData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::CameraImage>,
             RTC::ROS2CameraImageData>);
 
     RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ROS2Image",
+            instance().addFactory("ros2:sensor_msgs/Image",
             ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
             RTC::ROS2MessageInfo<sensor_msgs::msg::Image > >,
             ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -134,7 +134,7 @@ namespace RTC
       return;
     }
 
-    m_messageType = prop.getProperty("marshaling_type", "ROSFloat32");
+    m_messageType = prop.getProperty("marshaling_type", "ros2:std_msgs/Float32");
     m_topic = prop.getProperty("topic", "chatter");
     m_topic = "/" + m_topic;
 

--- a/src/ext/transport/ROSTransport/ROSOutPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSOutPort.cpp
@@ -83,7 +83,7 @@ namespace RTC
 
     m_properties = prop;
 
-    m_messageType = prop.getProperty("marshaling_type", "ROSFloat32");
+    m_messageType = prop.getProperty("marshaling_type", "ros2:std_msgs/Float32");
 
     m_topic = prop.getProperty("topic", "chatter");
     m_topic = "/" + m_topic;

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -105,16 +105,16 @@ namespace RTC
   template <class DataType, typename originalType>
   void ROSSimpleDataInit()
   {
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Float32, originalType, float>("ROSFloat32");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Float64, originalType, double>("ROSFloat64");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int8, originalType, int8_t>("ROSInt8");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int16, originalType, int16_t>("ROSInt16");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int32, originalType, int32_t>("ROSInt32");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int64, originalType, int64_t>("ROSInt64");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt8, originalType, uint8_t>("ROSUInt8");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt16, originalType, uint16_t>("ROSUInt16");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt32, originalType, uint32_t>("ROSUInt32");
-    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt64, originalType, uint64_t>("ROSUInt64");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Float32, originalType, float>("ros:std_msgs/Float32");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Float64, originalType, double>("ros:std_msgs/Float64");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int8, originalType, int8_t>("ros:std_msgs/Int8");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int16, originalType, int16_t>("ros:std_msgs/Int16");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int32, originalType, int32_t>("ros:std_msgs/Int32");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::Int64, originalType, int64_t>("ros:std_msgs/Int64");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt8, originalType, uint8_t>("ros:std_msgs/UInt8");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt16, originalType, uint16_t>("ros:std_msgs/UInt16");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt32, originalType, uint32_t>("ros:std_msgs/UInt32");
+    ROSSimpleDataInitBaseFunc<DataType, std_msgs::UInt64, originalType, uint64_t>("ros:std_msgs/UInt64");
   }
 
   /*!
@@ -166,16 +166,16 @@ namespace RTC
   template <class DataType, typename originalType>
   void ROSSequenceDataInit()
   {
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Float32MultiArray, originalType, float>("ROSFloat32MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Float64MultiArray, originalType, double>("ROSFloat64MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int8MultiArray, originalType, int8_t>("ROSInt8MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int16MultiArray, originalType, int16_t>("ROSInt16MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int32MultiArray, originalType, int32_t>("ROSInt32MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int64MultiArray, originalType, int64_t>("ROSInt64MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt8MultiArray, originalType, uint8_t>("ROSUInt8MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt16MultiArray, originalType, uint16_t>("ROSUInt16MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt32MultiArray, originalType, uint32_t>("ROSUInt32MultiArray");
-    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt64MultiArray, originalType, uint64_t>("ROSUInt64MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Float32MultiArray, originalType, float>("ros:std_msgs/Float32MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Float64MultiArray, originalType, double>("ros:std_msgs/Float64MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int8MultiArray, originalType, int8_t>("ros:std_msgs/Int8MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int16MultiArray, originalType, int16_t>("ros:std_msgs/Int16MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int32MultiArray, originalType, int32_t>("ros:std_msgs/Int32MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::Int64MultiArray, originalType, int64_t>("ros:std_msgs/Int64MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt8MultiArray, originalType, uint8_t>("ros:std_msgs/UInt8MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt16MultiArray, originalType, uint16_t>("ros:std_msgs/UInt16MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt32MultiArray, originalType, uint32_t>("ros:std_msgs/UInt32MultiArray");
+    ROSSequenceDataInitBaseFunc<DataType, std_msgs::UInt64MultiArray, originalType, uint64_t>("ros:std_msgs/UInt64MultiArray");
   }
 
   /*!
@@ -305,14 +305,14 @@ namespace RTC
   void ROSStringDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedString> >::
-            instance().addFactory("ROSString",
+            instance().addFactory("ros:std_msgs/String",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedString>,
             RTC::ROSStringData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedString>,
             RTC::ROSStringData>);
 
     RTC::ROSMessageInfoFactory::
-            instance().addFactory("ROSString",
+            instance().addFactory("ros:std_msgs/String",
             ::coil::Creator< ::RTC::ROSMessageInfoBase,
             RTC::ROSMessageInfo<std_msgs::String> >,
             ::coil::Destructor< ::RTC::ROSMessageInfoBase,
@@ -456,14 +456,14 @@ namespace RTC
   void ROSPont3DDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedPoint3D> >::
-            instance().addFactory("ROSPointStamped",
+            instance().addFactory("ros:geometry_msgs/PointStamped",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedPoint3D>,
             RTC::ROSPoint3DData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedPoint3D>,
             RTC::ROSPoint3DData>);
 
     RTC::ROSMessageInfoFactory::
-            instance().addFactory("ROSPointStamped",
+            instance().addFactory("ros:geometry_msgs/PointStamped",
             ::coil::Creator< ::RTC::ROSMessageInfoBase,
             RTC::ROSMessageInfo<geometry_msgs::PointStamped> >,
             ::coil::Destructor< ::RTC::ROSMessageInfoBase,
@@ -610,14 +610,14 @@ namespace RTC
   void ROSQuaternionDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedQuaternion> >::
-            instance().addFactory("ROSQuaternionStamped",
+            instance().addFactory("ros:geometry_msgs/QuaternionStamped",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedQuaternion>,
             RTC::ROSQuaternionData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedQuaternion>,
             RTC::ROSQuaternionData>);
 
     RTC::ROSMessageInfoFactory::
-            instance().addFactory("ROSQuaternionStamped",
+            instance().addFactory("ros:geometry_msgs/QuaternionStamped",
             ::coil::Creator< ::RTC::ROSMessageInfoBase,
             RTC::ROSMessageInfo<geometry_msgs::QuaternionStamped > >,
             ::coil::Destructor< ::RTC::ROSMessageInfoBase,
@@ -762,14 +762,14 @@ namespace RTC
   void ROSVector3DDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::TimedVector3D> >::
-            instance().addFactory("ROSVector3Stamped",
+            instance().addFactory("ros:geometry_msgs/Vector3Stamped",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::TimedVector3D>,
             RTC::ROSVector3DData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedVector3D>,
             RTC::ROSVector3DData>);
 
     RTC::ROSMessageInfoFactory::
-            instance().addFactory("ROSVector3Stamped",
+            instance().addFactory("ros:geometry_msgs/Vector3Stamped",
             ::coil::Creator< ::RTC::ROSMessageInfoBase,
             RTC::ROSMessageInfo<geometry_msgs::Vector3Stamped > >,
             ::coil::Destructor< ::RTC::ROSMessageInfoBase,
@@ -930,14 +930,14 @@ namespace RTC
   void ROSCameraImageDataInit()
   {
     coil::GlobalFactory < ::RTC::ByteDataStream<RTC::CameraImage> >::
-            instance().addFactory("ROSImage",
+            instance().addFactory("ros:sensor_msgs/Image",
             ::coil::Creator< ::RTC::ByteDataStream<RTC::CameraImage>,
             RTC::ROSCameraImageData>,
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::CameraImage>,
             RTC::ROSCameraImageData>);
 
     RTC::ROSMessageInfoFactory::
-            instance().addFactory("ROSImage",
+            instance().addFactory("ros:sensor_msgs/Image",
             ::coil::Creator< ::RTC::ROSMessageInfoBase,
             RTC::ROSMessageInfo<sensor_msgs::Image > >,
             ::coil::Destructor< ::RTC::ROSMessageInfoBase,


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
シリアライザの名前にstd_msgs、geometry_msgs、sensor_msgs等のメッセージの種類を含んでほしいという要望のため。

## Description of the Change
シリアライザの名前を以下のように変更。ROSの場合はros2をrosに変更。

|名前|クラス名|RTMデータ型|ROSメッセージ型|
|---|---|---|---|
|ros2:std_msgs/Float32|ROSSimpleData<DataType, Float32>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|Float32|
|ros2:std_msgs/Float64|ROSSimpleData<DataType, Float64>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|Float64|
|ros2:std_msgs/Int8|ROSSimpleData<DataType, Int8>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|Int8|
|ros2:std_msgs/Int16|ROSSimpleData<DataType, Int16>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|Int16|
|ros2:std_msgs/Int32|ROSSimpleData<DataType, UInt8>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|UInt8|
|ros2:std_msgs/Int64|ROSSimpleData<DataType, UInt16>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|UInt16|
|ros2:std_msgs/UInt32|ROSSimpleData<DataType, UInt32>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|UInt32|
|ros2:std_msgs/UInt64|ROSSimpleData<DataType, UInt64>|TimedState、TimedShort、TimedLong、TimedUShort、TimedULong、TimedFloat、TimedDouble|UInt64|
|ros2:std_msgs/Float32MultiArray|ROSSequenceData<DataType, Float32MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|Float32MultiArray|
|ros2:std_msgs/Float32MultiArray|ROSSequenceData<DataType, Float32MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|Float32MultiArray|
|ros2:std_msgs/Float64MultiArray|ROSSequenceData<DataType, Float64MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|Float64MultiArray|
|ros2:std_msgs/Int8MultiArray|ROSSequenceData<DataType, Int8MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|Int8MultiArray|
|ros2:std_msgs/Int16MultiArray|ROSSequenceData<DataType, Int16MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|Int16MultiArray|
|ros2:std_msgs/Int32MultiArray|ROSSequenceData<DataType, Int32MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|Int32MultiArray|
|ros2:std_msgs/Int64MultiArray|ROSSequenceData<DataType, Int64MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|Int64MultiArray|
|ros2:std_msgs/UInt8MultiArray|ROSSequenceData<DataType, UInt8MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|UInt8MultiArray|
|ros2:std_msgs/UInt16MultiArray|ROSSequenceData<DataType, UInt16MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|UInt16MultiArray|
|ros2:std_msgs/UInt32MultiArray|ROSSequenceData<DataType, UInt32MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|UInt32MultiArray|
|ros2:std_msgs/UInt64MultiArray|ROSSequenceData<DataType, UInt64MultiArray>|TimedShortSeq、TimedLongSeq、TimedUShortSeq、TimedULongSeq、TimedFloatSeq、TimedDoubleSeq|UInt64MultiArray|
|ros2:std_msgs/String|ROSStringData|TimedString|String|
|ros2:geometry_msgs/PointStamped|ROSPoint3DData|TimedPoint3D|PointStamped|
|ros2:geometry_msgs/QuaternionStamped|ROSQuaternionData|TimedQuaternion|QuaternionStamped|
|ros2:geometry_msgs/Vector3Stamped|ROSVector3DData|TimedVector3D|Vector3Stamped|
|ros2:sensor_msgs/Image|ROSCameraImageData|CameraImage|Image|



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
