### PR TITLE
ConnectorDataListenerHolderクラスのnotify関数の仕様を変更

### DIFF
--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -431,7 +431,7 @@ namespace RTC
       ~DataPortAction() override {}
 
       ReturnCode operator()(ConnectorInfo&  /*info*/,
-                            ByteData&  /*data*/, std::string& /*marsharingtype*/) override
+                            ByteData&  /*data*/, const std::string& /*marsharingtype*/) override
       {
         auto curr = std::chrono::steady_clock::now();
         auto intvl = curr - m_last;

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -431,7 +431,7 @@ namespace RTC
       ~DataPortAction() override {}
 
       ReturnCode operator()(ConnectorInfo&  /*info*/,
-                            ByteData&  /*data*/, PortType::Enum /*porttype*/) override
+                            ByteData&  /*data*/, std::string& /*marsharingtype*/) override
       {
         auto curr = std::chrono::steady_clock::now();
         auto intvl = curr - m_last;

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -127,13 +127,13 @@ namespace RTC
 
   ConnectorDataListenerHolder::ReturnCode
 	  ConnectorDataListenerHolder::notify(ConnectorInfo& info,
-                                                 ByteData& cdrdata, PortType::Enum porttype)
+                                                 ByteData& cdrdata, std::string& marsharingtype)
   {
     std::lock_guard<std::mutex> guard(m_mutex);
     ConnectorListenerHolder::ReturnCode ret(NO_CHANGE);
     for (auto & listener : m_listeners)
       {
-        ret = ret | listener.first->operator()(info, cdrdata, porttype);
+        ret = ret | listener.first->operator()(info, cdrdata, marsharingtype);
       }
     return ret;
   }

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -127,13 +127,13 @@ namespace RTC
 
   ConnectorDataListenerHolder::ReturnCode
 	  ConnectorDataListenerHolder::notify(ConnectorInfo& info,
-                                                 ByteData& cdrdata, std::string& marsharingtype)
+                                                 ByteData& cdrdata, const std::string& marshalingtype)
   {
     std::lock_guard<std::mutex> guard(m_mutex);
     ConnectorListenerHolder::ReturnCode ret(NO_CHANGE);
     for (auto & listener : m_listeners)
       {
-        ret = ret | listener.first->operator()(info, cdrdata, marsharingtype);
+        ret = ret | listener.first->operator()(info, cdrdata, marshalingtype);
       }
     return ret;
   }

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1068,7 +1068,7 @@ namespace RTC
      * @brief リスナーへ通知する(データ型指定版、InPort側)
      * 登録されているリスナのコールバックメソッドを呼び出す。
      * InPortとOutPortでシリアライザの種類が違う場合があるため、
-     * InPort側ではnotify_in関数を使用する必要がある。
+     * InPort側ではnotifyIn関数を使用する必要がある。
      *
      *
      * @param info ConnectorInfo
@@ -1083,7 +1083,7 @@ namespace RTC
      * @endif
      */
     template <class DataType>
