### PR TITLE
MSVC-build support /W4 on Release mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,9 +761,14 @@ function(openrtm_common_set_compile_options target)
 
 		$<$<CXX_COMPILER_ID:MSVC>:
 			$<$<CONFIG:Debug>:/W4>
-			$<$<CONFIG:Release>:/W3 /WX>
+			$<$<CONFIG:Release>:/W4 /WX>
 			$<$<CONFIG:RelWithDebInfo>:/Wall>
-			$<$<CONFIG:MinSizeRel>:/W3>
+			$<$<CONFIG:MinSizeRel>:/W4 /WX>
+			/wd4589 # for omniORB.
+			$<$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},19.00>:/wd4127> # for omniORB.
+			$<$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},19.00>:/wd4510> # for Macho.
+			$<$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},19.00>:/wd4512> # for omniORB.
+			$<$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},19.00>:/wd4610> # for Macho.
 		>
 	)
 endfunction()

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
@@ -27,10 +27,6 @@
 #include <rtm/ExecutionContextBase.h>
 #include "LogicalTimeTriggeredECSkel.h"
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace coil
 {
   class IClock;
@@ -681,10 +677,6 @@ namespace RTC
 
   };  // class LogicalTimeTriggeredEC
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 
 extern "C"

--- a/src/ext/ec/rtpreempt/RTPreemptEC.h
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.h
@@ -29,10 +29,6 @@
 
 #define NUM_OF_LIFECYCLESTATE 4
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC_exp
 {
   /*!
@@ -796,10 +792,6 @@ namespace RTC_exp
     int m_waitoffset;
   }; // class RTPreemptEC
 } // namespace RTC_exp
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 
 extern "C"

--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
@@ -316,7 +316,7 @@ namespace RTC
       }
     if (coil::toBool(prop["heartbeat.enable"], "YES", "NO", false))
       {
-        std::chrono::nanoseconds interval;
+        std::chrono::nanoseconds interval(m_rtcInterval);
         if (prop["heartbeat.interval"].empty()
             || !coil::stringTo(interval, prop["heartbeat.interval"].c_str()))
           {
@@ -401,7 +401,7 @@ namespace RTC
     // if rtc_heartbeat is set, use it.
     if (coil::toBool(prop["ec_heartbeat.enable"], "YES", "NO", false))
       {
-        std::chrono::nanoseconds interval;
+        std::chrono::nanoseconds interval(m_ecInterval);
         if (prop["ec_heartbeat.interval"].empty()
             || !coil::stringTo(interval, prop["ec_heartbeat.interval"].c_str()))
           {

--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -287,7 +287,7 @@ namespace RTC
   {
     if (coil::toBool(prop["heartbeat.enable"], "YES", "NO", false))
       {
-        std::chrono::nanoseconds interval;
+        std::chrono::nanoseconds interval(m_interval);
         if (prop["heartbeat.interval"].empty()
             || !coil::stringTo(interval, prop["heartbeat.interval"].c_str()))
           {

--- a/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
@@ -32,10 +32,6 @@
 
 
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 
 
 namespace RTC

--- a/src/ext/transport/FastRTPS/FastRTPSInPort.h
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.h
@@ -37,10 +37,6 @@
 
 
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -495,10 +491,6 @@ namespace RTC
 } // namespace RTC
 
 
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif // RTC_FASTRTPSINPORT_H
 

--- a/src/ext/transport/OpenSplice/OpenSpliceInPort.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceInPort.cpp
@@ -34,10 +34,6 @@
 
 
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 
 
 namespace RTC

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -32,10 +32,6 @@
 
 
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 
 
 namespace RTC

--- a/src/ext/transport/ROSTransport/ROSInPort.h
+++ b/src/ext/transport/ROSTransport/ROSInPort.h
@@ -31,10 +31,6 @@
 #include "ROSMessageInfo.h"
 
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -584,10 +580,6 @@ namespace RTC
 } // namespace RTC
 
 
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif // RTC_ROSINPORT_H
 

--- a/src/lib/rtm/CorbaConsumer.h
+++ b/src/lib/rtm/CorbaConsumer.h
@@ -26,17 +26,7 @@
 #include <CORBA.h>
 #endif
 #ifdef ORB_IS_OMNIORB
-#ifdef WIN32
-#pragma warning( disable : 4267 )
-#pragma warning( disable : 4311 )
-#pragma warning( disable : 4312 )
-#endif  // WIN32
 #include <omniORB4/CORBA.h>
-#ifdef WIN32
-#pragma warning( default : 4267 )
-#pragma warning( default : 4311 )
-#pragma warning( default : 4312 )
-#endif  // WIN32
 #endif
 #ifdef ORB_IS_ORBACUS
 #include <OB/CORBA.h>

--- a/src/lib/rtm/CorbaConsumer.h
+++ b/src/lib/rtm/CorbaConsumer.h
@@ -28,14 +28,12 @@
 #ifdef ORB_IS_OMNIORB
 #ifdef WIN32
 #pragma warning( disable : 4267 )
-#pragma warning( disable : 4290 )
 #pragma warning( disable : 4311 )
 #pragma warning( disable : 4312 )
 #endif  // WIN32
 #include <omniORB4/CORBA.h>
 #ifdef WIN32
 #pragma warning( default : 4267 )
-#pragma warning( default : 4290 )
 #pragma warning( default : 4311 )
 #pragma warning( default : 4312 )
 #endif  // WIN32

--- a/src/lib/rtm/CorbaNaming.h
+++ b/src/lib/rtm/CorbaNaming.h
@@ -42,10 +42,6 @@
  * @endif
  */
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -1676,9 +1672,5 @@ namespace RTC
 
   };  // class CorbaNaming
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // end of RTC_CORBANAMING_H

