### PR TITLE
Use default-member-init.

### DIFF
--- a/examples/SimpleService/MyServiceConsumer.h
+++ b/examples/SimpleService/MyServiceConsumer.h
@@ -193,13 +193,13 @@ class MyServiceConsumer
   template <class T>
   struct seq_print
   {
-    seq_print() : m_cnt(0) {}
+    seq_print()  {}
     void operator()(T val)
     {
       std::cout << m_cnt << ": " << val << std::endl;
       ++m_cnt;
     }
-    int m_cnt;
+    int m_cnt{0};
   };
 
 };

--- a/examples/SimpleService/MyServiceSVC_impl.cpp
+++ b/examples/SimpleService/MyServiceSVC_impl.cpp
@@ -12,13 +12,13 @@
 template <class T>
 struct seq_print
 {
-  seq_print() : m_cnt(0) {}
+  seq_print()  {}
   void operator()(T val)
   {
     std::cout << m_cnt << ": " << val << std::endl;
     ++m_cnt;
   }
-  int m_cnt;
+  int m_cnt{0};
 };
 
 /*

--- a/examples/StaticFsm/MicrowaveFsm.h
+++ b/examples/StaticFsm/MicrowaveFsm.h
@@ -47,7 +47,7 @@ namespace MicrowaveFsm
     // Top state data (visible to all substates)
     struct Box
     {
-      Box() : myCookingTime(0) {}
+      Box()  {}
       void printTimer()
       {
         std::cout << "  Timer set to ";
@@ -58,7 +58,7 @@ namespace MicrowaveFsm
       void resetTimer() { myCookingTime = 0; }
       int getRemainingTime() { return myCookingTime; }
     private:
-      int myCookingTime;
+      int myCookingTime{0};
     };
 
     FSM_STATE(Top);

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.cpp
@@ -34,11 +34,7 @@ namespace RTC
    * @endif
    */
   LogicalTimeTriggeredEC::LogicalTimeTriggeredEC()
