### PR TITLE
Fix "const" of char const* tables and "static" in headers.

### DIFF
--- a/examples/Analyzer/Analyzer.cpp
+++ b/examples/Analyzer/Analyzer.cpp
@@ -15,7 +15,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* analyzer_spec[] =
+static const char* const analyzer_spec[] =
   {
     "implementation_id", "Analyzer",
     "type_name",         "Analyzer",

--- a/examples/Analyzer/Analyzer_test.cpp
+++ b/examples/Analyzer/Analyzer_test.cpp
@@ -15,7 +15,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* analyzer_test_spec[] =
+static const char* const analyzer_test_spec[] =
   {
     "implementation_id", "Analyzer_test",
     "type_name",         "Analyzer_test",

--- a/examples/AutoTest/AutoTestIn.cpp
+++ b/examples/AutoTest/AutoTestIn.cpp
@@ -11,7 +11,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* autotestin_spec[] =
+static const char* const autotestin_spec[] =
   {
     "implementation_id", "AutoTestIn",
     "type_name",         "AutoTestIn",

--- a/examples/AutoTest/AutoTestOut.cpp
+++ b/examples/AutoTest/AutoTestOut.cpp
@@ -14,7 +14,7 @@
 #include "AutoTestOut.h"
 // Module specification
 // <rtc-template block="module_spec">
-static const char* autotestout_spec[] =
+static const char* const autotestout_spec[] =
   {
     "implementation_id", "AutoTestOut",
     "type_name",         "AutoTestOut",

--- a/examples/Composite/Controller.cpp
+++ b/examples/Composite/Controller.cpp
@@ -8,7 +8,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* controller_spec[] =
+static const char* const controller_spec[] =
   {
     "implementation_id", "Controller",
     "type_name",         "Controller",

--- a/examples/Composite/Motor.cpp
+++ b/examples/Composite/Motor.cpp
@@ -9,7 +9,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* motor_spec[] =
+static const char* const motor_spec[] =
   {
     "implementation_id", "Motor",
     "type_name",         "Motor",

--- a/examples/Composite/Sensor.cpp
+++ b/examples/Composite/Sensor.cpp
@@ -8,7 +8,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* sensor_spec[] =
+static const char* const sensor_spec[] =
   {
     "implementation_id", "Sensor",
     "type_name",         "Sensor",

--- a/examples/ConfigSample/ConfigSample.cpp
+++ b/examples/ConfigSample/ConfigSample.cpp
@@ -12,7 +12,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* configsample_spec[] =
+static const char* const configsample_spec[] =
   {
     "implementation_id", "ConfigSample",
     "type_name",         "ConfigSample",

--- a/examples/ExtTrigger/ConsoleIn.cpp
+++ b/examples/ExtTrigger/ConsoleIn.cpp
@@ -12,7 +12,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consolein_spec[] =
+static const char* const consolein_spec[] =
   {
     "implementation_id", "ConsoleIn",
     "type_name",         "ConsoleIn",

--- a/examples/ExtTrigger/ConsoleOut.cpp
+++ b/examples/ExtTrigger/ConsoleOut.cpp
@@ -11,7 +11,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consoleout_spec[] =
+static const char* const consoleout_spec[] =
   {
     "implementation_id", "ConsoleOut",
     "type_name",         "ConsoleOut",

--- a/examples/Fsm/Fsm.cc
+++ b/examples/Fsm/Fsm.cc
@@ -19,7 +19,7 @@
 #if defined(_MSC_VER)
   __pragma(warning(pop))
 #endif
-static const char* fsm_spec[] = {
+static const char* const fsm_spec[] = {
   "implementation_id", "Fsm",
   "type_name",         "Fsm",
   "description",       "Fsm component",

--- a/examples/SeqIO/SeqIn.cpp
+++ b/examples/SeqIO/SeqIn.cpp
@@ -15,7 +15,7 @@ bool g_Listener_dump_enabled = false;
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* seqin_spec[] =
+static const char* const seqin_spec[] =
   {
     "implementation_id", "SeqIn",
     "type_name",         "SequenceInComponent",

--- a/examples/SeqIO/SeqOut.cpp
+++ b/examples/SeqIO/SeqOut.cpp
@@ -15,7 +15,7 @@ bool g_Listener_dump_enabled = false;
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* seqout_spec[] =
+static const char* const seqout_spec[] =
   {
     "implementation_id", "SeqOut",
     "type_name",         "SequenceOutComponent",

--- a/examples/Serializer/ConsoleInShort.cpp
+++ b/examples/Serializer/ConsoleInShort.cpp
@@ -12,7 +12,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consoleinshort_spec[] =
+static const char* const consoleinshort_spec[] =
   {
     "implementation_id", "ConsoleInShort",
     "type_name",         "ConsoleInShort",

--- a/examples/Serializer/ConsoleOutDouble.cpp
+++ b/examples/Serializer/ConsoleOutDouble.cpp
@@ -11,7 +11,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consoleoutdouble_spec[] =
+static const char* const consoleoutdouble_spec[] =
   {
     "implementation_id", "ConsoleOutDouble",
     "type_name",         "ConsoleOutDouble",

--- a/examples/SimpleIO/ConsoleIn.cpp
+++ b/examples/SimpleIO/ConsoleIn.cpp
@@ -12,7 +12,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consolein_spec[] =
+static const char* const consolein_spec[] =
   {
     "implementation_id", "ConsoleIn",
     "type_name",         "ConsoleIn",

--- a/examples/SimpleIO/ConsoleOut.cpp
+++ b/examples/SimpleIO/ConsoleOut.cpp
@@ -11,7 +11,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consoleout_spec[] =
+static const char* const consoleout_spec[] =
   {
     "implementation_id", "ConsoleOut",
     "type_name",         "ConsoleOut",

--- a/examples/SimpleService/MyServiceConsumer.cpp
+++ b/examples/SimpleService/MyServiceConsumer.cpp
@@ -16,7 +16,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* myserviceconsumer_spec[] =
+static const char* const myserviceconsumer_spec[] =
   {
     "implementation_id", "MyServiceConsumer",
     "type_name",         "MyServiceConsumer",

--- a/examples/SimpleService/MyServiceProvider.cpp
+++ b/examples/SimpleService/MyServiceProvider.cpp
@@ -11,7 +11,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* myserviceprovider_spec[] =
+static const char* const myserviceprovider_spec[] =
   {
     "implementation_id", "MyServiceProvider",
     "type_name",         "MyServiceProvider",

--- a/examples/StaticFsm/Display.cpp
+++ b/examples/StaticFsm/Display.cpp
@@ -11,7 +11,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consoleout_spec[] =
+static const char* const consoleout_spec[] =
   {
     "implementation_id", "Display",
     "type_name",         "Display",

--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -12,7 +12,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consolein_spec[] =
+static const char* const consolein_spec[] =
   {
     "implementation_id", "Inputbutton",
     "type_name",         "Inputbutton",

--- a/examples/StaticFsm/Microwave.cpp
+++ b/examples/StaticFsm/Microwave.cpp
@@ -11,7 +11,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consoleout_spec[] =
+static const char* const consoleout_spec[] =
   {
     "implementation_id", "Microwave",
     "type_name",         "Microwave",

--- a/examples/Throughput/Throughput.cpp
+++ b/examples/Throughput/Throughput.cpp
@@ -17,7 +17,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* analyzer_spec[] =
+static const char* const analyzer_spec[] =
   {
     "implementation_id", "Throughput",
     "type_name",         "Throughput",

--- a/src/ext/ec/logical_time/example/LTTSample.cpp
+++ b/src/ext/ec/logical_time/example/LTTSample.cpp
@@ -12,7 +12,7 @@
 #include <iomanip>
 // Module specification
 // <rtc-template block="module_spec">
-static const char* consolein_spec[] =
+static const char* const consolein_spec[] =
   {
     "implementation_id", "LTTSample",
     "type_name",         "LTTSample",

--- a/src/ext/ec/rtpreempt/example/RTSample.cpp
+++ b/src/ext/ec/rtpreempt/example/RTSample.cpp
@@ -8,7 +8,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* rtsample_spec[] =
+static const char* const rtsample_spec[] =
   {
     "implementation_id", "RTSample",
     "type_name",         "RTSample",

--- a/src/ext/local_service/nameservice_file/FileNameservice.cpp
+++ b/src/ext/local_service/nameservice_file/FileNameservice.cpp
@@ -30,7 +30,7 @@
  * @brief FileNameService ctor
  * @endif
  */
-static const char* service_name =
+static const char* const service_name =
   "org.openrtm.local_service.nameservice.file_nameservice";
 
 /*!
@@ -40,7 +40,7 @@ static const char* service_name =
  * @brief FileNameService ctor
  * @endif
  */
-static const char* service_uuid = "7288D080-F618-480B-B6D9-A199686F3101";
+static const char* const service_uuid = "7288D080-F618-480B-B6D9-A199686F3101";
 
 /*!
  * @if jp
@@ -49,7 +49,7 @@ static const char* service_uuid = "7288D080-F618-480B-B6D9-A199686F3101";
  * @brief FileNameService ctor
  * @endif
  */
-static const char* default_config[] =
+static const char* const default_config[] =
   {
     "base_path",         "/tmp/.openrtm_ns/",
     "file_structure",    "tree",

--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
@@ -208,7 +208,7 @@ namespace RTC
      */
     inline const char* toString(RTC::StatusKind kind)
     {
-      static const char* kinds[] = 
+      static const char* const kinds[] = 
         {
           "COMPONENT_PROFILE",
           "RTC_STATUS",

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -127,7 +127,7 @@ namespace RTC
      */
     inline const char* toString(OpenRTM::StatusKind kind)
     {
-      static const char* kinds[] = 
+      static const char* const kinds[] = 
         {
           "COMPONENT_PROFILE",
           "RTC_STATUS",

--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -72,7 +72,7 @@ namespace coil
    * @brief Constructor(Give the default value with char*[])
    * @endif
    */
-  Properties::Properties(const char** defaults, long num)
+  Properties::Properties(const char* const defaults[], long num)
     : name(""), value(""), default_value(""), set_value(false), root(nullptr), m_empty("")
   {
     leaf.clear();
@@ -308,7 +308,7 @@ namespace coil
    * @brief Set a default value together in the property list
    * @endif
    */
-  void Properties::setDefaults(const char* defaults[], long num)
+  void Properties::setDefaults(const char* const defaults[], long num)
   {
     for (long i = 0; i < num && defaults[i][0] != '\0' ; i += 2)
       {

--- a/src/lib/coil/common/coil/Properties.h
+++ b/src/lib/coil/common/coil/Properties.h
@@ -207,7 +207,7 @@ namespace coil
      *
      * @endif
      */
-    explicit Properties(const char** defaults, long num = LONG_MAX);
+    explicit Properties(const char* const defaults[], long num = LONG_MAX);
 
     /*!
      * @if jp
@@ -595,7 +595,7 @@ namespace coil
      *
      * @endif
      */
-    void setDefaults(const char* defaults[], long num = LONG_MAX);
+    void setDefaults(const char* const defaults[], long num = LONG_MAX);
 
     //============================================================
     // load and save functions

--- a/src/lib/hrtm/properties.cpp
+++ b/src/lib/hrtm/properties.cpp
@@ -25,7 +25,7 @@ namespace utils
     : coil::Properties("", "")
   {
   }
-  Properties::Properties(const char* defaults[], long num)
+  Properties::Properties(const char* const defaults[], long num)
     : coil::Properties(defaults, num)
   {
   }

--- a/src/lib/hrtm/properties.h
+++ b/src/lib/hrtm/properties.h
@@ -29,7 +29,7 @@ namespace utils
   {
   public:
     explicit Properties();
-    explicit Properties(const char* defaults[], long num = LONG_MAX);
+    explicit Properties(const char* const defaults[], long num = LONG_MAX);
     virtual ~Properties();
   };
 } // namespace utils

--- a/src/lib/rtm/BufferStatus.h
+++ b/src/lib/rtm/BufferStatus.h
@@ -117,7 +117,7 @@ namespace RTC
      */
     static const char* toString(Enum status)
     {
-      static const char* str[] = {
+      static const char* const str[] = {
         "BUFFER_OK",
         "BUFFER_ERROR",
         "BUFFER_FULL",

--- a/src/lib/rtm/ComponentActionListener.h
+++ b/src/lib/rtm/ComponentActionListener.h
@@ -148,7 +148,7 @@ namespace RTC
     {
       if (type < PRE_COMPONENT_ACTION_LISTENER_NUM)
         {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "PRE_ON_INITIALIZE",
           "PRE_ON_FINALIZE",
@@ -314,7 +314,7 @@ namespace RTC
     {
       if (type < POST_COMPONENT_ACTION_LISTENER_NUM)
         {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "POST_ON_INITIALIZE",
           "POST_ON_FINALIZE",
@@ -434,7 +434,7 @@ namespace RTC
     {
       if (type < PORT_ACTION_LISTENER_NUM)
         {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "ADD_PORT",
           "REMOVE_PORT",
@@ -544,7 +544,7 @@ namespace RTC
     {
       if (type < EC_ACTION_LISTENER_NUM)
         {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "ATTACH_EC",
           "DETACH_ECT",

--- a/src/lib/rtm/ConfigurationListener.h
+++ b/src/lib/rtm/ConfigurationListener.h
@@ -100,7 +100,7 @@ namespace RTC
     {
       if (type < CONFIG_PARAM_LISTENER_NUM)
         {
-          static const char* typeString[] =
+          static const char* const typeString[] =
           {
             "ON_UPDATE_CONFIG_PARAM",
             "CONFIG_PARAM_LISTENER_NUM"
@@ -217,7 +217,7 @@ namespace RTC
     {
       if (type < CONFIG_SET_LISTENER_NUM)
         {
-          static const char* typeString[] =
+          static const char* const typeString[] =
           {
             "ON_SET_CONFIG_SET",
             "ON_ADD_CONFIG_SET",
@@ -330,7 +330,7 @@ namespace RTC
     {
       if (type < CONFIG_SET_NAME_LISTENER_NUM)
         {
-          static const char* typeString[] =
+          static const char* const typeString[] =
           {
             "ON_UPDATE_CONFIG_SET",
             "ON_REMOVE_CONFIG_SET",

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -435,7 +435,7 @@ namespace RTC
     {
       if (type < CONNECTOR_DATA_LISTENER_NUM)
         {
-          static const char* typeString[] =
+          static const char* const typeString[] =
           {
             "ON_BUFFER_WRITE",
             "ON_BUFFER_FULL",
@@ -895,7 +895,7 @@ namespace RTC
     {
       if (type < CONNECTOR_LISTENER_NUM)
         {
-          static const char* typeStr[] =
+          static const char* const typeStr[] =
           {
             "ON_BUFFER_EMPTY",
             "ON_BUFFER_READ_TIMEOUT",

--- a/src/lib/rtm/DataPortStatus.h
+++ b/src/lib/rtm/DataPortStatus.h
@@ -183,7 +183,7 @@ namespace RTC
      */
     static const char* toString(DataPortStatus::Enum status)
     {
-      static const char* str[] = {
+      static const char* const str[] = {
         "PORT_OK",
         "PORT_ERROR",
         "BUFFER_ERROR",

--- a/src/lib/rtm/DefaultConfiguration.h
+++ b/src/lib/rtm/DefaultConfiguration.h
@@ -37,7 +37,8 @@
  *
  * @endif
  */
-static const char* default_config[] =
+namespace RTC {
+  const char* const default_config[] =
   {
     "config.version",                        openrtm_version,
     "openrtm.name",                          openrtm_name,
@@ -129,4 +130,5 @@ static const char* default_config[] =
     "sdo.service.consumer.enabled_services",  "ALL",
     ""
   };
+}
 #endif  // RTM_DEFAULTCONFIGURATION_H

--- a/src/lib/rtm/ExecutionContextProfile.cpp
+++ b/src/lib/rtm/ExecutionContextProfile.cpp
@@ -175,7 +175,7 @@ namespace RTC_impl
   const char*
   ExecutionContextProfile::getKindString(RTC::ExecutionKind kind) const
   {
-    static const char* kinds[] = {"PERIODIC", "EVENT_DRIVEN", "OTHER"};
+    static const char* const kinds[] = {"PERIODIC", "EVENT_DRIVEN", "OTHER"};
     if (kind < RTC::PERIODIC || kind > RTC::OTHER)
       {
         return "";

--- a/src/lib/rtm/ExecutionContextWorker.h
+++ b/src/lib/rtm/ExecutionContextWorker.h
@@ -421,7 +421,7 @@ namespace RTC_impl
     RTC::LifeCycleState getComponentState(RTC::LightweightRTObject_ptr comp);
     const char* getStateString(RTC::LifeCycleState state)
     {
-      static const char* st[] = {
+      static const char* const st[] = {
         "CREATED_STATE",
         "INACTIVE_STATE",
         "ACTIVE_STATE",

--- a/src/lib/rtm/FsmActionListener.h
+++ b/src/lib/rtm/FsmActionListener.h
@@ -255,7 +255,7 @@ namespace RTC
      */
     static const char* toString(PreFsmActionListenerType type)
     {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "PRE_ON_INIT",
           "PRE_ON_ENTRY",
@@ -495,7 +495,7 @@ namespace RTC
      */
     static const char* toString(PostFsmActionListenerType type)
     {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "POST_ON_INIT",
           "POST_ON_ENTRY",
@@ -741,7 +741,7 @@ namespace RTC
      */
     static const char* toString(FsmProfileListenerType type)
     {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "SET_FSM_PROFILE",
           "GET_FSM_PROFILE",
@@ -959,7 +959,7 @@ namespace RTC
      */
     static const char* toString(FsmStructureListenerType type)
     {
-      static const char* typeString[] =
+      static const char* const typeString[] =
         {
           "SET_FSM_STRUCTURE",
           "GET_FSM_STRUCTURE",

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -769,7 +769,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
     coil::Properties prop;
     prop = factory->profile();
 
-    static const char* inherit_prop[] = {
+    static const char* const inherit_prop[] = {
       "config.version",
       "openrtm.name",
       "openrtm.version",

--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -36,14 +36,14 @@ namespace RTC
 
   // The list of default configuration file path.
 #ifdef RTM_OS_WIN32
-  const char* ManagerConfig::config_file_path[] = 
+  const char* const ManagerConfig::config_file_path[] = 
     {
       "./rtc.conf",
       "${RTM_ROOT}bin/${RTM_VC_VERSION}/rtc.conf",
       nullptr
     };
 #else
-  const char* ManagerConfig::config_file_path[] = 
+  const char* const ManagerConfig::config_file_path[] = 
     {
       "./rtc.conf",
       "/etc/rtc.conf",

--- a/src/lib/rtm/ManagerConfig.h
+++ b/src/lib/rtm/ManagerConfig.h
@@ -104,7 +104,7 @@ namespace RTC
      * @brief The default configuration file path for manager
      * @endif
      */
-    static const char* config_file_path[];
+    static const char* const config_file_path[];
 
     // Environment value to specify configuration file
     /*!

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -563,7 +563,7 @@ bool stringToStrVec(std::vector<std::string>& v, const char* is)
 
 namespace RTC
 {
-  static const char* periodicecsharedcomposite_spec[] =
+  static const char* const periodicecsharedcomposite_spec[] =
   {
     "implementation_id", "PeriodicECSharedComposite",
     "type_name",         "PeriodicECSharedComposite",

--- a/src/lib/rtm/PortConnectListener.cpp
+++ b/src/lib/rtm/PortConnectListener.cpp
@@ -32,7 +32,7 @@ namespace RTC
   const char*
   PortConnectListener::toString(PortConnectListenerType type)
   {
-    static const char* typeString[] =
+    static const char* const typeString[] =
       {
         "ON_NOTIFY_CONNECT",
         "ON_NOTIFY_DISCONNECT",
@@ -62,7 +62,7 @@ namespace RTC
   const char*
   PortConnectRetListener::toString(PortConnectRetListenerType type)
   {
-    static const char* typeString[] =
+    static const char* const typeString[] =
       {
         "ON_PUBLISH_INTERFACES",
         "ON_CONNECT_NEXTPORT",

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -39,7 +39,7 @@ namespace RTC
    * @brief RT-Component default profile
    * @endif
    */
-  static const char* default_conf[] =
+  static const char* const default_conf[] =
     {
       "implementation_id", "",
       "type_name",         "",
@@ -2695,7 +2695,7 @@ namespace RTC
   ReturnCode_t RTObject_impl::
   getInheritedECOptions(coil::Properties& default_opts)
   {
-    static const char* inherited_opts[] =
+    static const char* const inherited_opts[] =
       {
         "sync_transition",
         "sync_activation",
@@ -2968,7 +2968,7 @@ namespace RTC
           }
 
         default_opts << *prop;
-        static const char* inherited_opts[] =
+        static const char* const inherited_opts[] =
           {
             "sync_transition",
             "sync_activation",

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -29,7 +29,7 @@
 
 namespace RTC
 {
-  const char* Logger::m_levelString[] =
+  const char* const Logger::m_levelString[] =
     {
       "SILENT",
       "FATAL",
@@ -42,7 +42,7 @@ namespace RTC
       "PARANOID"
     };
 
-  const char* Logger::m_levelOutputString[] =
+  const char* const Logger::m_levelOutputString[] =
     {
       " SILENT: ",
       " FATAL: ",
@@ -55,7 +55,7 @@ namespace RTC
       " PARANOID: "
     };
 
-  const char* Logger::m_levelColor[] =
+  const char* const Logger::m_levelColor[] =
     {
       "\x1b[0m",          // SLILENT  (none)
       "\x1b[0m\x1b[31m",  // FATAL    (red)

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -498,9 +498,9 @@ namespace RTC
     std::string m_name;
     std::string m_dateFormat;
     coil::IClock* m_clock;
-    static const char* m_levelString[];
-    static const char* m_levelOutputString[];
-    static const char* m_levelColor[];
+    static const char* const m_levelString[];
+    static const char* const m_levelOutputString[];
+    static const char* const m_levelColor[];
     int m_msEnable;
     int m_usEnable;
   };

--- a/src/lib/rtm/version_cmake.h.in
+++ b/src/lib/rtm/version_cmake.h.in
@@ -4,9 +4,10 @@
 #ifndef INCLUDE_GUARD_VERSION_H
 #define INCLUDE_GUARD_VERSION_H
 
-static const char* openrtm_name    = "@OPENRTM_NAME@";
-static const char* openrtm_version = "@OPENRTM_VERSION@";
-static const char* corba_name      = "@CORBA_NAME@";
+namespace RTC {
+  const char* const openrtm_name    = "@OPENRTM_NAME@";
+  const char* const openrtm_version = "@OPENRTM_VERSION@";
+  const char* const corba_name      = "@CORBA_NAME@";
+}
 
 #endif // INCLUDE_GUARD_VERSION_H
-

--- a/utils/rtc-template/cxx_gen.py
+++ b/utils/rtc-template/cxx_gen.py
@@ -501,7 +501,7 @@ consumer_stub_h = """[for cidl in consumer_idl][if-any cidl.stub_h]
 #include "[cidl.stub_h]"
 [endif][endfor]"""
 
-module_spec = """static const char* [l_name]_spec[] =
+module_spec = """static const char* const [l_name]_spec[] =
   {
     "implementation_id", "[basicInfo.name]",
     "type_name",         "[basicInfo.name]",


### PR DESCRIPTION
## Identify the Bug

- 文字列の配列を変数(.data セクション)に作っているが参照しかしていない｡
  おそらく const の指定を正しく使えていないことが原因｡
- ヘッダファイル内で static 付きのクラス外の変数がある｡
   上記から派生する問題として､ ヘッダ上の文字列やテーブルが実際には定数になっていない｡
   そのためにリンカーがシンボル多重を検出してエラーするから､ static をつけてビルドを通しているのだろう｡
   もちろん､配列などはメモリは.cppの数だけ食っている｡
   該当箇所: DefaultConfiguration.h version.h

## Description of the Change

- 正しく const  を付与する
- ヘッダ内の static をやめて const をつける｡
   また､ namespace RTC 内で宣言する

default_config のシンボルに static ついていておかしいと思ったところから､
文字列置換で対応した結果がこのプルリクエストになっている｡
結果として､サンプルコンポーネントの情報テーブルがかなり置き換わっている｡
テンプレートを作り出す側の修正もしておくべき?

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?   ConsoleInComp が動くことだけしか見ていません｡