### PR TITLE
Add StringTo(std::chrono::duratio, ...).

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -721,6 +721,127 @@ namespace coil
     return false;
   }
 
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd::chrono::duratoin<double>に変換
+   * @else
+   * @brief Convert the given string to std::chrono::duratoin<double>.
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::duration<double>>(std::chrono::duration<double>& val,
+                                               const char* str)
+  {
+    double num;
+    if (stringTo(num, str)) {
+      val = std::chrono::duration<double>(num);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列 (実数､単位[s]) をstd::chrono::duratoin<>に変換
+   * @else
+   * @brief Convert the given string to std::chrono::duratoin<>.
+   * @endif
+   */
+  template<typename duration>
+  bool stringToDuration(duration& val, const char* str)
+  {
+    std::chrono::duration<double> val_d;
+    if (stringTo(val_d, str)) {
+      val = std::chrono::duration_cast<duration>(val_d);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列 (実数､単位[s]) をstd::chrono::nanosecondsに変換
+   * @else
+   * @brief Convert the given string to std::chrono::nanoseconds.
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::nanoseconds>(std::chrono::nanoseconds& val,
+                                          const char* str)
+  {
+    return stringToDuration(val, str);
+  }
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列 (実数､単位[s]) をstd::chrono::microsecondsに変換
+   * @else
+   * @brief Convert the given string to std::chrono::microseconds.
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::microseconds>(std::chrono::microseconds& val,
+                                           const char* str)
+  {
+    return stringToDuration(val, str);
+  }
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列 (実数､単位[s]) をstd::chrono::millisecondsに変換
+   * @else
+   * @brief Convert the given string to std::chrono::milliseconds.
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::milliseconds>(std::chrono::milliseconds& val,
+                                           const char* str)
+  {
+    return stringToDuration(val, str);
+  }
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列 (実数､単位[s]) をstd::chrono::secondsに変換
+   * @else
+   * @brief Convert the given string to std::chrono::seconds.
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::seconds>(std::chrono::seconds& val,
+                                      const char* str)
+  {
+    return stringToDuration(val, str);
+  }
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列 (実数､単位[s]) をstd::chrono::minutesに変換
+   * @else
+   * @brief Convert the given string to std::chrono::minutes.
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::minutes>(std::chrono::minutes& val,
+                                      const char* str)
+  {
+    return stringToDuration(val, str);
+  }
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列 (実数､単位[s]) をstd::chrono::hoursに変換
+   * @else
+   * @brief Convert the given string to std::chrono::hours.
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::hours>(std::chrono::hours& val, const char* str)
+  {
+    return stringToDuration(val, str);
+  }
 
   /*!
    * @if jp

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <cerrno>
 #include <cstdlib>
+#include <chrono>
 
 #if defined (_MSC_VER) && (_MSC_VER <=1500)  // VC2008(VC9.0) or before
 #elif defined(VXWORKS_66) && !defined(__RTP__)
@@ -693,6 +694,194 @@ namespace coil
    */
   template <>
   bool stringTo<bool>(bool& val, const char* str);
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd:chrono::duration<double>に変換
+   *
+   * 引数で与えられた文字列をstd:chrono::duration<double>に変換する。
+   *
+   * @param val 変換先文字列
+   * @param str 変換元文字列
+   *
+   * @return true: 成功, false: 失敗
+   *
+   * @else
+   * @brief Convert the given string to std:chrono::duration<double>.
+   *
+   * Convert string given by the argument to std:chrono::duration<double>.
+   *
+   * @param val String of conversion destination
+   * @param str String of conversion source
+   *
+   * @return true: successful, false: failed
+   *
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::duration<double>>(std::chrono::duration<double>& val,
+                                               const char* str);
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd:chrono::nanosecondsに変換
+   *
+   * 引数で与えられた文字列をstd:chrono::nanosecondsに変換する。
+   *
+   * @param val 変換先文字列
+   * @param str 変換元文字列
+   *
+   * @return true: 成功, false: 失敗
+   *
+   * @else
+   * @brief Convert the given string to std:chrono::nanoseconds.
+   *
+   * Convert string given by the argument to std:chrono::nanoseconds.
+   *
+   * @param val String of conversion destination
+   * @param str String of conversion source
+   *
+   * @return true: successful, false: failed
+   *
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::nanoseconds>(std::chrono::nanoseconds& val,
+                                          const char* str);
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd:chrono::microsecondsに変換
+   *
+   * 引数で与えられた文字列をstd:chrono::microsecondsに変換する。
+   *
+   * @param val 変換先文字列
+   * @param str 変換元文字列
+   *
+   * @return true: 成功, false: 失敗
+   *
+   * @else
+   * @brief Convert the given string to std:chrono::microseconds.
+   *
+   * Convert string given by the argument to std:chrono::microseconds.
+   *
+   * @param val String of conversion destination
+   * @param str String of conversion source
+   *
+   * @return true: successful, false: failed
+   *
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::microseconds>(std::chrono::microseconds& val,
+                                           const char* str);
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd:chrono::millisecondsに変換
+   *
+   * 引数で与えられた文字列をstd:chrono::millisecondsに変換する。
+   *
+   * @param val 変換先文字列
+   * @param str 変換元文字列
+   *
+   * @return true: 成功, false: 失敗
+   *
+   * @else
+   * @brief Convert the given string to std:chrono::milliseconds.
+   *
+   * Convert string given by the argument to std:chrono::milliseconds.
+   *
+   * @param val String of conversion destination
+   * @param str String of conversion source
+   *
+   * @return true: successful, false: failed
+   *
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::milliseconds>(std::chrono::milliseconds& val,
+                                           const char* str);
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd:chrono::secondsに変換
+   *
+   * 引数で与えられた文字列をstd:chrono::secondsに変換する。
+   *
+   * @param val 変換先文字列
+   * @param str 変換元文字列
+   *
+   * @return true: 成功, false: 失敗
+   *
+   * @else
+   * @brief Convert the given string to std:chrono::seconds.
+   *
+   * Convert string given by the argument to std:chrono::seconds.
+   *
+   * @param val String of conversion destination
+   * @param str String of conversion source
+   *
+   * @return true: successful, false: failed
+   *
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::seconds>(std::chrono::seconds& val,
+                                      const char* str);
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd:chrono::minutesに変換
+   *
+   * 引数で与えられた文字列をstd:chrono::minutesに変換する。
+   *
+   * @param val 変換先文字列
+   * @param str 変換元文字列
+   *
+   * @return true: 成功, false: 失敗
+   *
+   * @else
+   * @brief Convert the given string to std:chrono::minutes.
+   *
+   * Convert string given by the argument to std:chrono::minutes.
+   *
+   * @param val String of conversion destination
+   * @param str String of conversion source
+   *
+   * @return true: successful, false: failed
+   *
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::minutes>(std::chrono::minutes& val,
+                                      const char* str);
+
+  /*!
+   * @if jp
+   * @brief 与えられた文字列をstd:chrono::hoursに変換
+   *
+   * 引数で与えられた文字列をstd:chrono::hoursに変換する。
+   *
+   * @param val 変換先文字列
+   * @param str 変換元文字列
+   *
+   * @return true: 成功, false: 失敗
+   *
+   * @else
+   * @brief Convert the given string to std:chrono::hours.
+   *
+   * Convert string given by the argument to std:chrono::hours.
+   *
+   * @param val String of conversion destination
+   * @param str String of conversion source
+   *
+   * @return true: successful, false: failed
+   *
+   * @endif
+   */
+  template<>
+  bool stringTo<std::chrono::hours>(std::chrono::hours& val, const char* str);
 
   /*!
    * @if jp


### PR DESCRIPTION
## Description of the Change

コンフィグレーションパラメータのC++11対応のために、
std::chrono::duration<> に対応した coil::StringTo（） を導入する。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