-    : ExecutionContextBase("exttrig_async_ec"),
-      rtclog("exttrig_async_ec"),
-      m_clock(coil::ClockManager::instance().getClock("logical")),
-      m_syncTick(true), m_count(0),
-      m_svc(false)
+    : ExecutionContextBase("exttrig_async_ec")
   {
     RTC_TRACE(("LogicalTimeTriggeredEC()"));
 

--- a/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
+++ b/src/ext/ec/logical_time/LogicalTimeTriggeredEC.h
@@ -622,7 +622,7 @@ namespace RTC
      * @brief Logger stream
      * @endif
      */
-    RTC::Logger rtclog;
+    RTC::Logger rtclog{"exttrig_async_ec"};
     /*!
      * @if jp
      * @brief Logical clock
@@ -630,7 +630,7 @@ namespace RTC
      * @brief Logical clock
      * @endif
      */
-    coil::IClock& m_clock;
+    coil::IClock& m_clock{coil::ClockManager::instance().getClock("logical")};
     /*!
      * @if jp
      * @brief Synchronous tick flag
@@ -638,7 +638,7 @@ namespace RTC
      * @brief Synchronous tick flag
      * @endif
      */
-    bool m_syncTick;
+    bool m_syncTick{true};
     /*!
      * @if jp
      * @brief Tick counter
@@ -646,7 +646,7 @@ namespace RTC
      * @brief Tick counter
      * @endif
      */
-    unsigned int m_count;
+    unsigned int m_count{0};
     /*!
      * @if jp
      * @brief ExecutionContext のスレッド実行フラグ
@@ -654,7 +654,7 @@ namespace RTC
      * @brief The thread running flag of ExecutionContext
      * @endif
      */
-    bool m_svc;
+    bool m_svc{false};
     std::mutex m_svcmutex;
     std::mutex m_tickmutex;
 
@@ -667,10 +667,10 @@ namespace RTC
      */
     struct Worker
     {
-      Worker() : cond_(), ticked_(false) {}
+      Worker() {}
       std::mutex mutex_;
       std::condition_variable cond_;
-      bool ticked_;
+      bool ticked_{false};
     };
     // A condition variable for external triggered worker
     Worker m_worker;

--- a/src/ext/ec/rtpreempt/RTPreemptEC.cpp
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.cpp
@@ -43,9 +43,7 @@ namespace RTC_exp
    */
   RTPreemptEC::
   RTPreemptEC()
-    : ExecutionContextBase("periodic_ec"),
-      rtclog("periodic_ec"),
-      m_svc(false), m_nowait(false)
+    : ExecutionContextBase("periodic_ec")
   {
     RTC_TRACE(("RTPreemptEC()"));
 

--- a/src/ext/ec/rtpreempt/RTPreemptEC.h
+++ b/src/ext/ec/rtpreempt/RTPreemptEC.h
@@ -740,7 +740,7 @@ namespace RTC_exp
      * @brief Logger stream
      * @endif
      */
-    RTC::Logger rtclog;
+    RTC::Logger rtclog{"periodic_ec"};
 
     /*!
      * @if jp
@@ -749,7 +749,7 @@ namespace RTC_exp
      * @brief The thread running flag of ExecutionContext
      * @endif
      */
-    bool m_svc;
+    bool m_svc{false};
     std::mutex m_svcmutex;
     
     /*!
@@ -761,10 +761,10 @@ namespace RTC_exp
      */
     struct WorkerThreadCtrl
     {
-      WorkerThreadCtrl() : cond_(), running_(false) {}
+      WorkerThreadCtrl() {}
       std::mutex mutex_;
       std::condition_variable cond_;
-      bool running_;
+      bool running_{false};
     };
 
     /*!
@@ -784,7 +784,7 @@ namespace RTC_exp
      *        (to run without waiting)
      * @endif
      */
-    bool m_nowait;
+    bool m_nowait{false};
 
   private:
     int m_priority;

--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -30,7 +30,6 @@ namespace RTC
   //============================================================
   // FluentBitStream class
   FluentBitStream::FluentBitStream()
-    : m_pos(0)
   {
     for (char & i : m_buf) { i = '\0'; }
     if (s_flbContext == nullptr)

--- a/src/ext/logger/fluentbit_stream/FluentBit.h
+++ b/src/ext/logger/fluentbit_stream/FluentBit.h
@@ -76,7 +76,7 @@ namespace RTC
 
   private:
     char m_buf[BUFFER_LEN];
-    size_t m_pos;
+    size_t m_pos{0};
 
     typedef int FlbHandler;
 

--- a/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.cpp
+++ b/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.cpp
@@ -33,7 +33,6 @@ namespace RTC
    * @endif
    */
   ExtendedFsmServiceProvider::ExtendedFsmServiceProvider()
-    : m_rtobj(nullptr)
   {
     std::cout << "ExtendedFsmServiceProvider()" << std::endl;
 

--- a/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.h
+++ b/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.h
@@ -289,7 +289,7 @@ namespace RTC
     void unsetFSMStructureListeners();
 
   private:
-    RTC::RTObject_impl* m_rtobj;
+    RTC::RTObject_impl* m_rtobj{nullptr};
     SDOPackage::ServiceProfile m_profile;
     coil::Properties m_properties;
     FsmStructure m_fsmStructure;

--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
@@ -32,11 +32,6 @@ namespace RTC
    * @endif
    */
   ComponentObserverConsumer::ComponentObserverConsumer()
-    : m_rtobj(nullptr),
-      m_compstat(*this), m_portaction(*this),
-      m_ecaction(*this), m_configMsg(*this),
-      m_fsmaction(*this),
-      m_rtcHeartbeat(false), m_ecHeartbeat(false)
   {
     for (bool & i : m_observed)
       {

--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
@@ -576,9 +576,7 @@ namespace RTC
     {
     public:
       ECAction(ComponentObserverConsumer& coc)
-        : ecAttached(nullptr), ecDetached(nullptr), ecRatechanged(nullptr),
-          ecStartup(nullptr), ecShutdown(nullptr),
-          m_coc(coc) {}
+        : m_coc(coc) {}
       void onGeneric(const char* _msg, UniqueId ec_id)
       {
         std::string msg(_msg + coil::otos(ec_id));
@@ -613,11 +611,11 @@ namespace RTC
             onGeneric("SHUTDOWN:", ec_id);
           }
       }
-      ExecutionContextActionListener* ecAttached;
-      ExecutionContextActionListener* ecDetached;
-      PostComponentActionListener* ecRatechanged;
-      PostComponentActionListener* ecStartup;
-      PostComponentActionListener* ecShutdown;
+      ExecutionContextActionListener* ecAttached{nullptr};
+      ExecutionContextActionListener* ecDetached{nullptr};
+      PostComponentActionListener* ecRatechanged{nullptr};
+      PostComponentActionListener* ecStartup{nullptr};
+      PostComponentActionListener* ecShutdown{nullptr};
     private:
       ComponentObserverConsumer& m_coc;
     };
@@ -633,10 +631,7 @@ namespace RTC
     {
     public:
       ConfigAction(ComponentObserverConsumer& coc)
-        : updateConfigParamListener(nullptr), setConfigSetListener(nullptr),
-          addConfigSetListener(nullptr), updateConfigSetListener(nullptr),
-          removeConfigSetListener(nullptr), activateConfigSetListener(nullptr),
-          m_coc(coc) {}
+        : m_coc(coc) {}
       void updateConfigParam(const char* configsetname,
                              const char* configparamname)
       {
@@ -677,12 +672,12 @@ namespace RTC
         m_coc.updateStatus(RTC::CONFIGURATION, msg.c_str());
       }
       // Listener object's pointer holder
-      ConfigurationParamListener*   updateConfigParamListener;
-      ConfigurationSetListener*     setConfigSetListener;
-      ConfigurationSetListener*     addConfigSetListener;
-      ConfigurationSetNameListener* updateConfigSetListener;
-      ConfigurationSetNameListener* removeConfigSetListener;
-      ConfigurationSetNameListener* activateConfigSetListener;
+      ConfigurationParamListener*   updateConfigParamListener{nullptr};
+      ConfigurationSetListener*     setConfigSetListener{nullptr};
+      ConfigurationSetListener*     addConfigSetListener{nullptr};
+      ConfigurationSetNameListener* updateConfigSetListener{nullptr};
+      ConfigurationSetNameListener* removeConfigSetListener{nullptr};
+      ConfigurationSetNameListener* activateConfigSetListener{nullptr};
 
     private:
       ComponentObserverConsumer& m_coc;
@@ -778,21 +773,21 @@ namespace RTC
 
 
 
-    RTC::RTObject_impl* m_rtobj;
+    RTC::RTObject_impl* m_rtobj{nullptr};
     SDOPackage::ServiceProfile m_profile;
     CorbaConsumer<RTC::ComponentObserver> m_observer;
 
     bool m_observed[RTC::STATUS_KIND_NUM];
 
-    CompStatMsg m_compstat;
-    PortAction m_portaction;
-    ECAction m_ecaction;
-    ConfigAction m_configMsg;
-    FSMAction m_fsmaction;
+    CompStatMsg m_compstat{*this};
+    PortAction m_portaction{*this};
+    ECAction m_ecaction{*this};
+    ConfigAction m_configMsg{*this};
+    FSMAction m_fsmaction{*this};
 
-    bool m_rtcHeartbeat;
+    bool m_rtcHeartbeat{false};
     Manager::TaskId m_rtcHbTaskId;
-    bool m_ecHeartbeat;
+    bool m_ecHeartbeat{false};
     Manager::TaskId m_ecHbTaskId;
   };
 

--- a/src/ext/sdo/logger/LoggerConsumer.cpp
+++ b/src/ext/sdo/logger/LoggerConsumer.cpp
@@ -32,7 +32,6 @@ namespace RTC
    * @endif
    */
   LoggerConsumer::LoggerConsumer()
-    : m_rtobj(nullptr)
   {
   }
 

--- a/src/ext/sdo/logger/LoggerConsumer.h
+++ b/src/ext/sdo/logger/LoggerConsumer.h
@@ -97,7 +97,7 @@ namespace RTC
 
   protected:
 
-    RTC::RTObject_impl* m_rtobj;
+    RTC::RTObject_impl* m_rtobj{nullptr};
     SDOPackage::ServiceProfile m_profile;
     CorbaConsumer<OpenRTM::Logger> m_logger;
   };

--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -33,10 +33,6 @@ namespace RTC
    * @endif
    */
   ComponentObserverConsumer::ComponentObserverConsumer()
-    : m_rtobj(nullptr),
-      m_compstat(*this), m_portaction(*this),
-      m_inportInterval(std::chrono::seconds(1)), m_outportInterval(std::chrono::seconds(1)),
-      m_ecaction(*this), m_configMsg(*this), m_heartbeat(false)
   {
     for (bool & observed : m_observed)
       {

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -358,9 +358,7 @@ namespace RTC
     {
     public:
       PortAction(ComponentObserverConsumer& coc)
-        : portAddListener(nullptr), portRemoveListener(nullptr),
-          portConnectListener(nullptr), portDisconnectListener(nullptr),
-          m_coc(coc) {}
+        : m_coc(coc) {}
       void onGeneric(const char* _msg, const char* portname)
       {
         std::string msg(_msg);
@@ -392,10 +390,10 @@ namespace RTC
           }
       }
 
-      PortActionListener* portAddListener;
-      PortActionListener* portRemoveListener;
-      PortConnectRetListener* portConnectListener;
-      PortConnectRetListener* portDisconnectListener;
+      PortActionListener* portAddListener{nullptr};
+      PortActionListener* portRemoveListener{nullptr};
+      PortConnectRetListener* portConnectListener{nullptr};
+      PortConnectRetListener* portDisconnectListener{nullptr};
 
     private:
       ComponentObserverConsumer& m_coc;
@@ -415,8 +413,7 @@ namespace RTC
       DataPortAction(ComponentObserverConsumer& coc,
                      std::string  msg,
                      std::chrono::nanoseconds interval)
-        : m_coc(coc), m_msg(std::move(msg)), m_interval(interval),
-          m_last(std::chrono::steady_clock::now())
+        : m_coc(coc), m_msg(std::move(msg)), m_interval(interval)
       {
       }
       ~DataPortAction() override {}
@@ -438,7 +435,7 @@ namespace RTC
       ComponentObserverConsumer& m_coc;
       std::string m_msg;
       std::chrono::nanoseconds m_interval;
-      std::chrono::steady_clock::time_point m_last;
+      std::chrono::steady_clock::time_point m_last{std::chrono::steady_clock::now()};
     };
     
     /*!
@@ -452,9 +449,7 @@ namespace RTC
     {
     public:
       ECAction(ComponentObserverConsumer& coc)
-        : ecAttached(nullptr), ecDetached(nullptr), ecRatechanged(nullptr),
-          ecStartup(nullptr), ecShutdown(nullptr),
-          m_coc(coc) {}
+        : m_coc(coc) {}
       void onGeneric(const char* _msg, UniqueId ec_id)
       {
         std::string msg(_msg + coil::otos(ec_id));
@@ -489,11 +484,11 @@ namespace RTC
             onGeneric("SHUTDOWN:", ec_id);
           }
       }
-      ExecutionContextActionListener* ecAttached;
-      ExecutionContextActionListener* ecDetached;
-      PostComponentActionListener* ecRatechanged;
-      PostComponentActionListener* ecStartup;
-      PostComponentActionListener* ecShutdown;
+      ExecutionContextActionListener* ecAttached{nullptr};
+      ExecutionContextActionListener* ecDetached{nullptr};
+      PostComponentActionListener* ecRatechanged{nullptr};
+      PostComponentActionListener* ecStartup{nullptr};
+      PostComponentActionListener* ecShutdown{nullptr};
     private:
       ComponentObserverConsumer& m_coc;
     };
@@ -509,10 +504,7 @@ namespace RTC
     {
     public:
       ConfigAction(ComponentObserverConsumer& coc)
-        : updateConfigParamListener(nullptr), setConfigSetListener(nullptr),
-          addConfigSetListener(nullptr), updateConfigSetListener(nullptr),
-          removeConfigSetListener(nullptr), activateConfigSetListener(nullptr),
-          m_coc(coc) {}
+        : m_coc(coc) {}
       void updateConfigParam(const char* configsetname,
                              const char* configparamname)
       {
@@ -553,12 +545,12 @@ namespace RTC
         m_coc.updateStatus(OpenRTM::CONFIGURATION, msg.c_str());
       }
       // Listener object's pointer holder
-      ConfigurationParamListener*   updateConfigParamListener;
-      ConfigurationSetListener*     setConfigSetListener;
-      ConfigurationSetListener*     addConfigSetListener;
-      ConfigurationSetNameListener* updateConfigSetListener;
-      ConfigurationSetNameListener* removeConfigSetListener;
-      ConfigurationSetNameListener* activateConfigSetListener;
+      ConfigurationParamListener*   updateConfigParamListener{nullptr};
+      ConfigurationSetListener*     setConfigSetListener{nullptr};
+      ConfigurationSetListener*     addConfigSetListener{nullptr};
+      ConfigurationSetNameListener* updateConfigSetListener{nullptr};
+      ConfigurationSetNameListener* removeConfigSetListener{nullptr};
+      ConfigurationSetNameListener* activateConfigSetListener{nullptr};
 
     private:
       ComponentObserverConsumer& m_coc;
@@ -566,26 +558,26 @@ namespace RTC
 
 
 
-    RTC::RTObject_impl* m_rtobj;
+    RTC::RTObject_impl* m_rtobj{nullptr};
     SDOPackage::ServiceProfile m_profile;
     CorbaConsumer<OpenRTM::ComponentObserver> m_observer;
 
     bool m_observed[OpenRTM::STATUS_KIND_NUM];
 
     // ComponentProfile
-    CompStatMsg m_compstat;
+    CompStatMsg m_compstat{*this};
 
     // PortProfile
-    PortAction m_portaction;
-    std::chrono::nanoseconds m_inportInterval;
-    std::chrono::nanoseconds m_outportInterval;
+    PortAction m_portaction{*this};
+    std::chrono::nanoseconds m_inportInterval{std::chrono::seconds(1)};
+    std::chrono::nanoseconds m_outportInterval{std::chrono::seconds(1)};
 
     // Execution Context
-    ECAction m_ecaction;
-    ConfigAction m_configMsg;
+    ECAction m_ecaction{*this};
+    ConfigAction m_configMsg{*this};
 
     // Heartbeat
-    bool m_heartbeat;
+    bool m_heartbeat{false};
     Manager::TaskId m_hbtaskid;
 
     std::mutex mutex;

--- a/src/lib/coil/common/coil/PeriodicTask.cpp
+++ b/src/lib/coil/common/coil/PeriodicTask.cpp
@@ -29,11 +29,6 @@ namespace coil
    * @endif
    */
   PeriodicTask::PeriodicTask()
-    : m_period(std::chrono::seconds(0)),
-      m_func(nullptr),
-      m_alive(false), m_suspend(false),
-      m_execCount(0), m_execCountMax(1000),
-      m_periodCount(0), m_periodCountMax(1000)
   {
   }
 

--- a/src/lib/coil/common/coil/PeriodicTask.h
+++ b/src/lib/coil/common/coil/PeriodicTask.h
@@ -308,7 +308,7 @@ namespace coil
      * @brief Task execution period
      * @endif
      */
-    std::chrono::nanoseconds m_period;
+    std::chrono::nanoseconds m_period{0};
 
     /*!
      * @if jp
@@ -343,7 +343,7 @@ namespace coil
      * @brief Task alive flag
      * @endif
      */
-    alive_t m_alive;
+    alive_t m_alive{false};
 
     /*!
      * @if jp
@@ -354,7 +354,7 @@ namespace coil
      */
     struct suspend_t
     {
-      explicit suspend_t(bool sus) : suspend(sus), mutex(), cond() {}
+      explicit suspend_t(bool sus) : suspend(sus) {}
       bool suspend;
       std::mutex mutex;
       std::condition_variable cond;
@@ -367,7 +367,7 @@ namespace coil
      * @brief Task suspend infomation
      * @endif
      */
-    suspend_t m_suspend;
+    suspend_t m_suspend{false};
 
     /*!
      * @if jp
@@ -398,7 +398,7 @@ namespace coil
      * @brief Task execution time measurement count
      * @endif
      */
-    unsigned int      m_execCount;
+    unsigned int      m_execCount{0};
 
     /*!
      * @if jp
@@ -407,7 +407,7 @@ namespace coil
      * @brief Task execution time measurement max count
      * @endif
      */
-    unsigned int      m_execCountMax;
+    unsigned int      m_execCountMax{1000};
 
     /*!
      * @if jp
@@ -443,7 +443,7 @@ namespace coil
      * @brief Task periodic time measurement count
      * @endif
      */
-    unsigned int      m_periodCount;
+    unsigned int      m_periodCount{0};
 
     /*!
      * @if jp
@@ -452,7 +452,7 @@ namespace coil
      * @brief Task periodic time measurement max count
      * @endif
      */
-    unsigned int      m_periodCountMax;
+    unsigned int      m_periodCountMax{1000};
 
     /*!
      * @if jp

--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -39,7 +39,7 @@ namespace coil
    * @endif
    */
   Properties::Properties(const char* key, const char* value, bool set_value)
-    : name(key), value(value), default_value(""), set_value((this->value.empty()) ? set_value : true), root(nullptr), m_empty("")
+    : name(key), value(value), set_value((this->value.empty()) ? set_value : true)
   {
     leaf.clear();
   }
@@ -52,7 +52,6 @@ namespace coil
    * @endif
    */
   Properties::Properties(std::map<std::string, std::string>& defaults)
-    : name(""), value(""), default_value(""), set_value(false), root(nullptr), m_empty("")
   {
     leaf.clear();
     std::map<std::string, std::string>::iterator it(defaults.begin());
@@ -73,7 +72,6 @@ namespace coil
    * @endif
    */
   Properties::Properties(const char* const defaults[], long num)
-    : name(""), value(""), default_value(""), set_value(false), root(nullptr), m_empty("")
   {
     leaf.clear();
     setDefaults(defaults, num);

--- a/src/lib/coil/common/coil/Properties.h
+++ b/src/lib/coil/common/coil/Properties.h
@@ -1335,13 +1335,13 @@ namespace coil
     static std::string indent(int index);
 
   private:
-    std::string name;
-    std::string value;
-    std::string default_value;
-    bool set_value;
-    Properties* root;
+    std::string name = "";
+    std::string value = "";
+    std::string default_value = "";
+    bool set_value{false};
+    Properties* root{nullptr};
     std::vector<Properties*> leaf;
-    const std::string m_empty;
+    const std::string m_empty = "";
 
     /*!
      * @if jp

--- a/src/lib/coil/common/coil/TimeMeasure.cpp
+++ b/src/lib/coil/common/coil/TimeMeasure.cpp
@@ -36,9 +36,7 @@ namespace coil
    * @endif
    */
   TimeMeasure::TimeMeasure(unsigned long buflen)
-    : m_interval(std::chrono::seconds(0)),
-      m_count(0), m_countMax(buflen + 1),
-      m_recurred(false)
+    : m_countMax(buflen + 1)
   {
     m_record.reserve(m_countMax);
     for (unsigned long int i(0); i < m_countMax; ++i)

--- a/src/lib/coil/common/coil/TimeMeasure.h
+++ b/src/lib/coil/common/coil/TimeMeasure.h
@@ -236,12 +236,12 @@ namespace coil
   private:
     std::vector<std::chrono::nanoseconds> m_record;
     std::chrono::high_resolution_clock::time_point m_begin;
-    std::chrono::nanoseconds m_interval;
+    std::chrono::nanoseconds m_interval{0};
 
-    unsigned long int m_count;
+    unsigned long int m_count{0};
     const unsigned long int m_countMax;
 
-    bool m_recurred;
+    bool m_recurred{false};
   };
 } // namespace coil
 #endif  // COIL_TIMEMEASURE_H

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -235,7 +235,7 @@ namespace coil
    */
   struct unescape_functor
   {
-    unescape_functor() : count(0) {}
+    unescape_functor()  {}
     void operator()(char c)
     {
       if (c == '\\')
@@ -270,7 +270,7 @@ namespace coil
         }
     }
     std::string str;
-    int count;
+    int count{0};
   };
 
   /*!

--- a/src/lib/coil/posix/coil/SharedMemory.cpp
+++ b/src/lib/coil/posix/coil/SharedMemory.cpp
@@ -32,10 +32,6 @@ namespace coil
    * @endif
    */
   SharedMemory::SharedMemory()
-    : m_memory_size(0),
-      m_shm(nullptr),
-      m_file_create(false),
-      m_fd(-1)
   {
   }
 

--- a/src/lib/coil/posix/coil/SharedMemory.h
+++ b/src/lib/coil/posix/coil/SharedMemory.h
@@ -361,11 +361,11 @@ namespace coil
     virtual bool created();
 
   private:
-    unsigned long long m_memory_size;
+    unsigned long long m_memory_size{0};
     std::string m_shm_address;
-    char *m_shm;
-    bool m_file_create;
-    int m_fd;
+    char *m_shm{nullptr};
+    bool m_file_create{false};
+    int m_fd{-1};
   };  // class SharedMemory
 
 } // namespace coil

--- a/src/lib/coil/posix/coil/Signal.cpp
+++ b/src/lib/coil/posix/coil/Signal.cpp
@@ -21,10 +21,6 @@
 #include <coil/Signal.h>
 #include <cstring>
 
-#ifdef COIL_OS_FREEBSD
-#define _SIGSET_NWORDS _SIG_WORDS
-#endif
-
 namespace coil
 {
   /*!
@@ -50,7 +46,7 @@ namespace coil
    * @endif
    */
   SignalAction::SignalAction(SignalHandler handle, int signum)
-    : m_handle(handle), m_signum(signum), m_mask(nullptr), m_flags(0)
+    : m_handle(handle), m_signum(signum)
   {
     struct sigaction action;
     memset(&action, 0, sizeof(action));  // clear.
@@ -62,8 +58,6 @@ namespace coil
         signal(m_signum, SIG_DFL);
         m_handle = nullptr;
         m_signum = 0;
-        m_mask   = nullptr;
-        m_flags  = 0;
       }
   }
 
@@ -79,8 +73,6 @@ namespace coil
     signal(m_signum, SIG_DFL);
     m_handle = nullptr;
     m_signum = 0;
-    m_mask   = nullptr;
-    m_flags  = 0;
   }
 
 } // namespace coil

--- a/src/lib/coil/posix/coil/Signal.cpp
+++ b/src/lib/coil/posix/coil/Signal.cpp
@@ -35,7 +35,6 @@ namespace coil
    * @endif
    */
   SignalAction::SignalAction()
-    : m_handle(nullptr), m_signum(0), m_mask(nullptr), m_flags(0)
   {
   }
 

--- a/src/lib/coil/posix/coil/Signal.h
+++ b/src/lib/coil/posix/coil/Signal.h
@@ -102,11 +102,10 @@ namespace coil
   private:
     SignalAction(const SignalAction&) = delete;
     SignalAction& operator=(const SignalAction &) = delete;
-    SignalHandler m_handle;
-    int m_signum;
-    sigset_t* m_mask;
-    int m_flags;
-
+    SignalHandler m_handle{nullptr};
+    int m_signum{0};
+    sigset_t* m_mask{nullptr};
+    int m_flags{0};
   };
 } // namespace coil
 #endif  // COIL_SIGNAL_H

