### PR TITLE
共有メモリ通信で2MB以上のサイズのデータを送信すると異常終了するバグの修正

### DIFF
--- a/src/lib/rtm/SharedMemoryPort.h
+++ b/src/lib/rtm/SharedMemoryPort.h
@@ -264,7 +264,7 @@ namespace RTC
     ::OpenRTM::PortSharedMemory_var m_smInterface;
     bool m_endian;
     coil::SharedMemory m_shmem;
-
+    unsigned int m_created_count;
     
   };  // class SharedMemoryPort
 } // namespace RTC


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

データポートの共有メモリ通信で2MB以上のデータを送信するとプロセスが異常終了する。


## Description of the Change

データのサイズが現在の共有メモリのサイズよりも大きくなった場合に再初期化する処理を行っていたつもりでしたが、CreateFileMapping関数で指定の名前で共有メモリを作成した場合に、指定の名前の領域はプロセス終了まで削除されないらしく再初期化ができていませんでした。

このため、再初期化するたびにメモリ領域の名前を変更するようにしました。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