--- a/src/lib/rtm/ExecutionContextBase.h
+++ b/src/lib/rtm/ExecutionContextBase.h
@@ -26,10 +26,6 @@
 #include <rtm/ExecutionContextProfile.h>
 #include <rtm/ExecutionContextWorker.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 #define DEFAULT_EXECUTION_RATE 1000
 
 namespace coil
@@ -1206,7 +1202,6 @@ namespace RTC
 
 #ifdef WIN32
 EXTERN template class DLL_PLUGIN coil::GlobalFactory<RTC::ExecutionContextBase>;
-#pragma warning( default : 4290 )
 #elif defined(__GNUC__)
 EXTERN template class coil::Singleton<coil::GlobalFactory<RTC::ExecutionContextBase> >;
 #endif

--- a/src/lib/rtm/ExecutionContextProfile.h
+++ b/src/lib/rtm/ExecutionContextProfile.h
@@ -26,10 +26,6 @@
 #include <rtm/idl/RTCStub.h>
 #include <rtm/SystemLogger.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC_impl
 {
   /*!
@@ -582,9 +578,5 @@ namespace RTC_impl
     };
   };  // class ExecutionContextProfile
 } // namespace RTC_impl
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_EXECUTIONCONTEXTPROFILE_H

--- a/src/lib/rtm/ExecutionContextWorker.h
+++ b/src/lib/rtm/ExecutionContextWorker.h
@@ -27,10 +27,6 @@
 
 #define NUM_OF_LIFECYCLESTATE 4
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   class RTObject_impl;
@@ -597,9 +593,5 @@ namespace RTC_impl
 
   };  // class PeriodicExecutionContext
 } // namespace RTC_impl
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_PERIODICEXECUTIONCONTEXT_H

--- a/src/lib/rtm/ExtTrigExecutionContext.h
+++ b/src/lib/rtm/ExtTrigExecutionContext.h
@@ -25,10 +25,6 @@
 
 #include <rtm/ExecutionContextBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -641,10 +637,6 @@ namespace RTC
     Worker m_worker;
   };  // class ExtTrigExecutionContext
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 
 extern "C"

--- a/src/lib/rtm/InPortBase.h
+++ b/src/lib/rtm/InPortBase.h
@@ -26,12 +26,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/OutPortBase.h>
 
-#ifdef WIN32
-#pragma warning( push ) 
-#pragma warning( disable : 4290 )
-#endif
-
-
 /*!
  * @if jp
  * @namespace RTC
@@ -894,9 +888,5 @@ namespace RTC
     ConnectorListeners m_listeners;
   };
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( pop )
-#endif
 
 #endif // RTC_INPORTBASE_H

--- a/src/lib/rtm/InPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrProvider.cpp
@@ -19,10 +19,6 @@
 
 #include <rtm/InPortCorbaCdrProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -28,10 +28,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -402,10 +398,6 @@ extern "C"
    */
   void InPortCorbaCdrProviderInit(void);
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_INPORTCORBACDRPROVIDER_H
 

--- a/src/lib/rtm/InPortCorbaCdrUDPProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrUDPProvider.cpp
@@ -18,10 +18,6 @@
 
 #include <rtm/InPortCorbaCdrUDPProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/InPortCorbaCdrUDPProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrUDPProvider.h
@@ -27,10 +27,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -402,10 +398,6 @@ extern "C"
    */
   void InPortCorbaCdrUDPProviderInit(void);
 };
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif // RTC_INPORTCORBACDRUDPPROVIDER_H
 