--- a/src/lib/coil/posix/coil/Signal.h
+++ b/src/lib/coil/posix/coil/Signal.h
@@ -104,8 +104,6 @@ namespace coil
     SignalAction& operator=(const SignalAction &) = delete;
     SignalHandler m_handle{nullptr};
     int m_signum{0};
-    sigset_t* m_mask{nullptr};
-    int m_flags{0};
   };
 } // namespace coil
 #endif  // COIL_SIGNAL_H

--- a/src/lib/hrtm/statechart.cpp
+++ b/src/lib/hrtm/statechart.cpp
@@ -116,11 +116,7 @@ StateInfo * StateInfo::clone(MachineBase & new_machine) {
 ////////////////////////////////////////////////////////////////////////////////
 // Base class for Machine objects.
 MachineBase::MachineBase()
-  : current_state_(nullptr)
-  , pending_state_(nullptr)
-  , pending_data_(nullptr)
-  , pending_history_(false)
-  , pending_event_(nullptr) {}
+   {}
 
 MachineBase::~MachineBase() {
   assert(!pending_data_);

--- a/src/lib/hrtm/statechart.h
+++ b/src/lib/hrtm/statechart.h
@@ -445,12 +445,12 @@ class EXPORT_DLL MachineBase {
   friend class StateBase;
 
   // Current state of Machine object.
-  StateInfo * current_state_;
+  StateInfo * current_state_{nullptr};
   // Information about pending state transition.
-  StateInfo * pending_state_;
-  void * pending_data_;
-  bool pending_history_;
-  EventBase * pending_event_;
+  StateInfo * pending_state_{nullptr};
+  void * pending_data_{nullptr};
+  bool pending_history_{false};
+  EventBase * pending_event_{nullptr};
   EventQueue deferred_events_;
   EventNames deferred_names_;
   // Array of StateInfo objects.

--- a/src/lib/rtm/ByteData.cpp
+++ b/src/lib/rtm/ByteData.cpp
@@ -17,8 +17,7 @@ namespace RTC
      *
      * @endif
      */
-    ByteData::ByteData() :
-        m_buf(nullptr), m_len(0), m_little_endian(true)
+    ByteData::ByteData()
     {
 
     }

--- a/src/lib/rtm/ByteData.h
+++ b/src/lib/rtm/ByteData.h
@@ -263,9 +263,9 @@ namespace RTC
          */
         bool getEndian();
     private:
-        unsigned char* m_buf;
-        unsigned long m_len;
-        bool m_little_endian;
+        unsigned char* m_buf{nullptr};
+        unsigned long m_len{0};
+        bool m_little_endian{true};
     };
 
 } // namespace RTC

--- a/src/lib/rtm/CORBA_CdrMemoryStream.cpp
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.cpp
@@ -39,7 +39,7 @@
   */
 namespace RTC
 {
-    CORBA_CdrMemoryStream::CORBA_CdrMemoryStream(): m_endian(true)
+    CORBA_CdrMemoryStream::CORBA_CdrMemoryStream()
     {
     }
 

--- a/src/lib/rtm/CORBA_CdrMemoryStream.h
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.h
@@ -390,7 +390,7 @@ namespace RTC
 #else
         cdrMemoryStream m_cdr;
 #endif
-        bool m_endian;
+        bool m_endian{true};
     };
     /*!
      * @if jp

--- a/src/lib/rtm/ExecutionContextWorker.cpp
+++ b/src/lib/rtm/ExecutionContextWorker.cpp
@@ -34,8 +34,6 @@ namespace RTC_impl
    * @endif
    */
   ExecutionContextWorker::ExecutionContextWorker()
-    : rtclog("ec_worker"),
-      m_running(false)
   {
     RTC_TRACE(("ExecutionContextWorker()"));
   }

--- a/src/lib/rtm/ExecutionContextWorker.h
+++ b/src/lib/rtm/ExecutionContextWorker.h
@@ -564,7 +564,7 @@ namespace RTC_impl
      * @brief Logger stream
      * @endif
      */
-    RTC::Logger rtclog;
+    RTC::Logger rtclog{"ec_worker"};
 
     RTC::ExecutionContextService_var m_ref;
 
@@ -577,7 +577,7 @@ namespace RTC_impl
      * true: running, false: stopped
      * @endif
      */
-    bool m_running;
+    bool m_running{false};
 
     /*!
      * @if jp

--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -33,9 +33,7 @@ namespace RTC
    * @endif
    */
   ExtTrigExecutionContext::ExtTrigExecutionContext()
-    : ExecutionContextBase("exttrig_async_ec"),
-      rtclog("exttrig_async_ec"),
-      m_svc(false)
+    : ExecutionContextBase("exttrig_async_ec")
   {
     RTC_TRACE(("ExtTrigExecutionContext()"));
 

--- a/src/lib/rtm/ExtTrigExecutionContext.h
+++ b/src/lib/rtm/ExtTrigExecutionContext.h
@@ -607,7 +607,7 @@ namespace RTC
      * @brief Logger stream
      * @endif
      */
-    RTC::Logger rtclog;
+    RTC::Logger rtclog{"exttrig_async_ec"};
 
     /*!
      * @if jp
@@ -616,7 +616,7 @@ namespace RTC
      * @brief The thread running flag of ExecutionContext
      * @endif
      */
-    bool m_svc;
+    bool m_svc{false};
     std::mutex m_svcmutex;
 
     /*!
@@ -628,10 +628,10 @@ namespace RTC
      */
     struct Worker
     {
-      Worker() : cond_(), ticked_(false) {}
+      Worker() {}
       std::mutex mutex_;
       std::condition_variable cond_;
-      bool ticked_;
+      bool ticked_{false};
     };
     // A condition variable for external triggered worker
     Worker m_worker;

--- a/src/lib/rtm/InPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrProvider.cpp
@@ -29,7 +29,6 @@ namespace RTC
    * @endif
    */
   InPortCorbaCdrProvider::InPortCorbaCdrProvider()
-      : m_buffer(nullptr), m_connector(nullptr)
   {
     // PortProfile setting
     setInterfaceType("corba_cdr");

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -372,11 +372,11 @@ namespace RTC
     }
 
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
     ::OpenRTM::InPortCdr_var m_objref;
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
-    InPortConnector* m_connector;
+    InPortConnector* m_connector{nullptr};
 
   };  // class InPortCorbaCdrProvider
 } // namespace RTC

