### PR TITLE
Load "manager.termination_waittime" as std::chrono::duration.

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1253,14 +1253,11 @@ std::vector<coil::Properties> Manager::getLoadableModules()
     m_module = new ModuleManager(m_config);
 
     // initialize Terminator
-    double waittime(0.5);
-    if (m_config.findNode("manager.termination_waittime") != nullptr)
+    std::chrono::milliseconds waittime;
+    if ((m_config.findNode("manager.termination_waittime") == nullptr)
+         || !coil::stringTo(waittime, m_config["manager.termination_waittime"].c_str()))
       {
-	const char* s = m_config["manager.termination_waittime"].c_str();
-	if (!coil::stringTo(waittime, s))
-	  {
-	    waittime = 0.5;
-	  }
+          waittime = std::chrono::milliseconds(500);
       }
     m_terminator = new Terminator(this, waittime);
     {

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -2410,7 +2410,7 @@ namespace RTC
        *
        * @endif
        */
-      explicit Terminator(Manager* mgr, double waittime = 0)
+      explicit Terminator(Manager* mgr, std::chrono::nanoseconds waittime = std::chrono::seconds::zero())
                 : m_manager(mgr), m_waittime(waittime) {}
 
       /*!
@@ -2477,12 +2477,12 @@ namespace RTC
        */
       int svc() override
       {
-        coil::sleep(m_waittime);
+        std::this_thread::sleep_for(m_waittime);
         Manager::instance().shutdown();
         return 0;
       }
       Manager* m_manager;
-      coil::TimeValue m_waittime;
+      std::chrono::nanoseconds m_waittime;
     };
 
     /*!


### PR DESCRIPTION
## Description of the Change

コンフィグパラメータ "manager.termination_waittime" を std::chrono::nanoseconds として読み込む。
ナノ秒単位である必要はないと思いますが、使用上の最小単位がわからないので細かくしています。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
 Ubuntu18.04 ConsoleInComp で動作を確認
パラメータ設定ない場合 -> 500,000,000 ns
 0.001に設定した場合 -> 1,000,000 ns