--- a/src/lib/rtm/InPortDSProvider.cpp
+++ b/src/lib/rtm/InPortDSProvider.cpp
@@ -17,10 +17,6 @@
 
 #include <rtm/InPortDSProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -26,10 +26,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -400,10 +396,6 @@ extern "C"
    */
   void InPortDSProviderInit(void);
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_INPORTDSPROVIDER_H
 

--- a/src/lib/rtm/InPortDirectProvider.cpp
+++ b/src/lib/rtm/InPortDirectProvider.cpp
@@ -19,10 +19,6 @@
 
 #include <rtm/InPortDirectProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/InPortDirectProvider.h
+++ b/src/lib/rtm/InPortDirectProvider.h
@@ -26,10 +26,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -366,10 +362,6 @@ extern "C"
    */
   void InPortDirectProviderInit(void);
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_INPORTDIRECTPROVIDER_H
 

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -19,10 +19,6 @@
 
 #include <rtm/InPortSHMProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -26,10 +26,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -265,10 +261,6 @@ extern "C"
    */
   void InPortSHMProviderInit();
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif // RTC_INPORTCORBACDRPROVIDER_H
 

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -47,10 +47,6 @@
 #define MOD_DELMOD    "manager.modules.download_cleanup"
 #define MOD_PRELOAD   "manager.modules.preload"
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -779,9 +775,5 @@ namespace RTC
 
   };   // class ModuleManager
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_MODULEMANAGER_H

--- a/src/lib/rtm/MultilayerCompositeEC.h
+++ b/src/lib/rtm/MultilayerCompositeEC.h
@@ -24,10 +24,6 @@
 
 
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC_exp
 {
   /*!
@@ -180,10 +176,6 @@ namespace RTC_exp
 
   };  // class MultilayerCompositeEC
 } // namespace RTC_exp
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 
 extern "C"

--- a/src/lib/rtm/NVUtil.cpp
+++ b/src/lib/rtm/NVUtil.cpp
@@ -17,13 +17,6 @@
  *
  */
 
-#ifdef WIN32
-#pragma warning( push )
-#pragma warning( disable : 4267 )
-#pragma warning( disable : 4311 )
-#pragma warning( disable : 4312 )
-#endif  // WIN32
-
 #include <coil/stringutil.h>
 #include <rtm/NVUtil.h>
 #include <rtm/CORBA_SeqUtil.h>
@@ -31,10 +24,6 @@
 #include <algorithm>
 #include <map>
 #include <vector>
-
-#ifdef WIN32
-#pragma warning( pop )
-#endif  // WIN32
 
 namespace NVUtil
 {

--- a/src/lib/rtm/NVUtil.cpp
+++ b/src/lib/rtm/NVUtil.cpp
@@ -20,7 +20,6 @@
 #ifdef WIN32
 #pragma warning( push )
 #pragma warning( disable : 4267 )
-#pragma warning( disable : 4290 )
 #pragma warning( disable : 4311 )
 #pragma warning( disable : 4312 )
 #endif  // WIN32

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -23,10 +23,6 @@
 #include <rtm/RTC.h>
 #include <rtm/ExecutionContextBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -503,10 +499,6 @@ namespace RTC
 
   };  // class OpenHRPExecutionContext
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 
 extern "C"

--- a/src/lib/rtm/OutPortBase.h
+++ b/src/lib/rtm/OutPortBase.h
@@ -31,11 +31,6 @@
 #include <rtm/SystemLogger.h>
 #include <rtm/ConnectorListener.h>
 
-#ifdef WIN32
-#pragma warning( push ) 
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   class PublisherBase;
@@ -1110,8 +1105,5 @@ namespace RTC
   };
 } // End of namespace RTC
 
