### PR TITLE
共有メモリ通信で2MB以上のサイズのデータを送信すると異常終了するバグの修正

### DIFF
--- a/src/lib/coil/win32/coil/SharedMemory.cpp
+++ b/src/lib/coil/win32/coil/SharedMemory.cpp
@@ -111,10 +111,10 @@ namespace coil
   {
     m_shm_address = shm_address;
     m_memory_size = memory_size;
-    LONG highsize = static_cast<LONG>(m_memory_size >> 32) & 0xFFFFFFFF;
+    LONG highsize = static_cast<LONG>((m_memory_size >> 32) & 0xFFFFFFFF);
     LONG lowsize = static_cast<LONG>(m_memory_size & 0xFFFFFFFF);
     m_handle = CreateFileMapping(
-        (HANDLE)INVALID_HANDLE_VALUE,
+        static_cast<HANDLE>(INVALID_HANDLE_VALUE),
 		nullptr,
 		PAGE_READWRITE | SEC_COMMIT,
         static_cast<DWORD>(highsize),
@@ -260,11 +260,8 @@ namespace coil
     	{
     		return -1;
     	}
-	    else
-	    {
-            m_handle = nullptr;
-		    return 0;
-	    }
+        m_handle = nullptr;
+        return 0;
     }
     return 0;
 

--- a/src/lib/coil/win32/coil/SharedMemory.cpp
+++ b/src/lib/coil/win32/coil/SharedMemory.cpp
@@ -111,14 +111,14 @@ namespace coil
   {
     m_shm_address = shm_address;
     m_memory_size = memory_size;
-    LONG highsize = static_cast<LONG>((m_memory_size >> 32) & 0xFFFFFFFF);
-    LONG lowsize = static_cast<LONG>(m_memory_size & 0xFFFFFFFF);
+    DWORD highsize = static_cast<DWORD>((m_memory_size >> 32) & 0xFFFFFFFF);
+    DWORD lowsize = static_cast<DWORD>(m_memory_size & 0xFFFFFFFF);
     m_handle = CreateFileMapping(
         static_cast<HANDLE>(INVALID_HANDLE_VALUE),
 		nullptr,
 		PAGE_READWRITE | SEC_COMMIT,
-        static_cast<DWORD>(highsize),
-        static_cast<DWORD>(lowsize),
+        highsize,
+        lowsize,
 		shm_address.c_str());
 
     m_shm = static_cast<char *>(MapViewOfFile(m_handle, FILE_MAP_ALL_ACCESS, 0, 0, 0));

--- a/src/lib/coil/win32/coil/SharedMemory.h
+++ b/src/lib/coil/win32/coil/SharedMemory.h
@@ -358,7 +358,6 @@ namespace coil
     std::string m_shm_address;
     char *m_shm;
     HANDLE m_handle;
-    bool m_file_create;
   };  // class SharedMemory
 
 } // namespace coil

--- a/src/lib/rtm/SharedMemoryPort.cpp
+++ b/src/lib/rtm/SharedMemoryPort.cpp
@@ -153,7 +153,6 @@ namespace RTC
   {
 	  if (!m_shmem.created())
 	  {
-		  
 		  m_shmem.create(shm_address, memory_size);
 		  try
 		  {
@@ -181,7 +180,7 @@ namespace RTC
   *
   * @endif
   */
-	void SharedMemoryPort::open_memory(::CORBA::ULongLong memory_size, const char * shm_address)
+	void SharedMemoryPort::open_memory(::CORBA::ULongLong memory_size, const char *shm_address)
   {
 	  
 	  m_shmem.open(shm_address, memory_size);
@@ -203,7 +202,7 @@ namespace RTC
   */
 	void SharedMemoryPort::close_memory(::CORBA::Boolean unlink)
   {
-	  if (!m_shmem.created())
+	  if (m_shmem.created())
 	  {
 		  m_shmem.close();
 		  if (unlink)
@@ -241,7 +240,7 @@ namespace RTC
       CORBA::ULongLong data_size = static_cast<CORBA::ULongLong>(data.getDataLength());
 	  if (data_size + sizeof(CORBA::ULongLong) > m_shmem.get_size())
 	  {
-		  int memory_size = static_cast<int>(data_size) + static_cast<int>(sizeof(CORBA::ULongLong));
+          CORBA::ULongLong memory_size = data_size + static_cast<CORBA::ULongLong>(sizeof(CORBA::ULongLong));
 		  if (!CORBA::is_nil(m_smInterface))
 		  {
 			  try
@@ -258,7 +257,10 @@ namespace RTC
       CORBA_CdrMemoryStream data_size_cdr;
 
       data_size_cdr.setEndian(m_endian);
-      data_size_cdr.serializeCDR(data_size);
+      if (!data_size_cdr.serializeCDR(data_size))
+      {
+          return;
+      }
       int ret = m_shmem.write((char*)data_size_cdr.getBuffer(), 0, sizeof(CORBA::ULongLong));
 
 	  if (ret == 0)

--- a/src/lib/rtm/SharedMemoryPort.h
+++ b/src/lib/rtm/SharedMemoryPort.h
@@ -264,7 +264,6 @@ namespace RTC
     ::OpenRTM::PortSharedMemory_var m_smInterface;
     bool m_endian;
     coil::SharedMemory m_shmem;
-
     
   };  // class SharedMemoryPort
 } // namespace RTC


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

データポートの共有メモリ通信で2MB以上のデータを送信するとプロセスが異常終了する。

## Description of the Change

InPort側でOpenFileMapping関数により開いたファイルマッピングオブジェクトを閉じていないことが原因だったため修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