--- a/src/lib/rtm/InPortDSProvider.cpp
+++ b/src/lib/rtm/InPortDSProvider.cpp
@@ -27,7 +27,6 @@ namespace RTC
    * @endif
    */
   InPortDSProvider::InPortDSProvider()
-      : m_buffer(nullptr), m_connector(nullptr)
   {
     // PortProfile setting
     setInterfaceType("data_service");

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -370,11 +370,11 @@ namespace RTC
     }
 
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
     ::RTC::DataPushService_var m_objref;
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
-    InPortConnector* m_connector;
+    InPortConnector* m_connector{nullptr};
 
   };  // class InPortDSProvider
 } // namespace RTC

--- a/src/lib/rtm/InPortDirectProvider.cpp
+++ b/src/lib/rtm/InPortDirectProvider.cpp
@@ -29,7 +29,6 @@ namespace RTC
    * @endif
    */
   InPortDirectProvider::InPortDirectProvider()
-    : m_buffer(nullptr)
   {
     // PortProfile setting
     setInterfaceType("direct");

--- a/src/lib/rtm/InPortDirectProvider.h
+++ b/src/lib/rtm/InPortDirectProvider.h
@@ -337,7 +337,7 @@ namespace RTC
     }
 
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     InPortConnector* m_connector;