-#ifdef WIN32
-#pragma warning( pop )
-#endif
-
 #endif // RTC_RTCOUTPORTBASE_H
+

--- a/src/lib/rtm/OutPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.cpp
@@ -19,10 +19,6 @@
 
 #include <rtm/OutPortCorbaCdrProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -28,10 +28,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -376,9 +372,5 @@ extern "C"
    */
   void OutPortCorbaCdrProviderInit(void);
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_OUTPORTCORBACDRPROVIDER_H

--- a/src/lib/rtm/OutPortDSProvider.cpp
+++ b/src/lib/rtm/OutPortDSProvider.cpp
@@ -17,10 +17,6 @@
 
 #include <rtm/OutPortDSProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -26,10 +26,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -374,9 +370,5 @@ extern "C"
    */
   void OutPortDSProviderInit(void);
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_OUTPORTDSPROVIDER_H

--- a/src/lib/rtm/OutPortDirectProvider.cpp
+++ b/src/lib/rtm/OutPortDirectProvider.cpp
@@ -17,10 +17,6 @@
 
 #include <rtm/OutPortDirectProvider.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/OutPortDirectProvider.h
+++ b/src/lib/rtm/OutPortDirectProvider.h
@@ -25,10 +25,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -340,9 +336,5 @@ extern "C"
    */
   void OutPortDirectProviderInit(void);
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif // RTC_OUTPORTDIRECTPROVIDER_H

--- a/src/lib/rtm/OutPortSHMProvider.cpp
+++ b/src/lib/rtm/OutPortSHMProvider.cpp
@@ -18,10 +18,6 @@
 #include <coil/UUID.h>
 #include <memory>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -25,10 +25,6 @@
 #include <rtm/ConnectorListener.h>
 #include <rtm/ConnectorBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!
@@ -322,9 +318,5 @@ extern "C"
    */
   void OutPortSHMProviderInit(void);
 }
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif // RTC_OUTPORTSHMPROVIDER_H

