### PR TITLE
coil::Task::wait() wait thread completion.

### DIFF
--- a/src/lib/coil/common/coil/Task.cpp
+++ b/src/lib/coil/common/coil/Task.cpp
@@ -29,7 +29,6 @@ namespace coil
    * @endif
    */
   Task::Task()
-    : m_count(0)
   {
   }
 
@@ -42,7 +41,6 @@ namespace coil
    */
   Task::~Task()
   {
-    m_count = 0;
   }
 
   /*!
@@ -71,18 +69,6 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief スレッドを実行する
-   * @else
-   * @brief Execute thread
-   * @endif
-   */
-  int Task::svc()
-  {
-    return 0;
-  }
-
-  /*!
-   * @if jp
    * @brief スレッドを生成する
    * @else
    * @brief Create a thread
@@ -90,13 +76,12 @@ namespace coil
    */
   void Task::activate()
   {
-    if (m_count == 0)
+    if (!m_thread.joinable())
       {
         m_thread = std::thread([this] {
                                    svc();
                                    finalize();
                                });
-        ++m_count;
       };
   }
 
@@ -109,9 +94,9 @@ namespace coil
    */
   int Task::wait()
   {
-    if (m_count > 0)
+      if (m_thread.joinable())
       {
-         m_thread.join();
+        m_thread.join();
       }
     return 0;
   }
@@ -142,18 +127,6 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief タスク数リセット
-   * @else
-   * @brief Reset of task count
-   * @endif
-   */
-  void Task::reset()
-  {
-    m_count = 0;
-  }
-
-  /*!
-   * @if jp
    * @brief タスク実行を終了する
    * @else
    * @brief Finalizing the task
@@ -161,7 +134,6 @@ namespace coil
    */
   void Task::finalize()
   {
-    reset();
   }
 
 } // namespace coil

--- a/src/lib/coil/common/coil/Task.h
+++ b/src/lib/coil/common/coil/Task.h
@@ -130,7 +130,7 @@ namespace coil
      *
      * @endif
      */
-    virtual int svc();
+    virtual int svc() = 0;
 
     /*!
      * @if jp
@@ -203,23 +203,6 @@ namespace coil
     /*!
      * @if jp
      *
-     * @brief タスク数リセット
-     *
-     * タスク数リセット
-     *
-     * @else
-     *
-     * @brief Reset of task count
-     *
-     * Reset of task count
-     *
-     * @endif
-     */
-    virtual void reset();
-
-    /*!
-     * @if jp
-     *
      * @brief タスク実行を終了する
      *
      * タスク実行を終了する
@@ -235,7 +218,6 @@ namespace coil
     virtual void finalize();
 
   private:
-    int m_count;
     std::thread m_thread;
   };
 } // namespace coil


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

close #503.

作ったスレッドの中で finalize() → reset() → m_count =0 と実行されるために、
スレッドを作った側が Task::wait() をコールしても、 
すでに m_count == 0 となっている場合に join() できない。

std::thread を使う前からのバグであるが、
std::thread は join（） せずにデストラクタがコールされると例外を発行するため気がついた。

## Description of the Change

タスクが実行されているかどうかだけがわかれば良いので thread.joinable() を m_count の代わりに用いる。
m_count がなぜカウンタなのかや、 reset() でカウンタだけ0になるなど設計意図がよくわからない。
よって、 reset() も削除する。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
