### PR TITLE
File descriptor from popen not closed properly.

### DIFF
--- a/src/lib/coil/posix/coil/Process.cpp
+++ b/src/lib/coil/posix/coil/Process.cpp
@@ -89,7 +89,8 @@ namespace coil
           }
         out.push_back(line);
       } while (feof(fd) == 0);
-
+    
+    (void) pclose(fd);
     return 0;
   }
 


### PR DESCRIPTION
A file descriptor obtained by popen() in create_process() function is not closed. Resource leak. pclose() added to close the file descriptor.

## Description of the Change

create_process() 関数で popenで取得したFDがcloseされていない。 pclose()でcloseするよう変更した。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
