### PR TITLE
Examples components read parameters as std::chrono::duration.

### DIFF
--- a/examples/Analyzer/Analyzer.cpp
+++ b/examples/Analyzer/Analyzer.cpp
@@ -192,13 +192,7 @@ RTC::ReturnCode_t Analyzer::onExecute(RTC::UniqueId  /*ec_id*/)
 		std::lock_guard<std::mutex> guard(m_mu);
 		m_datalist.push_back(m_out);
 	}
-	auto end = std::chrono::system_clock::now();
-	double diff = std::chrono::duration<double>(end - start).count();
-	if(diff < m_sleep_time)
-	{
-		coil::sleep(coil::TimeValue(m_sleep_time - diff));
-	}
-	
+	std::this_thread::sleep_until(start + m_sleep_time);
 
 	m_outOut.write();
 

--- a/examples/Analyzer/Analyzer.h
+++ b/examples/Analyzer/Analyzer.h
@@ -262,7 +262,7 @@ class Analyzer
   * - Name: sleep_time sleep_time
   * - DefaultValue: 0.01
   */
-  double m_sleep_time;
+  std::chrono::microseconds m_sleep_time;
   /*!
   * 通信データ量を一定値(const)にするか、徐々に増加する値(increase)にするかの設定
   * - Name: mode mode

--- a/examples/Analyzer/Analyzer_test.cpp
+++ b/examples/Analyzer/Analyzer_test.cpp
@@ -133,12 +133,7 @@ RTC::ReturnCode_t Analyzer_test::onExecute(RTC::UniqueId  /*ec_id*/)
 		auto start = std::chrono::system_clock::now();
 		m_inIn.read();
 		m_out = m_in;
-		auto end = std::chrono::system_clock::now();
-		double diff = std::chrono::duration<double>(end - start).count();
-		if (diff < m_sleep_time)
-		{
-			coil::sleep(coil::TimeValue(m_sleep_time - diff));
-		}
+		std::this_thread::sleep_until(start + m_sleep_time);
 		
 		m_outOut.write();
 	}

--- a/examples/Analyzer/Analyzer_test.h
+++ b/examples/Analyzer/Analyzer_test.h
@@ -240,7 +240,7 @@ class Analyzer_test
    * - DefaultValue: 0.01
    * - Unit: s
    */
-  double m_sleep_time;
+  std::chrono::microseconds m_sleep_time;
 
   // </rtc-template>
 

--- a/examples/Throughput/Throughput.cpp
+++ b/examples/Throughput/Throughput.cpp
@@ -265,7 +265,8 @@ RTC::ReturnCode_t Throughput::onExecute(RTC::UniqueId ec_id)
   std::cout << "\tsendcount: " << m_sendcount << std::endl;
 #endif // DEBUG
 
-  coil::sleep(coil::TimeValue(m_sleep_time)); // sleep for calculating measurement statistics
+  // sleep for calculating measurement statistics
+  std::this_thread::sleep_for(m_sleep_time);
 
   // calculation is triggered data size change
   // to finish the last calculation, size 0 array is sent

--- a/examples/Throughput/Throughput.h
+++ b/examples/Throughput/Throughput.h
@@ -319,7 +319,7 @@ class Throughput
   * - Name: sleep_time sleep_time
   * - DefaultValue: 0.01
   */
-  double m_sleep_time;
+  std::chrono::microseconds m_sleep_time;
   /*!
    * 通信データ量を一定値(const)にするか、徐々に増加する値(increase)に
    * するかの設定


### PR DESCRIPTION
## Description of the Change

サンプルコンポーネントの時間関連のパラメータを double 型ではなく、
std::chrono::duration （今回は microseconds ）でリードする。

milliseconds 単位でも十分な気がしましたが、仕様がわからないので細かめに取ります。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