-    ReturnCode notify_in(ConnectorInfo& info, DataType& typeddata)
+    ReturnCode notifyIn(ConnectorInfo& info, DataType& typeddata)
     {
         std::string marshaling_type = info.properties.getProperty("marshaling_type", "corba");
         marshaling_type = info.properties.getProperty("in.marshaling_type", marshaling_type);
@@ -1099,7 +1099,7 @@ namespace RTC
      * @brief リスナーへ通知する(データ型指定版、OutPort側)
      * 登録されているリスナのコールバックメソッドを呼び出す。
      * InPortとOutPortでシリアライザの種類が違う場合があるため、
-     * InPort側ではnotify_out関数を使用する必要がある。
+     * InPort側ではnotifyOut関数を使用する必要がある。
      *
      *
      * @param info ConnectorInfo
@@ -1114,7 +1114,7 @@ namespace RTC
      * @endif
      */
     template <class DataType>
-    ReturnCode notify_out(ConnectorInfo& info, DataType& typeddata)
+    ReturnCode notifyOut(ConnectorInfo& info, DataType& typeddata)
     {
         std::string marshaling_type = info.properties.getProperty("marshaling_type", "corba");
         marshaling_type = info.properties.getProperty("out.marshaling_type", marshaling_type);

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -480,7 +480,7 @@ namespace RTC
      * @endif
      */
     virtual ReturnCode operator()(ConnectorInfo& info,
-                            ByteData& data, std::string& marshalingtype) = 0;
+                            ByteData& data, const std::string& marshalingtype) = 0;
   };
 
   /*!
@@ -549,7 +549,7 @@ namespace RTC
      * @endif
      */
     ReturnCode operator()(ConnectorInfo& info,
-                                  ByteData& cdrdata, std::string& marshalingtype) override
+                                  ByteData& cdrdata, const std::string& marshalingtype) override
     {
       DataType data;
       
@@ -1060,7 +1060,7 @@ namespace RTC
      * @endif
      */
     ReturnCode notify(ConnectorInfo& info,
-                ByteData& cdrdata, std::string& marshalingtype);
+                ByteData& cdrdata, const std::string& marshalingtype);
 
     /*!
      * @if jp
@@ -1147,7 +1147,7 @@ namespace RTC
      * @endif
      */
     template <class DataType>
-    ReturnCode notify(ConnectorInfo& info, DataType& typeddata, std::string& marshalingtype)
+    ReturnCode notify(ConnectorInfo& info, DataType& typeddata, const std::string& marshalingtype)
     {
       std::lock_guard<std::mutex> guard(m_mutex);
       ReturnCode ret(NO_CHANGE);

--- a/src/lib/rtm/EventPort.h
+++ b/src/lib/rtm/EventPort.h
@@ -57,7 +57,7 @@ namespace RTC
     ~EventBinder0() override {}
 
     ReturnCode operator()(ConnectorInfo& info,
-                                  ByteData&  /*data*/, std::string& /*marshalingtype*/) override
+                                  ByteData&  /*data*/, const std::string& /*marshalingtype*/) override
     {
       if (info.properties["fsm_event_name"] == m_eventName ||
           info.name == m_eventName)

--- a/src/lib/rtm/EventPort.h
+++ b/src/lib/rtm/EventPort.h
@@ -57,7 +57,7 @@ namespace RTC
     ~EventBinder0() override {}
 
     ReturnCode operator()(ConnectorInfo& info,
-                                  ByteData&  /*data*/, PortType::Enum /*porttype*/) override
+                                  ByteData&  /*data*/, std::string& /*marshalingtype*/) override
     {
       if (info.properties["fsm_event_name"] == m_eventName ||
           info.name == m_eventName)

--- a/src/lib/rtm/InPortConnector.h
+++ b/src/lib/rtm/InPortConnector.h
@@ -339,16 +339,16 @@ namespace RTC
                     "callback called in direct mode."));
             }
             outport->read(data);
-            m_outPortListeners->connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::Enum::InPortType);
+            m_outPortListeners->connectorData_[ON_BUFFER_READ].notify_in(m_profile, data);
             RTC_TRACE(("ON_BUFFER_READ(OutPort), "));
             RTC_TRACE(("callback called in direct mode."));
-            m_outPortListeners->connectorData_[ON_SEND].notify(m_profile, data, PortType::Enum::InPortType);
+            m_outPortListeners->connectorData_[ON_SEND].notify_in(m_profile, data);
             RTC_TRACE(("ON_SEND(OutPort), "));
             RTC_TRACE(("callback called in direct mode."));
-            m_listeners.connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::Enum::InPortType);
+            m_listeners.connectorData_[ON_RECEIVED].notify_in(m_profile, data);
             RTC_TRACE(("ON_RECEIVED(InPort), "));
             RTC_TRACE(("callback called in direct mode."));
-            m_listeners.connectorData_[ON_SEND].notify(m_profile, data, PortType::Enum::InPortType);
+            m_listeners.connectorData_[ON_SEND].notify_in(m_profile, data);
             RTC_TRACE(("ON_BUFFER_WRITE(InPort), "));
             RTC_TRACE(("callback called in direct mode."));
 

