### PR TITLE
Linux用IDLインストールパッケージを作成する(1.2)

### DIFF
--- a/packages/deb/debian/control
+++ b/packages/deb/debian/control
@@ -30,6 +30,13 @@ Description: OpenRTM-aist headers for development
  The header files and libraries needed for developing RT-Components
  using OpenRTM-aist.
 
+Package: openrtm-aist-idl
+Architecture: any
+Multi-Arch: same
+Depends: openrtm-aist
+Description: OpenRTM-aist idls for development
+ The idl files needed for developing RT-Components using OpenRTM-aist.
+
 Package: openrtm-aist-example
 Architecture: any
 Multi-Arch: same

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -150,6 +150,15 @@ install-arch:
 	(cd $(CURDIR)/src/ext/sdo/observer/idl; cp *.idl $(CURDIR)/debian/openrtm-aist-dev/usr/include/openrtm-$(SHORT_VER)/rtm/ext/sdo/observer/idl)
 	(cd $(CURDIR)/src/ext/sdo/observer/idl; cp *.cc $(CURDIR)/debian/openrtm-aist-dev/usr/include/openrtm-$(SHORT_VER)/rtm/ext/sdo/observer/idl)
 
+	# for openrtm-aist-idl package
+	(mkdir -p $(CURDIR)/debian/openrtm-aist-idl/usr/include/openrtm-$(SHORT_VER)/rtm/idl)
+	(mv $(CURDIR)/debian/openrtm-aist-dev/usr/include/openrtm-$(SHORT_VER)/rtm/idl/*.idl $(CURDIR)/debian/openrtm-aist-idl/usr/include/openrtm-$(SHORT_VER)/rtm/idl)
+	(mv $(CURDIR)/debian/openrtm-aist-dev/usr/include/openrtm-$(SHORT_VER)/rtm/ext/*.idl $(CURDIR)/debian/openrtm-aist-idl/usr/include/openrtm-$(SHORT_VER)/rtm/idl)
+	(mkdir -p $(CURDIR)/debian/openrtm-aist-idl/usr/share/openrtm-$(SHORT_VER)/idl)
+	(cp $(CURDIR)/debian/openrtm-aist-idl/usr/include/openrtm-$(SHORT_VER)/rtm/idl/* $(CURDIR)/debian/openrtm-aist-idl/usr/share/openrtm-$(SHORT_VER)/idl)
+	(mkdir -p $(CURDIR)/debian/openrtm-aist-idl/etc/profile.d)
+	(echo "export RTM_IDL_DIR=/usr/share/openrtm-$(SHORT_VER)/idl" > $(CURDIR)/debian/openrtm-aist-idl/etc/profile.d/openrtm-aist-idl.sh)
+
 	# for openrtm-aist-example package
 	#$(MAKE)
 	(mkdir -p $(CURDIR)/debian/openrtm-aist-example/usr/lib)


### PR DESCRIPTION

## Identify the Bug

Link #564 

- IDLファイルを openrtm-aist-dev パッケージから切り出して、新たに openrtm-aist-idl パッケージとして定義した
- openrtm-aist-idl のインストール先は互換性のため従来のパス（/usr/includeの下）を残し、新たなインストール先（/usr/shareの下）の計2か所とした
/usr/include/openrtm-1.2/rtm/idl
/usr/share/openrtm-1.2/idl
- IDLのインストール先を環境変数 RTM_IDL_DIR(=/usr/share/openrtm-1.2/idl) で定義した


## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- debパッケージを作成・インストールし、環境変数RTM_IDL_DIRでパスを取得できる動作を確認した