--- a/src/lib/rtm/InPortPushConnector.h
+++ b/src/lib/rtm/InPortPushConnector.h
@@ -316,10 +316,10 @@ namespace RTC
 
     struct WorkerThreadCtrl
     {
-        WorkerThreadCtrl() : cond_(), completed_(false) {}
+        WorkerThreadCtrl() {}
         std::mutex mutex_;
         std::condition_variable cond_;
-        bool completed_;
+        bool completed_{false};
     };
     WorkerThreadCtrl m_writecompleted_worker;
     WorkerThreadCtrl m_readcompleted_worker;

--- a/src/lib/rtm/InPortSHMConsumer.cpp
+++ b/src/lib/rtm/InPortSHMConsumer.cpp
@@ -34,9 +34,6 @@ namespace RTC
    * @endif
    */
 	InPortSHMConsumer::InPortSHMConsumer()
-		: m_memory_size(0),
-		m_endian(true),
-		rtclog("InPortSHMConsumer")
   {
 	  coil::UUID_Generator uugen;
 	  uugen.init();

--- a/src/lib/rtm/InPortSHMConsumer.h
+++ b/src/lib/rtm/InPortSHMConsumer.h
@@ -162,9 +162,9 @@ protected:
 	std::mutex m_mutex;
 	std::string m_shm_address;
 	SharedMemoryPort m_shmem;
-	int m_memory_size;
-	bool m_endian;
-	mutable Logger rtclog;
+	int m_memory_size{0};
+	bool m_endian{true};
+	mutable Logger rtclog{"InPortSHMConsumer"};
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -29,8 +29,6 @@ namespace RTC
    * @endif
    */
   InPortSHMProvider::InPortSHMProvider()
-   : m_buffer(nullptr),
-     m_connector(nullptr)
   {
     // PortProfile setting
     setInterfaceType("shared_memory");

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -235,11 +235,11 @@ namespace RTC
     }
 
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
 	::OpenRTM::PortSharedMemory_var  m_objref;
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
-    InPortConnector* m_connector;
+    InPortConnector* m_connector{nullptr};
 
   };  // class InPortCorCdrbaProvider
 } // namespace RTC

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -341,7 +341,6 @@ namespace RTC
   
   
   LogstreamFile::LogstreamFile()
-    : m_stdout(nullptr), m_fileout(nullptr)
   {
   }
 

--- a/src/lib/rtm/LogstreamFile.h
+++ b/src/lib/rtm/LogstreamFile.h
@@ -487,8 +487,8 @@ namespace RTC
   protected:
     static coil::vstring s_files;
     std::string m_fileName;
-    FileStreamBase* m_stdout;
-    FileStream* m_fileout;
+    FileStreamBase* m_stdout{nullptr};
+    FileStream* m_fileout{nullptr};
   };
 } // namespace RTC
 

