### PR TITLE
[compat, modify] enable the unused-but-set-variable/unused-variable o…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,7 +678,6 @@ function(openrtm_common_set_compile_options target)
 		-Wno-suggest-attribute=format
 		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wno-suggest-attribute=malloc>
 		-Wno-switch-enum
-		-Wno-unused-but-set-variable
 		-Wno-unused-macros
 		-Wno-unused-result
 		-Wno-useless-cast
@@ -721,7 +720,6 @@ function(openrtm_common_set_compile_options target)
 		-Wno-unreachable-code
 		-Wno-unused-local-typedef
 		-Wno-unused-macros
-		-Wno-unused-variable
 		-Wno-weak-vtables
 		)
 

--- a/examples/Composite/ControllerComp.cpp
+++ b/examples/Composite/ControllerComp.cpp
@@ -41,6 +41,11 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("Controller");
 
+  if (comp == nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
 
   // Example
   // The following procedure is examples how handle RT-Components.

--- a/examples/Composite/MotorComp.cpp
+++ b/examples/Composite/MotorComp.cpp
@@ -40,6 +40,11 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("Motor");
 
+  if (comp == nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
 
   // Example
   // The following procedure is examples how handle RT-Components.

--- a/examples/Composite/SensorComp.cpp
+++ b/examples/Composite/SensorComp.cpp
@@ -38,6 +38,11 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("Sensor");
 
+  if (comp == nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
 
   // Example
   // The following procedure is examples how handle RT-Components.

--- a/examples/ExtTrigger/ConnectorComp.cpp
+++ b/examples/ExtTrigger/ConnectorComp.cpp
@@ -190,6 +190,7 @@ int main (int argc, char** argv)
   ReturnCode_t ret;
   ret = pin[static_cast<CORBA::ULong>(0)]->connect(prof);
   assert(ret == RTC::RTC_OK);
+  (void)ret;
 
   std::cout << "Connector ID: " << prof.connector_id << std::endl;
   NVUtil::dump(prof.properties);

--- a/examples/SeqIO/SeqInComp.cpp
+++ b/examples/SeqIO/SeqInComp.cpp
@@ -38,6 +38,11 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("SeqIn");
 
+  if (comp == nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
 
   // Example
   // The following procedure is examples how handle RT-Components.

--- a/examples/SeqIO/SeqOutComp.cpp
+++ b/examples/SeqIO/SeqOutComp.cpp
@@ -38,6 +38,11 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("SeqOut");
 
+  if (comp == nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
 
   // Example
   // The following procedure is examples how handle RT-Components.

--- a/examples/SimpleService/MyServiceConsumerComp.cpp
+++ b/examples/SimpleService/MyServiceConsumerComp.cpp
@@ -39,6 +39,11 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("MyServiceConsumer");
 
+  if (comp == nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
 
   // Example
   // The following procedure is examples how handle RT-Components.

--- a/examples/SimpleService/MyServiceProviderComp.cpp
+++ b/examples/SimpleService/MyServiceProviderComp.cpp
@@ -38,6 +38,11 @@ void MyModuleInit(RTC::Manager* manager)
   // Create a component
   comp = manager->createComponent("MyServiceProvider");
 
+  if (comp == nullptr)
+  {
+    std::cerr << "Component create failed." << std::endl;
+    abort();
+  }
 
   // Example
   // The following procedure is examples how handle RT-Components.

--- a/src/lib/rtm/NamingManager.cpp
+++ b/src/lib/rtm/NamingManager.cpp
@@ -920,7 +920,6 @@ namespace RTC
   }
   void NamingManager::unregisterMgrName(const char* name)
   {
-    std::vector<Mgr*>::iterator it(m_mgrNames.begin());
     for (std::vector<Mgr*>::iterator mgr = m_mgrNames.begin(); mgr != m_mgrNames.end(); ++mgr)
       {
         if ((*mgr)->name == name)


### PR DESCRIPTION
…ptions.

 close #540

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #540 

## Description of the Change

- サンプルRTCのコードで createComponent() の戻り値が正常でない場合はabortさせた
  - なおこの if 条件の処理は RTCBuilder で出力されるコードと同じである。

- CMakeLists.txtで警告オプション抑制処理を削除した

- 使用していない変数を削除した

- Assert関数で使用している変数はvoidキャストで対応
  - C++17 からは maybe_unused 属性が使える

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
- [X] Have you passed the unit tests?  

- 検証ベースブランチ (ab1de46a)
- gcc-7.3 でReleaseモードでビルドが通ることを確認した
- clang-7.0 では Releaseモードで検証ブランチではビルドがとおらなかったため、
   Debugモードで対象箇所を特定し、修正後にDebugモードでのビルドログに対象の警告がないことを確認
- example配下で変更したサンプルRTCは実行できることを確認