### PR TITLE
Replace sec/nsec parameters with chrono::nanoseconds.

### DIFF
--- a/src/lib/rtm/BufferBase.h
+++ b/src/lib/rtm/BufferBase.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <coil/Properties.h>
 #include <rtm/BufferStatus.h>
+#include <chrono>
 
 /*!
  * @if jp
@@ -309,7 +310,8 @@ namespace RTC
      * @endif
      */
     virtual ReturnCode write(const DataType& value,
-                             long int sec = -1, long int nsec = -1) = 0;
+                             std::chrono::nanoseconds timeout
+                             = std::chrono::nanoseconds(-1)) = 0;
 
     /*!
      * @if jp
@@ -474,7 +476,8 @@ namespace RTC
      * @endif
      */
     virtual ReturnCode read(DataType& value,
-                            long int sec = -1, long int nsec = -1) = 0;
+                            std::chrono::nanoseconds nsec
+                            = std::chrono::nanoseconds(-1)) = 0;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortPushConnector.cpp
+++ b/src/lib/rtm/OutPortPushConnector.cpp
@@ -93,7 +93,7 @@ namespace RTC
     RTC_TRACE(("write()"));
     RTC_PARANOID(("data size = %d bytes", data->getDataLength()));
     
-    return m_publisher->write(data, 0, 0);
+    return m_publisher->write(data, std::chrono::seconds::zero());
   }
 
   /*!

--- a/src/lib/rtm/PublisherBase.h
+++ b/src/lib/rtm/PublisherBase.h
@@ -216,8 +216,7 @@ namespace RTC
      *
      *
      * @param data 書き込むデータ
-     * @param sec タイムアウト時間
-     * @param nsec タイムアウト時間
+     * @param timeout タイムアウト時間
      *
      * @return PORT_OK             正常終了
      *         PRECONDITION_NO_MET consumer, buffer, listener等が適切に設定
@@ -244,8 +243,7 @@ namespace RTC
      * In other cases, PROT_ERROR will be returned.
      *
      * @param data Data to be wrote to the buffer
-     * @param sec Timeout time in unit seconds
-     * @param nsec Timeout time in unit nano-seconds
+     * @param timeout Timeout time in unit nano-seconds
      * @return PORT_OK             Normal return
      *         PRECONDITION_NO_MET Precondition does not met. A consumer,
      *                             a buffer, listenes are not set properly.
@@ -256,8 +254,7 @@ namespace RTC
      * @endif
      */
     virtual ReturnCode write(ByteDataStreamBase* data,
-                             unsigned long sec,
-                             unsigned long usec) = 0;
+                             std::chrono::nanoseconds timeout) = 0;
 
     /*!
      * @if jp

--- a/src/lib/rtm/PublisherFlush.cpp
+++ b/src/lib/rtm/PublisherFlush.cpp
@@ -133,8 +133,7 @@ namespace RTC
    * @endif
    */
   PublisherBase::ReturnCode PublisherFlush::write(ByteDataStreamBase* data,
-                                                  unsigned long  /*sec*/,
-                                                  unsigned long  /*usec*/)
+                                                  std::chrono::nanoseconds /* timeout */)
   {
     RTC_PARANOID(("write()"));
 

--- a/src/lib/rtm/PublisherFlush.h
+++ b/src/lib/rtm/PublisherFlush.h
@@ -222,9 +222,8 @@ namespace RTC
      * これら以外のエラーの場合、PORT_ERROR が返される。
      *
      *
-     * @param data 書き込むデータ
-     * @param sec タイムアウト時間
-     * @param nsec タイムアウト時間
+     * @param data    書き込むデータ
+     * @param timeout タイムアウト時間
      *
      * @return PORT_OK             正常終了
      *         PRECONDITION_NO_MET consumer, buffer, listener等が適切に設定
@@ -250,9 +249,8 @@ namespace RTC
      *
      * In other cases, PROT_ERROR will be returned.
      *
-     * @param data Data to be wrote to the buffer
-     * @param sec Timeout time in unit seconds
-     * @param nsec Timeout time in unit nano-seconds
+     * @param data    Data to be wrote to the buffer
+     * @param timeout Timeout time in unit nano-seconds
      * @return PORT_OK             Normal return
      *         PRECONDITION_NO_MET Precondition does not met. A consumer,
      *                             a buffer, listenes are not set properly.
@@ -263,8 +261,8 @@ namespace RTC
      * @endif
      */
     ReturnCode write(ByteDataStreamBase* data,
-                             unsigned long sec,
-                             unsigned long usec) override;
+                     std::chrono::nanoseconds timeout
+                     = std::chrono::nanoseconds(-1)) override;
     /*!
      * @if jp
      *

--- a/src/lib/rtm/PublisherNew.cpp
+++ b/src/lib/rtm/PublisherNew.cpp
@@ -164,8 +164,7 @@ namespace RTC
    * @endif
    */
   PublisherBase::ReturnCode PublisherNew::write(ByteDataStreamBase* data,
-                                                unsigned long sec,
-                                                unsigned long usec)
+                                                std::chrono::nanoseconds timeout)
   {
     RTC_PARANOID(("write()"));
 
@@ -184,7 +183,7 @@ namespace RTC
     if (m_retcode == SEND_FULL)
       {
         RTC_DEBUG(("write(): InPort buffer is full."));
-        m_buffer->write(data_, sec, usec);
+        m_buffer->write(data_, timeout);
         m_task->signal();
         return BUFFER_FULL;
       }
@@ -192,7 +191,7 @@ namespace RTC
     assert(m_buffer != nullptr);
 
     onBufferWrite(data_);
-    CdrBufferBase::ReturnCode ret(m_buffer->write(data_, sec, usec));
+    CdrBufferBase::ReturnCode ret(m_buffer->write(data_, timeout));
 
     m_task->signal();
     RTC_DEBUG(("%s = write()", CdrBufferBase::toString(ret)));

--- a/src/lib/rtm/PublisherNew.h
+++ b/src/lib/rtm/PublisherNew.h
@@ -268,9 +268,8 @@ namespace RTC
      * これら以外のエラーの場合、PORT_ERROR が返される。
      *
      *
-     * @param data 書き込むデータ
-     * @param sec タイムアウト時間
-     * @param nsec タイムアウト時間
+     * @param data    書き込むデータ
+     * @param timeout タイムアウト時間
      *
      * @return PORT_OK             正常終了
      *         PRECONDITION_NO_MET consumer, buffer, listener等が適切に設定
@@ -305,9 +304,8 @@ namespace RTC
      *
      * In other cases, PROT_ERROR will be returned.
      *
-     * @param data Data to be wrote to the buffer
-     * @param sec Timeout time in unit seconds
-     * @param nsec Timeout time in unit nano-seconds
+     * @param data    Data to be wrote to the buffer
+     * @param timeout Timeout time in unit nano-seconds
      * @return PORT_OK             Normal return
      *         PRECONDITION_NO_MET Precondition does not met. A consumer,
      *                             a buffer, listenes are not set properly.
@@ -321,8 +319,7 @@ namespace RTC
      * @endif
      */
     ReturnCode write(ByteDataStreamBase* data,
-                             unsigned long sec,
-                             unsigned long usec) override;
+                     std::chrono::nanoseconds timeout) override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/PublisherPeriodic.cpp
+++ b/src/lib/rtm/PublisherPeriodic.cpp
@@ -166,8 +166,7 @@ namespace RTC
    */
   PublisherBase::ReturnCode
   PublisherPeriodic::write(ByteDataStreamBase* data,
-                           unsigned long sec,
-                           unsigned long usec)
+                           std::chrono::nanoseconds timeout)
   {
     RTC_PARANOID(("write()"));
 
@@ -186,12 +185,12 @@ namespace RTC
     if (m_retcode == SEND_FULL)
       {
         RTC_DEBUG(("write(): InPort buffer is full."));
-        m_buffer->write(data_, sec, usec);
+        m_buffer->write(data_, timeout);
         return BUFFER_FULL;
       }
 
     onBufferWrite(data_);
-    CdrBufferBase::ReturnCode ret(m_buffer->write(data_, sec, usec));
+    CdrBufferBase::ReturnCode ret(m_buffer->write(data_, timeout));
     RTC_DEBUG(("%s = write()", CdrBufferBase::toString(ret)));
     m_task->resume();
     return convertReturn(ret, data_);

--- a/src/lib/rtm/PublisherPeriodic.h
+++ b/src/lib/rtm/PublisherPeriodic.h
@@ -268,8 +268,7 @@ namespace RTC
      *
      *
      * @param data 書き込むデータ
-     * @param sec タイムアウト時間
-     * @param nsec タイムアウト時間
+     * @param timeout タイムアウト時間
      *
      * @return PORT_OK             正常終了
      *         PRECONDITION_NO_MET consumer, buffer, listener等が適切に設定
@@ -305,8 +304,7 @@ namespace RTC
      * In other cases, PROT_ERROR will be returned.
      *
      * @param data Data to be wrote to the buffer
-     * @param sec Timeout time in unit seconds
-     * @param nsec Timeout time in unit nano-seconds
+     * @param timeout Timeout time in unit nano-seconds
      * @return PORT_OK             Normal return
      *         PRECONDITION_NO_MET Precondition does not met. A consumer,
      *                             a buffer, listenes are not set properly.
@@ -320,8 +318,7 @@ namespace RTC
      * @endif
      */
     ReturnCode write(ByteDataStreamBase* data,
-                             unsigned long sec,
-                             unsigned long usec) override;
+                     std::chrono::nanoseconds timeout) override;
     /*!
      * @if jp
      *


### PR DESCRIPTION
## Description of the Change

使い勝手向上と long の直接使用をやめるため、
sec/nsec という古いインターフェースを C++11 の chrono に置き換える。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
