### PR TITLE
Svn/releng 1 2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1108,11 +1108,11 @@ if test "x$have_omniorb" = "xyes" ; then
 
         dnl Library with / without SSL
         if test "x$with_omnissl" = "xno" ; then
-                AM_DEFINE([ENABLE_OMNISSL], [TRUE], [omniSSL is used])
+                AC_DEFINE([ENABLE_OMNISSL], [TRUE], [omniSSL is used])
                 LIBS="$LIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
                 LDSOLIBS="$LDSOLIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
         else
-                AM_DEFINE([ENABLE_OMNISSL], [FALSE], [omniSSL is NOT used])
+                AC_DEFINE([ENABLE_OMNISSL], [FALSE], [omniSSL is NOT used])
                 LIBS="$LIBS -lomniORB4 -lomnithread -lomniDynamic4"
                 LDSOLIBS="$LDSOLIBS -lomniORB4 -lomnithread -lomniDynamic4"
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -1516,16 +1516,16 @@ dnl ------------------------------------------------------------
 dnl ext/Makefile settings....
 dnl
 dnl ------------------------------------------------------------
-EXT_TARGET="local_service ec sdo"
+EXT_TARGET="local_service ec"
 dnl ------------------------------------------------------------
 dnl ext/observer
 dnl
 dnl ------------------------------------------------------------
 if test "x$enable_observer" = "xyes" ; then
-        AC_DEFINE([BUILD_EXTOBSERVER], [TRUE], [Build ext/observer])
-        EXT_TARGET="$EXT_TARGET observer"
+        AC_DEFINE([BUILD_EXTOBSERVER], [TRUE], [Build ext/sdo])
+        EXT_TARGET="$EXT_TARGET sdo"
 else
-        AC_DEFINE([BUILD_EXTOBSERVER], [FALSE], [Build ext/observer])
+        AC_DEFINE([BUILD_EXTOBSERVER], [FALSE], [Build ext/sdo])
 fi
 
 dnl ------------------------------------------------------------
@@ -1608,6 +1608,9 @@ AC_SUBST(UNITTEST)
 
 dnl RT preempt EC
 AC_SUBST(RTPREEMPTEC)
+
+dnl src/ext targets
+AC_SUBST(EXT_TARGET)
 
 dnl OpenRTM's includedir/libdir/datadir definition
 rtm_includedir=$includedir"/openrtm-"$major_version"."$minor_version

--- a/configure.ac
+++ b/configure.ac
@@ -1512,6 +1512,46 @@ if test "x$enable_test" = "xyes" ; then
 fi
 
 
+dnl ------------------------------------------------------------
+dnl ext/Makefile settings....
+dnl
+dnl ------------------------------------------------------------
+EXT_TARGET="local_service ec sdo"
+dnl ------------------------------------------------------------
+dnl ext/observer
+dnl
+dnl ------------------------------------------------------------
+if test "x$enable_observer" = "xyes" ; then
+        AC_DEFINE([BUILD_EXTOBSERVER], [TRUE], [Build ext/observer])
+        EXT_TARGET="$EXT_TARGET observer"
+else
+        AC_DEFINE([BUILD_EXTOBSERVER], [FALSE], [Build ext/observer])
+fi
+
+dnl ------------------------------------------------------------
+dnl ext/fluentd
+dnl
+dnl ------------------------------------------------------------
+if test "x$enable_fluentd" = "xyes" ; then
+        AC_DEFINE([BUILD_EXTFLUENTD], [TRUE], [Build ext/fluentd])
+        EXT_TARGET="$EXT_TARGET fluentd"
+else
+        AC_DEFINE([BUILD_EXTFLUENTD], [FALSE], [Build ext/fluentd])
+fi
+dnl ------------------------------------------------------------
+dnl ext/ssl 
+dnl
+dnl ------------------------------------------------------------
+if test "x$orb_to_use" = "xomniORB" ; then
+        if test "x$with_omnissl" = "xno" ; then
+                if test "x$enable_ssl" = "xyes" ; then
+                        AC_DEFINE([BUILD_EXTSSL], [TRUE], [Build ext/ssl])
+                        EXT_TARGET="$EXT_TARGET ssl"
+                else
+                        AC_DEFINE([BUILD_EXTSSL], [FALSE], [Build ext/ssl])
+                fi
+        fi
+fi
 
 dnl ------------------------------------------------------------
 dnl exported environmental variables

