### PR TITLE
Fix memory leak of ORB_init argument.

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -881,26 +881,32 @@ namespace coil
    * @brief Convert the given string list into the argument list
    * @endif
    */
-  char** toArgv(const vstring& args)
+  Argv::Argv(const vstring& args)
   {
-    char** argv;
-    size_t argc(args.size());
+    m_size = args.size();
+    m_argv = new char*[m_size + 1];
 
-    argv = new char*[argc + 1];
-
-    for (size_t i(0); i < argc; ++i)
+    for (size_t i(0); i < m_size; ++i)
       {
         size_t sz(args[i].size());
-        argv[i] = new char[sz + 1];
+        m_argv[i] = new char[sz + 1];
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
-        strncpy_s(argv[i], sz + 1, args[i].c_str(), sz);
+        strncpy_s(m_argv[i], sz + 1, args[i].c_str(), sz);
 #else
-        strncpy(argv[i], args[i].c_str(), sz);
+        strncpy(m_argv[i], args[i].c_str(), sz);
 #endif
-        argv[i][sz] = '\0';
+        m_argv[i][sz] = '\0';
       }
-    argv[argc] = nullptr;
-    return argv;
+    m_argv[m_size] = nullptr;
+  }
+
+  Argv::~Argv()
+  {
+    for(size_t i(0); i < m_size; ++i)
+      {
+        delete[] m_argv[i];
+      }
+    delete[] m_argv;
   }
 
   /*!

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -1023,8 +1023,33 @@ namespace coil
    *
    * @endif
    */
-  char** toArgv(const vstring& args);
-
+  class Argv
+  {
+    char** m_argv{nullptr};
+    size_t m_size{0};
+  public:
+    Argv() = default;
+    Argv(const vstring& args);
+    ~Argv();
+    // Non copyable: Implement this when you need.
+    Argv(const Argv&) = delete;
+    Argv& operator=(const Argv&) = delete;
+    // Movable
+    Argv(Argv&& x) noexcept { *this = std::move(x); }
+    Argv& operator=(Argv&& x) noexcept
+    {
+      if(this != &x)
+        {
+          m_argv = x.m_argv;
+          m_size = x.m_size;
+          x.m_argv = nullptr;
+          x.m_size = 0;
+        }
+      return *this;
+    }
+    char** get() { return m_argv;}
+    size_t size() { return m_size; }
+  };
 
   /*!
    * @if jp

--- a/src/lib/coil/posix/coil/Process.cpp
+++ b/src/lib/coil/posix/coil/Process.cpp
@@ -56,9 +56,9 @@ namespace coil
         setsid();
 
         coil::vstring vstr(::coil::split(command, " "));
-        char* const * argv = ::coil::toArgv(vstr);
+        Argv argv(vstr);
 
-        execvp(vstr.front().c_str(), argv);
+        execvp(vstr.front().c_str(), argv.get());
 
         return -1;
       }

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1554,20 +1554,20 @@ std::vector<coil::Properties> Manager::getLoadableModules()
          }
          // TAO's ORB_init needs argv[0] as command name.
          args.insert(args.begin(), "manager");
-
-         char** argv = coil::toArgv(args);
-         int argc(static_cast<int>(args.size()));
-         
+         m_argv = coil::Argv(args);
 #ifdef ORB_IS_ORBEXPRESS
          CORBA::ORB::spawn_flags(VX_SPE_TASK | VX_STDIO);
          CORBA::ORB::stack_size(20000);
-         m_pORB = CORBA::ORB_init(argc, argv, "");
+         m_pORB = CORBA::ORB_init(m_argv.size(), m_argv.get(), "");
          CORBA::Object_var obj =
          m_pORB->resolve_initial_references((char*)"RootPOA");
          m_pPOA = PortableServer::POA::_narrow(obj);
 #else
          // ORB initialization
-         m_pORB = CORBA::ORB_init(argc, argv);
+         // ORB_init() of omniORB is too terrible. We cannot release all
+         // arguments until shutdown and the first argument type is int&
+         m_argvSize = static_cast<int>(m_argv.size());
+         m_pORB = CORBA::ORB_init(m_argvSize, m_argv.get());
          // Get the RootPOA
          CORBA::Object_var obj =
          m_pORB->resolve_initial_references((char*)"RootPOA");

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -1992,6 +1992,30 @@ namespace RTC
      */
     PortableServer::POAManager_var m_pPOAManager;
 
+    /*!
+     * @if jp
+     * @brief ORB_init に指定する引数
+     *
+     * omniORB の実装がひどすぎて、ORB_init後も与えた引数を維持しなければならない。
+     *
+     * @else
+     * @brief The argument of ORB_init
+     * @endif
+     */
+    coil::Argv m_argv;
+
+    /*!
+     * @if jp
+     * @brief ORB_init に指定する引数
+     *
+     * omniORB の実装がひどすぎて、ORB_init後も与えた引数を維持しなければならない。
+     *
+     * @else
+     * @brief The argument of ORB_init
+     * @endif
+     */
+    int m_argvSize;
+
     //------------------------------------------------------------
     // Manager's variable
     //------------------------------------------------------------

--- a/utils/rtcprof/rtcprof.cpp
+++ b/utils/rtcprof/rtcprof.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
   opts.push_back("manager.corba_servant:NO");
 
   // Manager initialization
-  RTC::Manager::init(static_cast<int>(opts.size()), coil::toArgv(opts));
+  RTC::Manager::init(static_cast<int>(opts.size()), coil::Argv(opts).get());
   RTC::Manager& mgr(RTC::Manager::instance());
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

coil::toArgv の実装は new をしているにもかかわらず delete を設計していない。

## Description of the Change

Argv をクラス化して、 delete が呼び出されるように変更した。

追加コメント：
非常に残念なことに omniORB の init() に与えた引数は、omniORB が動作している間は解放できない。
解放すると、メモリの不正アクセスが発生してプログラムが落ちるため、 init() 後に Argv を解放できない。
（Web で簡単に検索しても、そんな制限事項はどこにも書いていない…）
また、今のところ Manager の解放タイミングがないために、 
Argv のインスタンスが解放されるタイミングはない。
（#575 が入れば削除されるはず。）

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  ConsoleIn/Out は動いた。
