### PR TITLE
Manager終了時にログレベルが高いにもかかわらずPARANOIDの情報を出力する問題の修正

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2127,9 +2127,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             comp->exit();
             coil::Properties p(comp->getInstanceName());
             p << comp->getProperties();
-            rtclog.lock();
-            rtclog.write(::RTC::Logger::RTL_PARANOID,  p);
-            rtclog.unlock();
+            RTC_PARANOID_STR((p));
           }
         catch (...)
           {


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
shutdownComponents関数で以下のように関数マクロを使わずにログを出力している箇所がある。

```CPP
            rtclog.lock();
            rtclog.write(::RTC::Logger::RTL_PARANOID,  p);	
            rtclog.unlock();
```

ただログレベルの判定を関数マクロ内で実行しているため、直接write関数を読んだ場合にはログレベルにかかわらず出力されてしまう。

## Description of the Change

この部分だけマクロを使わない意味はおそらくないため、マクロを使うように変更した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