--- a/src/lib/rtm/PeriodicECSharedComposite.h
+++ b/src/lib/rtm/PeriodicECSharedComposite.h
@@ -46,10 +46,6 @@
  * @endif
  */
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace SDOPackage
 {
   /*!
@@ -670,10 +666,6 @@ namespace RTC
     SDOPackage::PeriodicECOrganization* m_org;
   };  // class PeriodicECOrganization
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 
 extern "C"

--- a/src/lib/rtm/PeriodicExecutionContext.h
+++ b/src/lib/rtm/PeriodicExecutionContext.h
@@ -30,10 +30,6 @@
 
 #define NUM_OF_LIFECYCLESTATE 4
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC_exp
 {
   /*!
@@ -706,10 +702,6 @@ namespace RTC_exp
 
   };  // class PeriodicExecutionContext
 } // namespace RTC_exp
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 
 extern "C"

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -32,10 +32,6 @@
 #include <iostream>
 #include <rtm/DirectPortBase.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   class ConnectionCallback;
@@ -2290,9 +2286,5 @@ namespace RTC
     };  // struct find_interface
   };  // class PortBase
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_PORTBASE_H

--- a/src/lib/rtm/RTC.h
+++ b/src/lib/rtm/RTC.h
@@ -42,7 +42,6 @@
 
 #ifdef WIN32
 #pragma warning( disable : 4267 )
-#pragma warning( disable : 4290 )
 #pragma warning( disable : 4311 )
 #pragma warning( disable : 4312 )
 #endif  // WIN32
@@ -52,7 +51,6 @@
 
 #ifdef WIN32
 #pragma warning( default : 4267 )
-#pragma warning( default : 4290 )
 #pragma warning( default : 4311 )
 #pragma warning( default : 4312 )
 #endif  // WIN32

--- a/src/lib/rtm/RTC.h
+++ b/src/lib/rtm/RTC.h
@@ -40,20 +40,8 @@
 
 #ifdef ORB_IS_OMNIORB
 
-#ifdef WIN32
-#pragma warning( disable : 4267 )
-#pragma warning( disable : 4311 )
-#pragma warning( disable : 4312 )
-#endif  // WIN32
-
 #include <omniORB4/CORBA.h>
 #include <omnithread.h>
-
-#ifdef WIN32
-#pragma warning( default : 4267 )
-#pragma warning( default : 4311 )
-#pragma warning( default : 4312 )
-#endif  // WIN32
 
 #endif  // ORB_IS_OMNIORB
 

--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -46,10 +46,6 @@ namespace SDOPackage
   class Configuration_impl;
 } // namespace SDOPackage
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   class Manager;
@@ -5538,9 +5534,5 @@ namespace RTC
     };  // struct deactivate_comps
   };  // class RTObject_impl
 } // namespace RTC
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_RTOBJECT

--- a/src/lib/rtm/RTObjectStateMachine.h
+++ b/src/lib/rtm/RTObjectStateMachine.h
@@ -29,10 +29,6 @@
 #include <iostream>
 
 #define NUM_OF_LIFECYCLESTATE 4
-
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
 namespace RTC
 {
   class RTObject_impl;
@@ -119,9 +115,5 @@ namespace RTC_impl
     coil::TimeMeasure m_refMeasure;
   };
 } // namespace RTC_impl
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_RTOBJECTSTATEMACHINE_H

--- a/src/lib/rtm/SdoConfiguration.h
+++ b/src/lib/rtm/SdoConfiguration.h
@@ -50,10 +50,6 @@
  * @endif
  */
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace SDOPackage
 {
   /*!
@@ -1149,9 +1145,5 @@ namespace SDOPackage
     };
   };  // class Configuration_impl
 } // namespace SDOPackage
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_SDOCONFIGURATION_H

--- a/src/lib/rtm/SdoOrganization.cpp
+++ b/src/lib/rtm/SdoOrganization.cpp
@@ -386,14 +386,7 @@ namespace SDOPackage
   CORBA::Boolean Organization_impl::set_dependency(DependencyType dependency)
   {
     RTC_TRACE(("set_dependency()"));
-    try
-      {
-        m_dependency = dependency;
-        return true;
-      }
-    catch (...)
-      {
-        throw InternalError("set_dependency(): Unknown.");
-      }
+    m_dependency = dependency;
+    return true;
   }
 } // namespace SDOPackage

--- a/src/lib/rtm/SdoOrganization.h
+++ b/src/lib/rtm/SdoOrganization.h
@@ -43,10 +43,6 @@
  * @endif
  */
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace SDOPackage
 {
   /*!
@@ -845,9 +841,5 @@ namespace SDOPackage
     };  // struct sdo_id
   };  // class Organization_impl
 } // namespace SDOPackage
-
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
 
 #endif  // RTC_NAMESPACE SDOPACKAGE

--- a/src/lib/rtm/SharedMemoryPort.cpp
+++ b/src/lib/rtm/SharedMemoryPort.cpp
@@ -18,10 +18,6 @@
 #include <rtm/SharedMemoryPort.h>
 #include <rtm/Manager.h>
 
-#ifdef WIN32
-#pragma warning( disable : 4290 )
-#endif
-
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/SharedMemoryPort.h
+++ b/src/lib/rtm/SharedMemoryPort.h
@@ -269,8 +269,4 @@ namespace RTC
   };  // class SharedMemoryPort
 } // namespace RTC
 
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
-
 #endif // RTC_RTOBJECT

--- a/src/lib/rtm/SimulatorExecutionContext.h
+++ b/src/lib/rtm/SimulatorExecutionContext.h
@@ -147,10 +147,6 @@ namespace RTC
 
 
 
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
-
 extern "C"
 {
   /*!

--- a/src/lib/rtm/VxWorksRTExecutionContext.h
+++ b/src/lib/rtm/VxWorksRTExecutionContext.h
@@ -207,10 +207,6 @@ namespace RTC_exp
   };
 } // namespace RTC
 
-#ifdef WIN32
-#pragma warning( default : 4290 )
-#endif
-
 
 extern "C"
 {


### PR DESCRIPTION
## Description of the Change

MSVC の リリースビルドでも W4 を使用します。

- c4290 は throw() を対応したときに解決済みなので削除
- Visual Studio 2013 だけが問題となるオプションは CMakeLists.txt で対処
- omniORB に依存した c4589 が出力されないように CMakeLists.txt で対処

MSVC のW4までの警告で対応せずに塞いでいるものは、以下の二つになっているはず。
ただし、examples, src/ext/transport を除く。
 - Factory.c c4251
 - 上記の c4589

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
 ビルドは問題ない。ただし各警告に対応していないことについて、問題無いことを確認したわけではない。