--- a/src/lib/rtm/InPortConnector.h
+++ b/src/lib/rtm/InPortConnector.h
@@ -339,16 +339,16 @@ namespace RTC
                     "callback called in direct mode."));
             }
             outport->read(data);
-            m_outPortListeners->connectorData_[ON_BUFFER_READ].notify_in(m_profile, data);
+            m_outPortListeners->connectorData_[ON_BUFFER_READ].notifyIn(m_profile, data);
             RTC_TRACE(("ON_BUFFER_READ(OutPort), "));
             RTC_TRACE(("callback called in direct mode."));
-            m_outPortListeners->connectorData_[ON_SEND].notify_in(m_profile, data);
+            m_outPortListeners->connectorData_[ON_SEND].notifyIn(m_profile, data);
             RTC_TRACE(("ON_SEND(OutPort), "));
             RTC_TRACE(("callback called in direct mode."));
-            m_listeners.connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+            m_listeners.connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
             RTC_TRACE(("ON_RECEIVED(InPort), "));
             RTC_TRACE(("callback called in direct mode."));
-            m_listeners.connectorData_[ON_SEND].notify_in(m_profile, data);
+            m_listeners.connectorData_[ON_SEND].notifyIn(m_profile, data);
             RTC_TRACE(("ON_BUFFER_WRITE(InPort), "));
             RTC_TRACE(("callback called in direct mode."));
 

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -271,7 +271,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -286,7 +286,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -301,7 +301,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
     }
 
     /*!
@@ -316,7 +316,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -331,7 +331,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
     }
 
     /*!
@@ -346,7 +346,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -359,7 +359,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
     }
 
     /*!
@@ -372,7 +372,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -271,7 +271,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -286,7 +286,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -301,7 +301,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
     }
 
     /*!
@@ -316,7 +316,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -331,7 +331,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
     }
 
     /*!
@@ -346,7 +346,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -359,7 +359,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
     }
 
     /*!
@@ -372,7 +372,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -269,7 +269,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -284,7 +284,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -299,7 +299,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
     }
 
     /*!
@@ -314,7 +314,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -329,7 +329,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
     }
 
     /*!
@@ -344,7 +344,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -357,7 +357,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
     }
 
     /*!
@@ -370,7 +370,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -269,7 +269,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -284,7 +284,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -299,7 +299,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
     }
 
     /*!
@@ -314,7 +314,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -329,7 +329,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
     }
 
     /*!
@@ -344,7 +344,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -357,7 +357,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
     }
 
     /*!
@@ -370,7 +370,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data, PortType::Enum::InPortType);
+        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortDirectProvider.h
+++ b/src/lib/rtm/InPortDirectProvider.h
@@ -236,7 +236,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -251,7 +251,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -266,7 +266,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
     }
 
     /*!
@@ -281,7 +281,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -296,7 +296,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
     }
 
     /*!
@@ -311,7 +311,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -324,7 +324,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
     }
 
     /*!
@@ -337,7 +337,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortDirectProvider.h
+++ b/src/lib/rtm/InPortDirectProvider.h
@@ -236,7 +236,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -251,7 +251,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -266,7 +266,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
     }
 
     /*!
@@ -281,7 +281,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -296,7 +296,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
     }
 
     /*!
@@ -311,7 +311,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -324,7 +324,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
     }
 
     /*!
@@ -337,7 +337,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortPushConnector.h
+++ b/src/lib/rtm/InPortPushConnector.h
@@ -277,7 +277,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners.
-        connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_READ].notify_in(m_profile, data);
 
     }
     void onBufferEmpty(ByteData&  /*data*/)

