### PR TITLE
ClockManager and SystemLogger use std::chrono.

### DIFF
--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
@@ -17,7 +17,6 @@
  *
  */
 
-#include <coil/TimeValue.h>
 #include <mutex>
 #include <coil/ClockManager.h>
 
@@ -198,8 +197,8 @@ namespace RTC
   tick(::CORBA::ULong sec, ::CORBA::ULong usec)
   {
     RTC_TRACE(("tick(sec = %d, usec = %d)", sec, usec));
-    coil::TimeValue time(sec, usec);
-    m_clock.settime(time);
+    m_clock.settime(std::chrono::seconds(sec)
+                    + std::chrono::microseconds(usec));
 
     if (!isRunning())
       {
@@ -221,14 +220,14 @@ namespace RTC
     return;
   }
 
-
-  
   void LogicalTimeTriggeredEC::
   get_time(::CORBA::ULong& sec, ::CORBA::ULong& usec)
   {
-    coil::TimeValue time(m_clock.gettime());
-    sec  = time.sec();
-    usec = time.usec();
+    std::chrono::nanoseconds time(m_clock.gettime());
+    auto time_s = std::chrono::duration_cast<std::chrono::seconds>(time);
+    auto time_us = std::chrono::duration_cast<std::chrono::microseconds>(time);
+    sec  = static_cast<::CORBA::ULong>(time_s.count());
+    usec = static_cast<::CORBA::ULong>((time_us - time_s).count());
   }
 
   //============================================================

--- a/src/ext/ec/logical_time/example/LTTSample.h
+++ b/src/ext/ec/logical_time/example/LTTSample.h
@@ -11,7 +11,6 @@
 #define LTTSAMPLE_H
 
 #include <coil/ClockManager.h>
-#include <coil/TimeValue.h>
 
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/Manager.h>

--- a/src/lib/coil/common/coil/ClockManager.h
+++ b/src/lib/coil/common/coil/ClockManager.h
@@ -20,7 +20,6 @@
 #define COIL_CLOCKMANAGER_H
 
 #include <coil/Singleton.h>
-#include <coil/TimeValue.h>
 #include <mutex>
 
 #include <string>
@@ -62,7 +61,7 @@ namespace coil
      * @return Current time
      * @endif
      */
-    virtual coil::TimeValue gettime() const = 0;
+    virtual std::chrono::nanoseconds gettime() const = 0;
     /*!
      * @if jp
      * @brief 時刻を設定する
@@ -72,7 +71,7 @@ namespace coil
      * @param clocktime Current time
      * @endif
      */
-    virtual bool settime(coil::TimeValue clocktime) = 0;
+    virtual bool settime(std::chrono::nanoseconds clocktime) = 0;
   };
 
   /*!
@@ -93,8 +92,8 @@ namespace coil
   {
   public:
     ~SystemClock() override;
-    coil::TimeValue gettime() const override;
-    bool settime(coil::TimeValue clocktime) override;
+    std::chrono::nanoseconds gettime() const override;
+    bool settime(std::chrono::nanoseconds clocktime) override;
   };
 
   /*!
@@ -118,10 +117,10 @@ namespace coil
   public:
     LogicalClock();
     ~LogicalClock() override;
-    coil::TimeValue gettime() const override;
-    bool settime(coil::TimeValue clocktime) override;
+    std::chrono::nanoseconds gettime() const override;
+    bool settime(std::chrono::nanoseconds clocktime) override;
   private:
-    coil::TimeValue m_currentTime;
+    std::chrono::nanoseconds m_currentTime;
     mutable std::mutex m_currentTimeMutex;
   };
 
@@ -146,8 +145,8 @@ namespace coil
   public:
     AdjustedClock();
     ~AdjustedClock() override;
-    coil::TimeValue gettime() const override;
-    bool settime(coil::TimeValue clocktime) override;
+    std::chrono::nanoseconds gettime() const override;
+    bool settime(std::chrono::nanoseconds clocktime) override;
   private:
     std::chrono::steady_clock::time_point m_offset;
     mutable std::mutex m_offsetMutex;


### PR DESCRIPTION
## Description of the Change
Clockmanager と SystemLogger を std::chrono に対応する。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
ログ出力で時間が出力されることを確認した。