--- a/src/lib/rtm/Macho.cpp
+++ b/src/lib/rtm/Macho.cpp
@@ -188,11 +188,6 @@ _StateInstance * _StateInstance::clone(_MachineBase & newMachine) {
 ////////////////////////////////////////////////////////////////////////////////
 // Base class for Machine objects.
 _MachineBase::_MachineBase()
-	: myCurrentState(nullptr)
-	, myPendingState(nullptr)
-	, myPendingInit(nullptr)
-	, myPendingBox(nullptr)	// Deprecated!
-	, myPendingEvent(nullptr)
 {}
 
 _MachineBase::~_MachineBase() {

--- a/src/lib/rtm/Macho.h
+++ b/src/lib/rtm/Macho.h
@@ -1455,16 +1455,16 @@ namespace Macho {
 		friend class ::TestAccess;
 
 		// Current state of Machine object.
-		_StateInstance * myCurrentState;
+		_StateInstance * myCurrentState{nullptr};
 
 		// Information about pending state transition.
-		_StateInstance * myPendingState;
-		_Initializer * myPendingInit;
+		_StateInstance * myPendingState{nullptr};
+		_Initializer * myPendingInit{nullptr};
 
 		// Deprecated!
-		void * myPendingBox;
+		void * myPendingBox{nullptr};
 
-		_IEventBase * myPendingEvent;
+		_IEventBase * myPendingEvent{nullptr};
 
 		// Array of StateInstance objects.
 		_StateInstance ** myInstances;

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -98,8 +98,6 @@ namespace RTC
    * @endif
    */
   Manager::Manager()
-    : m_initProc(nullptr), m_namingManager(nullptr),
-      m_logStreamBuf(), rtclog(&m_logStreamBuf)
   {
     m_signals.emplace_back(openrtm_signal_handler, SIGINT);
   }

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -2060,7 +2060,7 @@ namespace RTC
      * @brief User's initialization function's pointer
      * @endif
      */
-    ModuleInitProc m_initProc;
+    ModuleInitProc m_initProc{nullptr};
 
     /*!
      * @if jp
@@ -2087,7 +2087,7 @@ namespace RTC
      * @brief The pointer to the NamingManager
      * @endif
      */
-    NamingManager* m_namingManager;
+    NamingManager* m_namingManager{nullptr};
 
     /*!
      * @if jp
@@ -2162,7 +2162,7 @@ namespace RTC
      * @brief Logger stream
      * @endif
      */
-    Logger rtclog;
+    Logger rtclog{&m_logStreamBuf};
 
     /*!
      * @if jp

--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -65,7 +65,6 @@ namespace RTC
    * @endif
    */
   ManagerConfig::ManagerConfig()
-    : m_isMaster(false)
   {
   }
 

--- a/src/lib/rtm/ManagerConfig.h
+++ b/src/lib/rtm/ManagerConfig.h
@@ -413,7 +413,7 @@ namespace RTC
      *
      * @endif
      */
-    bool m_isMaster;
+    bool m_isMaster{false};
   };
 } // namespace RTC
 #endif  // RTC_MANAGERCONFIG_H

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -35,11 +35,7 @@ namespace RTM
   // Example implementational code for IDL interface RTM::Manager
   //
   ManagerServant::ManagerServant()
-    : rtclog("ManagerServant"),
-      m_mgr(::RTC::Manager::instance()),
-      m_objref(RTM::Manager::_nil()),
-      m_masters(0), m_slaves(0),
-      m_isMaster(false)
+    : m_masters(0), m_slaves(0)
   {
     rtclog.setName("ManagerServant");
     coil::Properties config(m_mgr.getConfig());    

--- a/src/lib/rtm/ManagerServant.h
+++ b/src/lib/rtm/ManagerServant.h
@@ -714,7 +714,7 @@ namespace RTM
      * @brief Logger object
      * @endif
      */
-    ::RTC::Logger rtclog;
+    ::RTC::Logger rtclog{"ManagerServant"};
 
     /*!
      * @if jp
@@ -723,7 +723,7 @@ namespace RTM
      * @brief Reference to the RTC::Manager
      * @endif
      */
-    ::RTC::Manager& m_mgr;
+    ::RTC::Manager& m_mgr{::RTC::Manager::instance()};
 
     /*!
      * @if jp
@@ -732,7 +732,7 @@ namespace RTM
      * @brief An object reference of ManagerServant
      * @endif
      */
-    ::RTM::Manager_var m_objref;
+    ::RTM::Manager_var m_objref{RTM::Manager::_nil()};
 
     /*!
      * @if jp
@@ -777,7 +777,7 @@ namespace RTM
      * @brief Flag if this is master
      * @endif
      */
-    CORBA::Boolean m_isMaster;
+    CORBA::Boolean m_isMaster{false};
 
     /*!
      * @if jp

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -38,7 +38,7 @@ namespace RTC_exp
    */
   MultilayerCompositeEC::
   MultilayerCompositeEC()
-  : PeriodicExecutionContext(), m_ownersm(nullptr)
+  : PeriodicExecutionContext()
   {
     RTC_TRACE(("MultilayerCompositeEC()"));
   }

--- a/src/lib/rtm/MultilayerCompositeEC.h
+++ b/src/lib/rtm/MultilayerCompositeEC.h
@@ -171,7 +171,7 @@ namespace RTC_exp
       virtual void addRTCToTask(ChildTask* task, RTC::LightweightRTObject_ptr rtobj);
 
       std::vector<ChildTask*> m_tasklist;
-      RTC_impl::RTObjectStateMachine* m_ownersm;
+      RTC_impl::RTObjectStateMachine* m_ownersm{nullptr};
 
 
   };  // class MultilayerCompositeEC

--- a/src/lib/rtm/NumberingPolicy.h
+++ b/src/lib/rtm/NumberingPolicy.h
@@ -68,7 +68,7 @@ namespace RTM
      *
      * @endif
      */
-    ProcessUniquePolicy() : m_num(0) {}
+    ProcessUniquePolicy()  {}
     
     /*!
      * @if jp
@@ -162,7 +162,7 @@ namespace RTM
     long int find(void* obj);
     
   private:
-    int m_num;
+    int m_num{0};
     std::vector<void*> m_objects;
   };
 } // namespace RTM

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -30,8 +30,7 @@ namespace RTC
    * @endif
    */
   OpenHRPExecutionContext::OpenHRPExecutionContext()
-    :  ExecutionContextBase("exttrig_sync_ec"),
-       rtclog("exttrig_sync_ec"), m_count(0)
+    :  ExecutionContextBase("exttrig_sync_ec")
   {
     RTC_TRACE(("OpenHRPExecutionContext()"));
 

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -490,12 +490,12 @@ namespace RTC
      * @brief Logger stream
      * @endif
      */
-    RTC::Logger rtclog;
+    RTC::Logger rtclog{"exttrig_sync_ec"};
 
     /*!
      * @brief A counter for log message in worker
      */
-    unsigned int m_count;
+    unsigned int m_count{0};
 
   };  // class OpenHRPExecutionContext
 } // namespace RTC

--- a/src/lib/rtm/OutPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.cpp
@@ -29,7 +29,6 @@ namespace RTC
    * @endif
    */
   OutPortCorbaCdrProvider::OutPortCorbaCdrProvider()
-    : m_buffer(nullptr), m_connector(nullptr)
   {
     // PortProfile setting
     setInterfaceType("corba_cdr");

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -347,11 +347,11 @@ namespace RTC
     }
 
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
     ::OpenRTM::OutPortCdr_var m_objref;
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
-    OutPortConnector* m_connector;
+    OutPortConnector* m_connector{nullptr};
   };  // class OutPortCorbaCdrProvider
 } // namespace RTC
 

--- a/src/lib/rtm/OutPortDSProvider.cpp
+++ b/src/lib/rtm/OutPortDSProvider.cpp
@@ -27,7 +27,6 @@ namespace RTC
    * @endif
    */
   OutPortDSProvider::OutPortDSProvider()
-    : m_buffer(nullptr), m_connector(nullptr)
   {
     // PortProfile setting
     setInterfaceType("data_service");

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -345,11 +345,11 @@ namespace RTC
     }
 
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
     ::RTC::DataPullService_var m_objref;
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
-    OutPortConnector* m_connector;
+    OutPortConnector* m_connector{nullptr};
   };  // class OutPortDSProvider
 } // namespace RTC
 

--- a/src/lib/rtm/OutPortDirectProvider.cpp
+++ b/src/lib/rtm/OutPortDirectProvider.cpp
@@ -27,7 +27,7 @@ namespace RTC
    * @endif
    */
   OutPortDirectProvider::OutPortDirectProvider()
-   : m_buffer(nullptr) 
+    
   {
     // PortProfile setting
     setInterfaceType("direct");

--- a/src/lib/rtm/OutPortDirectProvider.h
+++ b/src/lib/rtm/OutPortDirectProvider.h
@@ -312,7 +312,7 @@ namespace RTC
     }
     
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     OutPortConnector* m_connector;

--- a/src/lib/rtm/OutPortPullConnector.h
+++ b/src/lib/rtm/OutPortPullConnector.h
@@ -288,10 +288,10 @@ namespace RTC
 
       struct WorkerThreadCtrl
       {
-          WorkerThreadCtrl() : cond_(), completed_(false) {}
+          WorkerThreadCtrl() {}
           std::mutex mutex_;
           std::condition_variable cond_;
-          bool completed_;
+          bool completed_{false};
       };
       WorkerThreadCtrl m_writecompleted_worker;
       WorkerThreadCtrl m_readcompleted_worker;

--- a/src/lib/rtm/OutPortSHMConsumer.cpp
+++ b/src/lib/rtm/OutPortSHMConsumer.cpp
@@ -30,10 +30,8 @@ namespace RTC
    * @endif
    */
   OutPortSHMConsumer::OutPortSHMConsumer()
-  : m_listeners(nullptr)
   {
     rtclog.setName("OutPortSHMConsumer");
-	
   }
     
   /*!

--- a/src/lib/rtm/OutPortSHMConsumer.h
+++ b/src/lib/rtm/OutPortSHMConsumer.h
@@ -331,7 +331,7 @@ protected:
     bool m_endian;
 
 	CdrBufferBase* m_buffer;
-	ConnectorListeners* m_listeners;
+	ConnectorListeners* m_listeners{nullptr};
 	ConnectorInfo m_profile;
   };
 } // namespace RTC

--- a/src/lib/rtm/OutPortSHMProvider.cpp
+++ b/src/lib/rtm/OutPortSHMProvider.cpp
@@ -28,9 +28,6 @@ namespace RTC
    * @endif
    */
   OutPortSHMProvider::OutPortSHMProvider()
-   : m_buffer(nullptr),
-     m_connector(nullptr),
-     m_memory_size(0)
   {
     // PortProfile setting
     setInterfaceType("shared_memory");

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -291,13 +291,13 @@ namespace RTC
     }
     
   private:
-    CdrBufferBase* m_buffer;
+    CdrBufferBase* m_buffer{nullptr};
     ::OpenRTM::PortSharedMemory_var m_objref;
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
-    OutPortConnector* m_connector;
+    OutPortConnector* m_connector{nullptr};
     std::string m_shm_address;
-    int m_memory_size;
+    int m_memory_size{0};
   };  // class OutPortCorbaCdrProvider
 } // namespace RTC
 

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -36,9 +36,7 @@ namespace RTC_exp
    */
   PeriodicExecutionContext::
   PeriodicExecutionContext()
