### PR TITLE
[compat, modify] enable the zero-as-null-pointer-constant for Relase …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,7 +682,7 @@ function(openrtm_common_set_compile_options target)
 		-Wno-unused-macros
 		-Wno-unused-result
 		-Wno-useless-cast
-		-Wno-zero-as-null-pointer-constant)
+		)
 	set(WARN_CLANG
 		-Weverything
 		# exclude rule
@@ -723,7 +723,6 @@ function(openrtm_common_set_compile_options target)
 		-Wno-unused-macros
 		-Wno-unused-variable
 		-Wno-weak-vtables
-		-Wno-zero-as-null-pointer-constant
 		)
 
 	target_compile_options(${target} PRIVATE

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -228,7 +228,7 @@ namespace coil
                           Creator creator,
                           Destructor destructor)
     {
-      if (creator == 0 || destructor == 0) { return INVALID_ARG; }
+      if (creator == nullptr || destructor == nullptr) { return INVALID_ARG; }
       if (m_creators.count(id) != 0) { return ALREADY_EXISTS; }
       FactoryEntry f(id, creator, destructor);
       m_creators[id] = f;

--- a/src/lib/hrtm/component_manager.cpp
+++ b/src/lib/hrtm/component_manager.cpp
@@ -22,7 +22,7 @@ namespace hrtm
 {
   // static members initialization
   ModuleInitProc ComponentManager::initProc;
-  ComponentManager* ComponentManager::manager = NULL;
+  ComponentManager* ComponentManager::manager = nullptr;
   std::mutex ComponentManager::mutex;
   
   hrtm::DataFlowComponent*

--- a/src/lib/hrtm/statechart.h
+++ b/src/lib/hrtm/statechart.h
@@ -216,7 +216,7 @@ public:
         if (data_place) {
             // Free cached memory of previously used data.
             ::operator delete(data_place);
-            data_place = 0;
+            data_place = nullptr;
         }
         data_ = data;
     }
@@ -349,7 +349,7 @@ class StateAlias {
   // Clones object.
   // Will call copy constructor of data.
   StateAlias clone() {
-    return StateAlias(character_, data_ ? (character_->clone)(data_) : 0);
+    return StateAlias(character_, data_ ? (character_->clone)(data_) : nullptr);
   }
   StateInfo & get_info(MachineBase & machine) const {
     return (character_->get_info)(machine);
@@ -357,7 +357,7 @@ class StateAlias {
   // Hand over data object (to state instances or other state aliases).
   void * take_data() const {
     void * data = data_;
-    data_ = 0;
+    data_ = nullptr;
     return data;
   }
 
@@ -487,11 +487,11 @@ class Link : public P {
   static void clear_history(Machine<TOP> & m) { get_info(m).set_history(0); }
   static void clear_history_deep(Machine<TOP> & m) {
     m.clear_history_deep(get_info(m)); }
-  static void set_state(Machine<TOP> & machine, void * data = 0) {
+  static void set_state(Machine<TOP> & machine, void * data = nullptr) {
     StateInfo & info = get_info(machine);
     machine.set_pending_state(info, true, data);
   }
-  static void set_state_direct(Machine<TOP> & machine, void * data = 0) {
+  static void set_state_direct(Machine<TOP> & machine, void * data = nullptr) {
     StateInfo & info = get_info(machine);
     machine.set_pending_state(info, false, data);
   }
@@ -507,7 +507,7 @@ class Link : public P {
     P::machine().set_pending_state(info, true, state.take_data());
   }
   // to be used with restore
-  void set_state(StateInfo & current, void * data = 0) {
+  void set_state(StateInfo & current, void * data = nullptr) {
     this->state_info_.machine().set_pending_state(current, true, data);
   }
 
@@ -983,7 +983,7 @@ class Machine : public MachineBase {
     for (unsigned int i = 0; i < the_state_count_; ++i) {
       StateInfo * s = states_[i];
       if (s && s->is_child(state))
-        s->set_history(0);
+        s->set_history(nullptr);
     }
   }
 

--- a/src/lib/rtm/StateMachine.h
+++ b/src/lib/rtm/StateMachine.h
@@ -285,12 +285,12 @@ namespace RTC_Utils
     explicit StateMachine(int num_of_state)
       : m_num(num_of_state),
         m_listener(nullptr),
-        m_entry(m_num, (Callback)NULL),
-        m_predo(m_num, (Callback)NULL),
-        m_do(m_num, (Callback)NULL),
-        m_postdo(m_num, (Callback)NULL),
-        m_exit(m_num, (Callback)NULL),
-        m_transit(NULL),
+        m_entry(m_num, (Callback)nullptr),
+        m_predo(m_num, (Callback)nullptr),
+        m_do(m_num, (Callback)nullptr),
+        m_postdo(m_num, (Callback)nullptr),
+        m_exit(m_num, (Callback)nullptr),
+        m_transit(nullptr),
         m_selftrans(false)
     {
     }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #534

## Description of the Change

- コンパイラが警告する ポインタに対して NULL や 0 を設定している箇所を nullptr に修正する
- Release モード時の -Wno-zero-as-null-pointer-constant を削除 

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [X] No warnings for the build?  
- [X] Have you passed the unit tests?

- 検証ベースブランチ (d2ddbd7)
- gcc-7.3 でReleaseモードでビルドが通ることを確認した
- clang-7.0 では Releaseモードで検証ブランチではビルドがとおらなかったため、
   Debugモードで対象箇所を特定し、修正後にDebugモードでのビルドログに対象の警告がないことを確認
- hrtmはサンプルRTCがないため結合動作未確認