### PR TITLE
Unsupport msvc2012 on appveyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,7 +72,7 @@ cache:
 
 only_commits:
   files:
-    - appveyor.yml
+    - .appveyor.yml
     - CMakeLists.txt
     - etc/
     - examples/

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,10 +18,6 @@ environment:
       cmake_archtecture: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       python: 27
-    - cmake_generator: Visual Studio 11 2012
-      cmake_archtecture: x64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      python: 27
 matrix:
   fast_finish: true
 
@@ -36,7 +32,6 @@ init:
   - ps: $Env:cmake_archtecture
   - ps: |
       switch ($Env:cmake_generator) {
-        "Visual Studio 11 2012" { $vc_tool = "110" }
         "Visual Studio 12 2013" { $vc_tool = "120" }
         "Visual Studio 14 2015" { $vc_tool = "140" }
         "Visual Studio 15 2017" { $vc_tool = "140" }


### PR DESCRIPTION
## Description of the Change

MSVC 2012 をサポート対象から外すため、appveyor の自動ビルドをやめる。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
