### PR TITLE
Replace coil::TimeValue in TimeMeasure with std::chrono.

### DIFF
--- a/src/lib/coil/common/coil/PeriodicTask.cpp
+++ b/src/lib/coil/common/coil/PeriodicTask.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <coil/PeriodicTask.h>
-#include <coil/Time.h>
 
 namespace coil
 {
@@ -30,7 +29,7 @@ namespace coil
    * @endif
    */
   PeriodicTask::PeriodicTask()
-    : m_period(0.0), m_nowait(false),
+    : m_period(std::chrono::seconds(0)), m_nowait(false),
       m_func(nullptr), m_deleteInDtor(true),
       m_alive(false), m_suspend(false),
       m_execCount(0), m_execCountMax(1000),
@@ -156,31 +155,11 @@ namespace coil
    * @brief Setting task execution period
    * @endif
    */
-  void PeriodicTask::setPeriod(double period)
+  void PeriodicTask::setPeriod(std::chrono::nanoseconds period)
   {
     m_period = period;
 
-    if (m_period.sec() == 0 && m_period.usec() == 0)
-      {
-        m_nowait = true;
-        return;
-      }
-    m_nowait = false;
-    return;
-  }
-
-  /*!
-   * @if jp
-   * @brief タスク実行周期をセットする
-   * @else
-   * @brief Setting task execution period
-   * @endif
-   */
-  void PeriodicTask::setPeriod(TimeValue& period)
-  {
-    m_period = period;
-
-    if (m_period.sec() == 0 && m_period.usec() == 0)
+    if (m_period == std::chrono::seconds::zero())
       {
         m_nowait = true;
         return;
@@ -322,7 +301,7 @@ namespace coil
       {
         return;
       }
-    coil::sleep(m_period - m_execTime.interval());
+    std::this_thread::sleep_for((m_period - m_execTime.interval()));
   }
 
   /*!

--- a/src/lib/coil/common/coil/PeriodicTask.h
+++ b/src/lib/coil/common/coil/PeriodicTask.h
@@ -22,7 +22,6 @@
 
 #include <mutex>
 #include <condition_variable>
-#include <coil/TimeValue.h>
 #include <coil/TimeMeasure.h>
 #include <coil/PeriodicTaskBase.h>
 
@@ -222,21 +221,6 @@ namespace coil
      * @if jp
      * @brief タスク実行周期をセットする
      *
-     * @param period 実行周期 [sec]
-     *
-     * @else
-     * @brief Setting task execution period
-     *
-     * @param period Execution period [sec]
-     *
-     * @endif
-     */
-    void setPeriod(double period) override;
-
-    /*!
-     * @if jp
-     * @brief タスク実行周期をセットする
-     *
      * @param period 実行周期
      *
      * @else
@@ -246,7 +230,7 @@ namespace coil
      *
      * @endif
      */
-    void setPeriod(TimeValue& period) override;
+    void setPeriod(std::chrono::nanoseconds period) override;
 
     /*!
      * @if jp
@@ -347,7 +331,7 @@ namespace coil
      * @brief Task execution period
      * @endif
      */
-    coil::TimeValue m_period;
+    std::chrono::nanoseconds m_period;
 
     /*!
      * @if jp

--- a/src/lib/coil/common/coil/PeriodicTaskBase.h
+++ b/src/lib/coil/common/coil/PeriodicTaskBase.h
@@ -20,7 +20,6 @@
 #ifndef COIL_PERIODICTASKBASE_H
 #define COIL_PERIODICTASKBASE_H
 
-#include <coil/TimeValue.h>
 #include <coil/TimeMeasure.h>
 #include <coil/Task.h>
 
@@ -369,28 +368,7 @@ namespace coil
      *
      * @endif
      */
-    virtual void setPeriod(double period) = 0;
-
-    /*!
-     * @if jp
-     *
-     * @brief タスク実行周期をセットする純粋仮想関数
-     *
-     * タスク実行周期をセットする純粋仮想関数。
-     *
-     * @param period 実行周期
-     *
-     * @else
-     *
-     * @brief Setting task execution period
-     *
-     * Pure virtual function for setting task execution period.
-     *
-     * @param period Execution period.
-     *
-     * @endif
-     */
-    virtual void setPeriod(coil::TimeValue& period) = 0;
+    virtual void setPeriod(std::chrono::nanoseconds period) = 0;
 
     /*!
      * @if jp

--- a/src/lib/coil/common/coil/TimeMeasure.cpp
+++ b/src/lib/coil/common/coil/TimeMeasure.cpp
@@ -17,7 +17,6 @@
  *
  */
 
-#include <coil/Time.h>
 #include <coil/TimeMeasure.h>
 #include <cmath>
 
@@ -37,14 +36,14 @@ namespace coil
    * @endif
    */
   TimeMeasure::TimeMeasure(unsigned long buflen)
-    : m_interval(0.0),
+    : m_interval(std::chrono::seconds(0)),
       m_count(0), m_countMax(buflen + 1),
       m_recurred(false)
   {
     m_record.reserve(m_countMax);
     for (unsigned long int i(0); i < m_countMax; ++i)
       {
-        m_record.emplace_back(0, 0);
+        m_record.emplace_back(std::chrono::seconds(0));
       }
   }
 
@@ -69,10 +68,7 @@ namespace coil
    */
   void TimeMeasure::tack()
   {
-    auto interval = std::chrono::high_resolution_clock::now() - m_begin;
-    auto sec = std::chrono::duration_cast<std::chrono::seconds>(interval);
-    auto usec = std::chrono::duration_cast<std::chrono::microseconds>(interval - sec);
-    m_interval = coil::TimeValue(static_cast<long>(sec.count()), static_cast<long>(usec.count()));
+    m_interval = std::chrono::high_resolution_clock::now() - m_begin;
     m_record.at(m_count) = m_interval;
     ++m_count;
     if (m_count == m_countMax)
@@ -89,7 +85,7 @@ namespace coil
    * @brief Get a interval time
    * @endif
    */
-  coil::TimeValue& TimeMeasure::interval()
+  std::chrono::nanoseconds TimeMeasure::interval()
   {
     return m_interval;
   }
@@ -144,7 +140,7 @@ namespace coil
 
     for (unsigned long int i(0); i < len; ++i)
       {
-        double trecord(m_record[i]);
+        double trecord = std::chrono::duration<double>(m_record[i]).count();
         sum += trecord;
         sq_sum += trecord * trecord;
 

--- a/src/lib/coil/common/coil/TimeMeasure.h
+++ b/src/lib/coil/common/coil/TimeMeasure.h
@@ -20,7 +20,7 @@
 #ifndef COIL_TIMEMEASURE_H
 #define COIL_TIMEMEASURE_H
 
-#include <coil/TimeValue.h>
+#include <chrono>
 #include <vector>
 
 namespace coil
@@ -126,7 +126,7 @@ namespace coil
      *
      * 経過時間を取得する
      *
-     * @return TimeValue オブジェクト
+     * @return std::chrono::nanoseconds オブジェクト
      *
      * @else
      *
@@ -134,11 +134,11 @@ namespace coil
      *
      * Get a interval time.
      *
-     * @return TimeValue object
+     * @return std::chrono::nanoseconds object
      *
      * @endif
      */
-    coil::TimeValue& interval();
+    std::chrono::nanoseconds interval();
 
     /*!
      * @if jp
@@ -234,9 +234,9 @@ namespace coil
     Statistics getStatistics();
 
   private:
-    std::vector<coil::TimeValue> m_record;
+    std::vector<std::chrono::nanoseconds> m_record;
     std::chrono::high_resolution_clock::time_point m_begin;
-    coil::TimeValue m_interval;
+    std::chrono::nanoseconds m_interval;
 
     unsigned long int m_count;
     const unsigned long int m_countMax;

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -223,7 +223,7 @@ namespace RTC_exp
       ChildTask *ct = new ChildTask(task, this);
 
       task->setTask(ct, &ChildTask::svc);
-      task->setPeriod(0.0);
+      task->setPeriod(std::chrono::seconds(0));
       task->executionMeasure(coil::toBool(prop["measurement.exec_time"],
           "enable", "disable", true));
 

--- a/src/lib/rtm/PublisherNew.cpp
+++ b/src/lib/rtm/PublisherNew.cpp
@@ -334,7 +334,7 @@ namespace RTC
 
     // setting task function
     m_task->setTask(this, &PublisherNew::svc);
-    m_task->setPeriod(0.0);
+    m_task->setPeriod(std::chrono::seconds(0));
     m_task->executionMeasure(coil::toBool(prop["measurement.exec_time"],
                                     "enable", "disable", true));
 

--- a/src/lib/rtm/PublisherPeriodic.cpp
+++ b/src/lib/rtm/PublisherPeriodic.cpp
@@ -478,7 +478,8 @@ namespace RTC
         RTC_ERROR(("invalid period: %f [s]", hz));
         return false;
       }
-    m_task->setPeriod(1.0/hz);
+    auto period = std::chrono::duration<double>(1.0/hz);
+    m_task->setPeriod(std::chrono::duration_cast<std::chrono::nanoseconds>(period));
 
     // Setting task measurement function
     m_task->executionMeasure(coil::toBool(prop["measurement.exec_time"],


### PR DESCRIPTION
## Description of the Change

- TimeMeasure を std::chrono に対応する。
- TimeMeasure のユーザーである PeridicTask も std::chrono に対応する。 
   時間に関するインターフェースを std::chrono に統一する。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
     SimpleIO を用いてバッファの周期送信を確認した。