--- a/src/lib/rtm/InPortPushConnector.h
+++ b/src/lib/rtm/InPortPushConnector.h
@@ -277,7 +277,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners.
-        connectorData_[ON_BUFFER_READ].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_READ].notifyIn(m_profile, data);
 
     }
     void onBufferEmpty(ByteData&  /*data*/)

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -193,49 +193,49 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
     }
 
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
     }
 
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
     }
 
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
     }
 
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
     }
 
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
     }
 
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
     }
 
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -193,49 +193,49 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
     }
 
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
     }
 
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
     }
 
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
     }
 
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
     }
 
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
     }
 
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
     }
 
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/OutPortConnector.h
+++ b/src/lib/rtm/OutPortConnector.h
@@ -226,30 +226,30 @@ namespace RTC
                 {
                   // ON_BUFFER_OVERWRITE(In,Out), ON_RECEIVER_FULL(In,Out) callback
                   m_listeners.
-                    connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data, PortType::OutPortType);
+                    connectorData_[ON_BUFFER_OVERWRITE].notify_out(m_profile, data);
                   m_inPortListeners->
-                    connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data, PortType::OutPortType);
+                    connectorData_[ON_BUFFER_OVERWRITE].notify_out(m_profile, data);
                   m_listeners.
-                    connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::OutPortType);
+                    connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
                   m_inPortListeners->
-                    connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::OutPortType);
+                    connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
                   RTC_PARANOID(("ON_BUFFER_OVERWRITE(InPort,OutPort), "
                                 "ON_RECEIVER_FULL(InPort,OutPort) "
                                 "callback called in direct mode."));
                 }
               // ON_BUFFER_WRITE(In,Out) callback
               m_listeners.
-                connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::OutPortType);
+                connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
               m_inPortListeners->
-                connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::OutPortType);
+                connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
               RTC_PARANOID(("ON_BUFFER_WRITE(InPort,OutPort), "
                                 "callback called in direct mode."));
               inport->write(data);  // write to InPort variable!!
               // ON_RECEIVED(In,Out) callback
               m_listeners.
-                connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::OutPortType);
+                connectorData_[ON_RECEIVED].notify_out(m_profile, data);
               m_inPortListeners->
-                connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::OutPortType);
+                connectorData_[ON_RECEIVED].notify_out(m_profile, data);
               RTC_PARANOID(("ON_RECEIVED(InPort,OutPort), "
                             "callback called in direct mode."));
               

--- a/src/lib/rtm/OutPortConnector.h
+++ b/src/lib/rtm/OutPortConnector.h
@@ -226,30 +226,30 @@ namespace RTC
                 {
                   // ON_BUFFER_OVERWRITE(In,Out), ON_RECEIVER_FULL(In,Out) callback
                   m_listeners.
-                    connectorData_[ON_BUFFER_OVERWRITE].notify_out(m_profile, data);
+                    connectorData_[ON_BUFFER_OVERWRITE].notifyOut(m_profile, data);
                   m_inPortListeners->
-                    connectorData_[ON_BUFFER_OVERWRITE].notify_out(m_profile, data);
+                    connectorData_[ON_BUFFER_OVERWRITE].notifyOut(m_profile, data);
                   m_listeners.
-                    connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
+                    connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
                   m_inPortListeners->
-                    connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
+                    connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
                   RTC_PARANOID(("ON_BUFFER_OVERWRITE(InPort,OutPort), "
                                 "ON_RECEIVER_FULL(InPort,OutPort) "
                                 "callback called in direct mode."));
                 }
               // ON_BUFFER_WRITE(In,Out) callback
               m_listeners.
-                connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
+                connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
               m_inPortListeners->
-                connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
+                connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
               RTC_PARANOID(("ON_BUFFER_WRITE(InPort,OutPort), "
                                 "callback called in direct mode."));
               inport->write(data);  // write to InPort variable!!
               // ON_RECEIVED(In,Out) callback
               m_listeners.
-                connectorData_[ON_RECEIVED].notify_out(m_profile, data);
+                connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
               m_inPortListeners->