--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,7 @@ AC_ARG_WITH(rtorb,            [  --with-rtorb=dir                Find RtORB inst
 AC_ARG_WITH(generic-orb,      [  --with-generic-orb              Use other CORBA 2.3 ORB])
 AC_ARG_WITH(generic-orb-lib,  [  --with-generic-orb-lib	=libs    ORB libraries (-l...)])
 AC_ARG_WITH(doxygen,          [  --without-doxygen               Don't create documentation by doxygen])
+AC_ARG_WITH(omnissl,          [  --without-omnissl               Don't use OmniSSL library])
 
 dnl  Script wrapper selection
 #AC_ARG_WITH(python,           [  --with-python=dir               Find Python installation below dir])
@@ -1104,8 +1105,18 @@ if test "x$have_omniorb" = "xyes" ; then
 	CPPFLAGS="-I$omniORB4_CORBA_h_dir $CPPFLAGS"
 	CXXFLAGS="-I$omniORB4_CORBA_h_dir $CXXFLAGS"
 	LDFLAGS="-L$omniorb_lib_dir $LDFLAGS"
-	LIBS="$LIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
-	LDSOLIBS="$LDSOLIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
+
+        dnl Library with / without SSL
+        if test "x$with_omnissl" = "xno" ; then
+                AM_DEFINE([ENABLE_OMNISSL], [TRUE], [omniSSL is used])
+                LIBS="$LIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
+                LDSOLIBS="$LDSOLIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
+        else
+                AM_DEFINE([ENABLE_OMNISSL], [FALSE], [omniSSL is NOT used])
+                LIBS="$LIBS -lomniORB4 -lomnithread -lomniDynamic4"
+                LDSOLIBS="$LDSOLIBS -lomniORB4 -lomnithread -lomniDynamic4"
+        fi
+
 	AC_DEFINE([ORB_IS_OMNIORB], [TRUE], [ORB is omniORB])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1533,8 +1533,10 @@ dnl ext/fluentd
 dnl
 dnl ------------------------------------------------------------
 if test "x$enable_fluentd" = "xyes" ; then
-        AC_DEFINE([BUILD_EXTFLUENTD], [TRUE], [Build ext/fluentd])
-        EXT_TARGET="$EXT_TARGET fluentd"
+        if test "$os" = "linux" ; then
+                AC_DEFINE([BUILD_EXTFLUENTD], [TRUE], [Build ext/fluentd])
+                EXT_TARGET="$EXT_TARGET fluentd"
+        fi
 else
         AC_DEFINE([BUILD_EXTFLUENTD], [FALSE], [Build ext/fluentd])
 fi

--- a/src/ext/Makefile.am
+++ b/src/ext/Makefile.am
@@ -7,12 +7,9 @@
 
 AUTOMAKE_OPTIONS = 1.4
 
-if ENABLE_OMNISSL
-SUBDIRS = local_service ec sdo ssl
+#SUBDIRS = local_service ec sdo
+SUBDIRS = @EXT_TARGET@
 DIST_SUBDIRS = local_service ec sdo logger ssl
-else
-SUBDIRS = local_service ec sdo
-DIST_SUBDIRS = local_service ec sdo logger
-endif
+
 
 

--- a/src/ext/Makefile.am
+++ b/src/ext/Makefile.am
@@ -7,6 +7,12 @@
 
 AUTOMAKE_OPTIONS = 1.4
 
+if ENABLE_OMNISSL
 SUBDIRS = local_service ec sdo ssl
 DIST_SUBDIRS = local_service ec sdo logger ssl
+else
+SUBDIRS = local_service ec sdo
+DIST_SUBDIRS = local_service ec sdo logger
+endif
+
 

--- a/src/lib/coil/posix/coil/Affinity.cpp
+++ b/src/lib/coil/posix/coil/Affinity.cpp
@@ -28,7 +28,7 @@ namespace coil
 {
   bool getProcCpuAffinity(CpuMask& cpu_mask)
   {
-#ifndef COIL_OS_QNX
+#if !(defined(COIL_OS_QNX) || defined(COIL_OS_DARWIN))
     pid_t pid(getpid());
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);
@@ -49,7 +49,7 @@ namespace coil
 
   bool setProcCpuAffinity(std::vector<unsigned int> mask)
   {
-#ifndef COIL_OS_QNX
+#if !(defined(COIL_OS_QNX) || defined(COIL_OS_DARWIN))
     pid_t pid(getpid());
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);
@@ -67,7 +67,7 @@ namespace coil
 
   bool setProcCpuAffinity(std::string cpu_mask)
   {
-#ifndef COIL_OS_QNX
+#if !(defined(COIL_OS_QNX) || defined(COIL_OS_DARWIN))
     coil::vstring tmp = coil::split(cpu_mask, ",", true);
     CpuMask mask;
     for (size_t i(0); i < tmp.size(); ++i)
@@ -87,7 +87,7 @@ namespace coil
 
   bool getThreadCpuAffinity(CpuMask& cpu_mask)
   {
-#ifndef COIL_OS_QNX
+#if !(defined(COIL_OS_QNX) || defined(COIL_OS_DARWIN))
     pthread_t tid(pthread_self());
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);
@@ -108,7 +108,7 @@ namespace coil
 
   bool setThreadCpuAffinity(std::vector<unsigned int> mask)
   {
-#ifndef COIL_OS_QNX
+#if !(defined(COIL_OS_QNX) || defined(COIL_OS_DARWIN))
     pthread_t tid(pthread_self());
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);
@@ -126,7 +126,7 @@ namespace coil
 
   bool setThreadCpuAffinity(std::string cpu_mask)
   {
-#ifndef COIL_OS_QNX
+#if !(defined(COIL_OS_QNX) || defined(COIL_OS_DARWIN))
     coil::vstring tmp = coil::split(cpu_mask, ",", true);
     CpuMask mask;
     for (size_t i(0); i < tmp.size(); ++i)


### PR DESCRIPTION
OSX mojaveでビルドできるように直しています．

1. Affinityを無視
2. configure.acを変更

1. Affinityを無視

これはQNXと同様の変更を施しました．
osxでビルドする時はifdefを使ってクラスの中身を空っぽにしました．

2. configure.acを変更

homebrewでインストールされるomniorb4.2.3にはomnisslが含まれていないようです．
そのため，omnisslなしでビルドできるように変更しました．

--without-omnisslオプションで，omnisslを除去してビルドが可能です．

また，src/ext以下のビルドをオプションにしました．

--enable-observer:
--enable-fluentd
--enable-ssl

オプションが加わりました．