-    : ExecutionContextBase("periodic_ec"),
-      rtclog("periodic_ec"),
-      m_svc(false), m_nowait(false)
+    : ExecutionContextBase("periodic_ec")
   {
     RTC_TRACE(("PeriodicExecutionContext()"));
 

--- a/src/lib/rtm/PeriodicExecutionContext.h
+++ b/src/lib/rtm/PeriodicExecutionContext.h
@@ -649,7 +649,7 @@ namespace RTC_exp
      * @brief Logger stream
      * @endif
      */
-    RTC::Logger rtclog;
+    RTC::Logger rtclog{"periodic_ec"};
 
     /*!
      * @if jp
@@ -658,7 +658,7 @@ namespace RTC_exp
      * @brief The thread running flag of ExecutionContext
      * @endif
      */
-    bool m_svc;
+    bool m_svc{false};
     std::mutex m_svcmutex;
 
     /*!
@@ -670,10 +670,10 @@ namespace RTC_exp
      */
     struct WorkerThreadCtrl
     {
-      WorkerThreadCtrl() : cond_(), running_(false) {}
+      WorkerThreadCtrl() {}
       std::mutex mutex_;
       std::condition_variable cond_;
-      bool running_;
+      bool running_{false};
     };
 
     /*!
@@ -693,7 +693,7 @@ namespace RTC_exp
      *        (to run without waiting)
      * @endif
      */
-    bool m_nowait;
+    bool m_nowait{false};
 
     /*!
      * @brief CPU affinity mask list

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -37,24 +37,11 @@ namespace RTC
    * @endif
    */
   PortBase::PortBase(const char* name)
-    : rtclog(name),
-      m_ownerInstanceName("unknown"),
-      m_connectionLimit(-1),
-      m_onPublishInterfaces(nullptr),
-      m_onSubscribeInterfaces(nullptr),
-      m_onConnected(nullptr),
-      m_onUnsubscribeInterfaces(nullptr),
-      m_onDisconnected(nullptr),
-      m_onConnectionLost(nullptr),
-      m_portconnListeners(nullptr),
-	  m_directport(nullptr)
+    : rtclog(name)
   {
     m_objref = this->_this();
     // Now Port name is <instance_name>.<port_name>. r1648
-    std::string portname(m_ownerInstanceName);
-    portname += ".";
-    portname += name;
-
+    std::string portname(m_ownerInstanceName + '.' + name);
     m_profile.name = CORBA::string_dup(portname.c_str());
     m_profile.interfaces.length(0);
     m_profile.port_ref = m_objref;

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -2102,7 +2102,7 @@ namespace RTC
      * @brief Instance name
      * @endif
      */
-    std::string m_ownerInstanceName;
+    std::string m_ownerInstanceName = "unknown";
 
     /*!
      * @if jp
@@ -2111,7 +2111,7 @@ namespace RTC
      * @brief The maximum number of connections
      * @endif
      */
-    int m_connectionLimit;
+    int m_connectionLimit{-1};
 
     /*!
      * @if jp
@@ -2127,7 +2127,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectionCallback* m_onPublishInterfaces;
+    ConnectionCallback* m_onPublishInterfaces{nullptr};
     /*!
      * @if jp
      * @brief Callback functor オブジェクト
@@ -2141,7 +2141,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectionCallback* m_onSubscribeInterfaces;
+    ConnectionCallback* m_onSubscribeInterfaces{nullptr};
     /*!
      * @if jp
      * @brief Callback functor オブジェクト
@@ -2156,7 +2156,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectionCallback* m_onConnected;
+    ConnectionCallback* m_onConnected{nullptr};
     /*!
      * @if jp
      * @brief Callback functor オブジェクト
@@ -2170,7 +2170,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectionCallback* m_onUnsubscribeInterfaces;
+    ConnectionCallback* m_onUnsubscribeInterfaces{nullptr};
     /*!
      * @if jp
      * @brief Callback functor オブジェクト
@@ -2184,7 +2184,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectionCallback* m_onDisconnected;
+    ConnectionCallback* m_onDisconnected{nullptr};
 
     /*!
      * @if jp
@@ -2200,7 +2200,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectionCallback* m_onConnectionLost;
+    ConnectionCallback* m_onConnectionLost{nullptr};
 
     /*!
      * @if jp
@@ -2215,9 +2215,9 @@ namespace RTC
      *
      * @endif
      */
-    PortConnectListeners* m_portconnListeners;
+    PortConnectListeners* m_portconnListeners{nullptr};
 
-	DirectPortBase *m_directport;
+	DirectPortBase *m_directport{nullptr};
 
     //============================================================
     // Functor

--- a/src/lib/rtm/PublisherFlush.cpp
+++ b/src/lib/rtm/PublisherFlush.cpp
@@ -34,9 +34,6 @@ namespace RTC
    * @endif
    */
   PublisherFlush::PublisherFlush()
-    : rtclog("PublisherFlush"),
-      m_consumer(nullptr), m_listeners(nullptr),
-      m_retcode(DataPortStatus::PORT_OK), m_active(false)
   {
   }
 

--- a/src/lib/rtm/PublisherFlush.h
+++ b/src/lib/rtm/PublisherFlush.h
@@ -422,13 +422,13 @@ namespace RTC
     }
 
   private:
-    Logger rtclog;
-    InPortConsumer* m_consumer;
+    Logger rtclog{"PublisherFlush"};
+    InPortConsumer* m_consumer{nullptr};
     ConnectorInfo m_profile;
-    ConnectorListeners* m_listeners;
-    DataPortStatus m_retcode;
+    ConnectorListeners* m_listeners{nullptr};
+    DataPortStatus m_retcode{DataPortStatus::PORT_OK};
     std::mutex m_retmutex;
-    bool m_active;
+    bool m_active{false};
   };
 
 } // namespace RTC

--- a/src/lib/rtm/PublisherNew.cpp
+++ b/src/lib/rtm/PublisherNew.cpp
@@ -41,10 +41,6 @@ namespace RTC
    * @endif
    */
   PublisherNew::PublisherNew()
-    : rtclog("PublisherNew"),
-      m_consumer(nullptr), m_buffer(nullptr), m_task(nullptr), m_listeners(nullptr),
-      m_retcode(DataPortStatus::PORT_OK), m_pushPolicy(PUBLISHER_POLICY_NEW),
-      m_skipn(0), m_active(false), m_leftskip(0)
   {
   }
 

--- a/src/lib/rtm/PublisherNew.h
+++ b/src/lib/rtm/PublisherNew.h
@@ -711,18 +711,18 @@ namespace RTC
 
 
   private:
-    Logger rtclog;
-    InPortConsumer* m_consumer;
-    CdrBufferBase* m_buffer;
+    Logger rtclog{"PublisherNew"};
+    InPortConsumer* m_consumer{nullptr};
+    CdrBufferBase* m_buffer{nullptr};
     ConnectorInfo m_profile;
-    coil::PeriodicTaskBase* m_task;
-    ConnectorListeners* m_listeners;
-    DataPortStatus m_retcode;
+    coil::PeriodicTaskBase* m_task{nullptr};
+    ConnectorListeners* m_listeners{nullptr};
+    DataPortStatus m_retcode{DataPortStatus::PORT_OK};
     std::mutex m_retmutex;
-    Policy m_pushPolicy;
-    int m_skipn;
-    bool m_active;
-    int m_leftskip;
+    Policy m_pushPolicy{PUBLISHER_POLICY_NEW};
+    int m_skipn{0};
+    bool m_active{false};
+    int m_leftskip{0};
   };
 } // namespace RTC
 

--- a/src/lib/rtm/PublisherPeriodic.cpp
+++ b/src/lib/rtm/PublisherPeriodic.cpp
@@ -38,10 +38,6 @@ namespace RTC
    * @endif
    */
   PublisherPeriodic::PublisherPeriodic()
-    : rtclog("PublisherPeriodic"),
-      m_consumer(nullptr), m_buffer(nullptr), m_task(nullptr), m_listeners(nullptr),
-      m_retcode(DataPortStatus::PORT_OK), m_pushPolicy(PUBLISHER_POLICY_NEW),
-      m_skipn(0), m_active(false), m_readback(false), m_leftskip(0)
   {
   }
 

