### PR TITLE
[compat, modify] enable -Wformat-nonliteral for Release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,7 +667,6 @@ function(openrtm_common_set_compile_options target)
 		-Wno-cast-qual
 		-Wno-conditionally-supported
 		-Wno-conversion
-		-Wno-format-nonliteral
 		-Wno-missing-declarations
 		-Wno-old-style-cast
 		-Wno-overloaded-virtual

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -169,7 +169,10 @@ namespace RTC
 #else
     struct tm* date;
     date = gmtime(&timer);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
     strftime(buf, sizeof(buf), m_dateFormat.c_str(), date);
+#pragma GCC diagnostic pop
 #endif
 
     std::string fmt(buf);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #571 


## Description of the Change

- pragma により警告を制御する
  - リテラルに修正しなかった理由
警告の対象部分は、ログの出力フォーマットを変更することを可能にする処理の一部であったため。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [X] Did you succeed the build?  
- [X] No warnings for the build?  
- [ ] Have you passed the unit tests?  