-                connectorData_[ON_RECEIVED].notify_out(m_profile, data);
+                connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
               RTC_PARANOID(("ON_RECEIVED(InPort,OutPort), "
                             "callback called in direct mode."));
               

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.h
@@ -281,7 +281,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -296,7 +296,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -311,7 +311,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
     }
 
     /*!
@@ -326,7 +326,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.h
@@ -281,7 +281,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -296,7 +296,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -311,7 +311,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
     }
 
     /*!
@@ -326,7 +326,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -267,7 +267,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
     }
 
     /*!
@@ -282,7 +282,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_SEND].notify_out(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -267,7 +267,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
     }
 
     /*!
@@ -282,7 +282,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify_out(m_profile, data);
+        connectorData_[ON_SEND].notifyOut(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortDSConsumer.h
+++ b/src/lib/rtm/OutPortDSConsumer.h
@@ -279,7 +279,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -294,7 +294,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -309,7 +309,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
     }
 
     /*!
@@ -324,7 +324,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortDSConsumer.h
+++ b/src/lib/rtm/OutPortDSConsumer.h
@@ -279,7 +279,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -294,7 +294,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -309,7 +309,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
     }
 
     /*!
@@ -324,7 +324,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -265,7 +265,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
     }
 
     /*!
@@ -280,7 +280,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify_out(m_profile, data);
+        connectorData_[ON_SEND].notifyOut(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -265,7 +265,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
     }
 
     /*!
@@ -280,7 +280,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_SEND].notify_out(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortDirectProvider.h
+++ b/src/lib/rtm/OutPortDirectProvider.h
@@ -232,7 +232,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
     }
 
     /*!
@@ -247,7 +247,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify_out(m_profile, data);
+        connectorData_[ON_SEND].notifyOut(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortDirectProvider.h
+++ b/src/lib/rtm/OutPortDirectProvider.h
@@ -232,7 +232,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
     }
 
     /*!
@@ -247,7 +247,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_SEND].notify_out(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortSHMConsumer.h
+++ b/src/lib/rtm/OutPortSHMConsumer.h
@@ -236,7 +236,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
     }
 
     /*!
@@ -251,7 +251,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
     }
 
     /*!
@@ -266,7 +266,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
     }
 
     /*!
@@ -281,7 +281,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::InPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortSHMConsumer.h
+++ b/src/lib/rtm/OutPortSHMConsumer.h
@@ -236,7 +236,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
     }
 
     /*!
@@ -251,7 +251,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
     }
 
     /*!
@@ -266,7 +266,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
     }
 
     /*!
@@ -281,7 +281,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_in(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -211,7 +211,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
     }
 
     /*!
@@ -226,7 +226,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_SEND].notify_out(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -211,7 +211,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
     }
 
     /*!
@@ -226,7 +226,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify_out(m_profile, data);
+        connectorData_[ON_SEND].notifyOut(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/PublisherFlush.h
+++ b/src/lib/rtm/PublisherFlush.h
@@ -361,7 +361,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify_out(m_profile, data);
+        connectorData_[ON_SEND].notifyOut(m_profile, data);
     }
 
     /*!
@@ -376,7 +376,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
     }
 
     /*!
@@ -391,7 +391,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
     }
 
     /*!
@@ -406,7 +406,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT].notifyOut(m_profile, data);
     }
 
     /*!
@@ -421,7 +421,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR].notifyOut(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/PublisherFlush.h
+++ b/src/lib/rtm/PublisherFlush.h
@@ -361,7 +361,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_SEND].notify_out(m_profile, data);
     }
 
     /*!
@@ -376,7 +376,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVED].notify_out(m_profile, data);
     }
 
     /*!
@@ -391,7 +391,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
     }
 
     /*!
@@ -406,7 +406,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_TIMEOUT].notify_out(m_profile, data);
     }
 
     /*!
@@ -421,7 +421,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_ERROR].notify_out(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/PublisherNew.h
+++ b/src/lib/rtm/PublisherNew.h
@@ -560,7 +560,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
     }
 
     /*!
@@ -575,7 +575,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_FULL].notify_out(m_profile, data);
     }
 
     /*!
@@ -590,7 +590,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_out(m_profile, data);
     }
 
     /*!
@@ -605,7 +605,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_OVERWRITE].notify_out(m_profile, data);
     }
 
     /*!
@@ -620,7 +620,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
     }
 
     /*!
@@ -635,7 +635,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_SEND].notify_out(m_profile, data);
     }
 
     /*!
@@ -650,7 +650,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVED].notify_out(m_profile, data);
     }
 
     /*!
@@ -665,7 +665,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
     }
 
     /*!
@@ -680,7 +680,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_TIMEOUT].notify_out(m_profile, data);
     }
 
     /*!
@@ -695,7 +695,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_ERROR].notify_out(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/PublisherNew.h
+++ b/src/lib/rtm/PublisherNew.h
@@ -560,7 +560,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
     }
 
     /*!
@@ -575,7 +575,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyOut(m_profile, data);
     }
 
     /*!
@@ -590,7 +590,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyOut(m_profile, data);
     }
 
     /*!
@@ -605,7 +605,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE].notifyOut(m_profile, data);
     }
 
     /*!
@@ -620,7 +620,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
     }
 
     /*!
@@ -635,7 +635,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify_out(m_profile, data);
+        connectorData_[ON_SEND].notifyOut(m_profile, data);
     }
 
     /*!
@@ -650,7 +650,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
     }
 
     /*!
@@ -665,7 +665,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
     }
 
     /*!
@@ -680,7 +680,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT].notifyOut(m_profile, data);
     }
 
     /*!
@@ -695,7 +695,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR].notifyOut(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/PublisherPeriodic.h
+++ b/src/lib/rtm/PublisherPeriodic.h
@@ -558,7 +558,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
     }
 
     /*!
@@ -573,7 +573,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_FULL].notifyOut(m_profile, data);
     }
 
     /*!
@@ -588,7 +588,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyOut(m_profile, data);
     }
 
     /*!
@@ -603,7 +603,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
+        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
     }
 
     /*!
@@ -618,7 +618,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify_out(m_profile, data);
+        connectorData_[ON_SEND].notifyOut(m_profile, data);
     }
 
     /*!
@@ -633,7 +633,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
     }
 
     /*!
@@ -648,7 +648,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
     }
 
     /*!
@@ -663,7 +663,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT].notifyOut(m_profile, data);
     }
 
     /*!
@@ -678,7 +678,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify_out(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR].notifyOut(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/PublisherPeriodic.h
+++ b/src/lib/rtm/PublisherPeriodic.h
@@ -558,7 +558,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_WRITE].notify_out(m_profile, data);
     }
 
     /*!
@@ -573,7 +573,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_FULL].notify_out(m_profile, data);
     }
 
     /*!
@@ -588,7 +588,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify_out(m_profile, data);
     }
 
     /*!
@@ -603,7 +603,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_BUFFER_READ].notify_out(m_profile, data);
     }
 
     /*!
@@ -618,7 +618,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_SEND].notify_out(m_profile, data);
     }
 
     /*!
@@ -633,7 +633,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVED].notify_out(m_profile, data);
     }
 
     /*!
@@ -648,7 +648,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_FULL].notify_out(m_profile, data);
     }
 
     /*!
@@ -663,7 +663,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_TIMEOUT].notify_out(m_profile, data);
     }
 
     /*!
@@ -678,7 +678,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data, PortType::OutPortType);
+        connectorData_[ON_RECEIVER_ERROR].notify_out(m_profile, data);
     }
 
     /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

OutPortとInPortでシリアライザを個別に設定するために、#489 でConnectorDataListenerHolderクラスのnotify関数の引数でInPort、OutPortを指定するようにしたが、ポートの種類の指定方法について苦情があったため修正する。



## Description of the Change
`notifyOut`関数、`notifyIn`関数を新たに実装した。
InPort側では`notifyIn`関数、OutPort側では`notifyOut`関数を呼ぶようにした。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