--- a/src/lib/rtm/PublisherPeriodic.h
+++ b/src/lib/rtm/PublisherPeriodic.h
@@ -730,19 +730,19 @@ namespace RTC
       return false;
     }
 
-    Logger rtclog;
-    InPortConsumer* m_consumer;
-    CdrBufferBase* m_buffer;
+    Logger rtclog{"PublisherPeriodic"};
+    InPortConsumer* m_consumer{nullptr};
+    CdrBufferBase* m_buffer{nullptr};
     ConnectorInfo m_profile;
-    coil::PeriodicTaskBase* m_task;
-    ConnectorListeners* m_listeners;
-    DataPortStatus m_retcode;
+    coil::PeriodicTaskBase* m_task{nullptr};
+    ConnectorListeners* m_listeners{nullptr};
+    DataPortStatus m_retcode{DataPortStatus::PORT_OK};
     std::mutex m_retmutex;
-    Policy m_pushPolicy;
-    int m_skipn;
-    bool m_active;
-    bool m_readback;
-    int m_leftskip;
+    Policy m_pushPolicy{PUBLISHER_POLICY_NEW};
+    int m_skipn{0};
+    bool m_active{false};
+    bool m_readback{false};
+    int m_leftskip{0};
   };
 } // namespace RTC
 

--- a/src/lib/rtm/RingBuffer.h
+++ b/src/lib/rtm/RingBuffer.h
@@ -113,12 +113,7 @@ namespace RTC
      * @endif
      */
     explicit RingBuffer(long int length = RINGBUFFER_DEFAULT_LENGTH)
-      : m_overwrite(true), m_readback(true),
-        m_timedwrite(false), m_timedread(false),
-        m_wtimeout(std::chrono::seconds(1)), m_rtimeout(std::chrono::seconds(1)),
-        m_length(length),
-        m_wpos(0), m_rpos(0), m_fillcount(0), m_wcount(0),
-        m_buffer(m_length)
+      : m_length(length), m_buffer(m_length)
     {
       this->reset();
     }
@@ -926,7 +921,7 @@ namespace RTC
      * @brief Overwrite flag
      * @endif
      */
-    bool m_overwrite;
+    bool m_overwrite{true};
 
     /*!
      * @if jp
@@ -935,7 +930,7 @@ namespace RTC
      * @brief Readback flag
      * @endif
      */
-    bool m_readback;
+    bool m_readback{true};
 
     /*!
      * @if jp
@@ -944,7 +939,7 @@ namespace RTC
      * @brief Timedwrite flag
      * @endif
      */
-    bool m_timedwrite;
+    bool m_timedwrite{false};
     /*!
      * @if jp
      * @brief タイムアウト付き読み出しフラグ
@@ -952,7 +947,7 @@ namespace RTC
      * @brief Timedread flag
      * @endif
      */
-    bool m_timedread;
+    bool m_timedread{false};
 
     /*!
      * @if jp
@@ -961,7 +956,7 @@ namespace RTC
      * @brief Timeout time for writing
      * @endif
      */
-    std::chrono::nanoseconds m_wtimeout;
+    std::chrono::nanoseconds m_wtimeout{std::chrono::seconds(1)};
 
     /*!
      * @if jp
@@ -970,7 +965,7 @@ namespace RTC
      * @brief Timeout time of reading
      * @endif
      */
-    std::chrono::nanoseconds m_rtimeout;
+    std::chrono::nanoseconds m_rtimeout{std::chrono::seconds(1)};
 
     /*!
      * @if jp
@@ -988,7 +983,7 @@ namespace RTC
      * @brief pointer to write
      * @endif
      */
-    size_t m_wpos;
+    size_t m_wpos{0};
 
     /*!
      * @if jp
@@ -997,7 +992,7 @@ namespace RTC
      * @brief poitner to read
      * @endif
      */
-    size_t m_rpos;
+    size_t m_rpos{0};
 
     /*!
      * @if jp
@@ -1006,7 +1001,7 @@ namespace RTC
      * @brief Fill count
      * @endif
      */
-    size_t m_fillcount;
+    size_t m_fillcount{0};
 
     /*!
      * @if jp
@@ -1015,7 +1010,7 @@ namespace RTC
      * @brief Counter for writing
      * @endif
      */
-    size_t m_wcount;
+    size_t m_wcount{0};
 
     /*!
      * @if jp
@@ -1035,7 +1030,7 @@ namespace RTC
      */
     struct condition
     {
-      condition() : cond() {}
+      condition() {}
       std::condition_variable cond;
       std::mutex mutex;
     };

--- a/src/lib/rtm/SharedMemoryPort.cpp
+++ b/src/lib/rtm/SharedMemoryPort.cpp
@@ -27,9 +27,7 @@ namespace RTC
    * @brief Constructor
    * @endif
    */
-	SharedMemoryPort::SharedMemoryPort()
-   : m_smInterface(OpenRTM::PortSharedMemory::_nil()),
-     m_endian(true)
+  SharedMemoryPort::SharedMemoryPort()
   {
 
   }

--- a/src/lib/rtm/SharedMemoryPort.h
+++ b/src/lib/rtm/SharedMemoryPort.h
@@ -261,8 +261,8 @@ namespace RTC
 	virtual ::OpenRTM::PortSharedMemory_ptr getObjRef();
 
  protected:
-    ::OpenRTM::PortSharedMemory_var m_smInterface;
-    bool m_endian;
+    ::OpenRTM::PortSharedMemory_var m_smInterface{OpenRTM::PortSharedMemory::_nil()};
+    bool m_endian{true};
     coil::SharedMemory m_shmem;
 
     

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -67,10 +67,7 @@ namespace RTC
   Logger::Logger(const char* name)
     : ::coil::LogStream(&(Manager::instance().getLogStreamBuf()),
                         RTL_SILENT, RTL_PARANOID, RTL_SILENT),
-      m_name(name),
-      m_dateFormat("%b %d %H:%M:%S.%Q"),
-      m_clock(&coil::ClockManager::instance().getClock("system")),
-      m_msEnable(0), m_usEnable(0)
+      m_name(name)
   {
     setLevel(Manager::instance().getLogLevel().c_str());
     coil::Properties& prop(Manager::instance().getConfig());
@@ -82,16 +79,11 @@ namespace RTC
       {
         setClockType(prop["logger.clock_type"]);
       }
-	
   }
 
   Logger::Logger(LogStreamBuf* streambuf)
     : ::coil::LogStream(streambuf,
-                        RTL_SILENT, RTL_PARANOID,  RTL_SILENT),
-      m_name("unknown"),
-      m_dateFormat("%b %d %H:%M:%S.%Q"),
-      m_clock(&coil::ClockManager::instance().getClock("system")),
-      m_msEnable(0), m_usEnable(0)
+                        RTL_SILENT, RTL_PARANOID,  RTL_SILENT)
   {
     setDateFormat(m_dateFormat.c_str());
   }

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -494,14 +494,14 @@ namespace RTC
 
 
   private:
-    std::string m_name;
-    std::string m_dateFormat;
-    coil::IClock* m_clock;
+    std::string m_name = "unknown";
+    std::string m_dateFormat = "%b %d %H:%M:%S.%Q";
+    coil::IClock* m_clock{&coil::ClockManager::instance().getClock("system")};
     static const char* const m_levelString[];
     static const char* const m_levelOutputString[];
     static const char* const m_levelColor[];
-    int m_msEnable;
-    int m_usEnable;
+    int m_msEnable{0};
+    int m_usEnable{0};
   };
 
 


### PR DESCRIPTION
## Description of the Change

C++11 に従い、クラス内の変数宣言で初期化を実施する。利点は、
- 変数宣言とセットになることで初期化ミスが減る
- 複数のコンストラクタが存在する場合も共通のデフォルト初期値として書ける
  コンストラクタでも初期化した場合は、そちら優先でデフォルト初期値は無視される
- コンストラクタによる初期化でよくある「書いた順ではなく宣言順に初期化される」罠にはまりにくい

Visual Studio 2013 の C++11 が壊れているため、`std::string` を `{"hoge"}` 記法で初期化すると
C2797 のエラーが発生する。よって、`std::string` は `＝ "hoge"` の記法に変更した。
参考：
https://devblogs.microsoft.com/cppblog/the-future-of-non-static-data-member-initialization/

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
