### PR TITLE
Use equals default.

### DIFF
--- a/examples/Analyzer/Analyzer.cpp
+++ b/examples/Analyzer/Analyzer.cpp
@@ -60,10 +60,7 @@ DataListener::DataListener(Analyzer *comp) : m_comp(comp)
 
 }
 
-DataListener::~DataListener()
-{
-
-}
+DataListener::~DataListener() = default;
 
 
 
@@ -86,9 +83,7 @@ Analyzer::Analyzer(RTC::Manager* manager)
 /*!
  * @brief destructor
  */
-Analyzer::~Analyzer()
-{
-}
+Analyzer::~Analyzer() = default;
 
 
 

--- a/examples/Analyzer/Analyzer_test.cpp
+++ b/examples/Analyzer/Analyzer_test.cpp
@@ -58,9 +58,7 @@ Analyzer_test::Analyzer_test(RTC::Manager* manager)
 /*!
  * @brief destructor
  */
-Analyzer_test::~Analyzer_test()
-{
-}
+Analyzer_test::~Analyzer_test() = default;
 
 
 

--- a/examples/Composite/Controller.cpp
+++ b/examples/Composite/Controller.cpp
@@ -35,9 +35,7 @@ Controller::Controller(RTC::Manager* manager)
 {
 }
 
-Controller::~Controller()
-{
-}
+Controller::~Controller() = default;
 
 
 RTC::ReturnCode_t Controller::onInitialize()

--- a/examples/Composite/Motor.cpp
+++ b/examples/Composite/Motor.cpp
@@ -38,9 +38,7 @@ Motor::Motor(RTC::Manager* manager)
 {
 }
 
-Motor::~Motor()
-{
-}
+Motor::~Motor() = default;
 
 
 RTC::ReturnCode_t Motor::onInitialize()

--- a/examples/Composite/Sensor.cpp
+++ b/examples/Composite/Sensor.cpp
@@ -36,9 +36,7 @@ Sensor::Sensor(RTC::Manager* manager)
 {
 }
 
-Sensor::~Sensor()
-{
-}
+Sensor::~Sensor() = default;
 
 
 RTC::ReturnCode_t Sensor::onInitialize()

--- a/examples/ConfigSample/ConfigSample.cpp
+++ b/examples/ConfigSample/ConfigSample.cpp
@@ -54,9 +54,7 @@ ConfigSample::ConfigSample(RTC::Manager* manager)
 {
 }
 
-ConfigSample::~ConfigSample()
-{
-}
+ConfigSample::~ConfigSample() = default;
 
 
 RTC::ReturnCode_t ConfigSample::onInitialize()

--- a/examples/ExtTrigger/ConsoleIn.cpp
+++ b/examples/ExtTrigger/ConsoleIn.cpp
@@ -36,9 +36,7 @@ ConsoleIn::ConsoleIn(RTC::Manager* manager)
 {
 }
 
-ConsoleIn::~ConsoleIn()
-{
-}
+ConsoleIn::~ConsoleIn() = default;
 
 
 RTC::ReturnCode_t ConsoleIn::onInitialize()

--- a/examples/ExtTrigger/ConsoleOut.cpp
+++ b/examples/ExtTrigger/ConsoleOut.cpp
@@ -36,9 +36,7 @@ ConsoleOut::ConsoleOut(RTC::Manager* manager)
 {
 }
 
-ConsoleOut::~ConsoleOut()
-{
-}
+ConsoleOut::~ConsoleOut() = default;
 
 
 RTC::ReturnCode_t ConsoleOut::onInitialize()

--- a/examples/SeqIO/SeqIn.cpp
+++ b/examples/SeqIO/SeqIn.cpp
@@ -49,9 +49,7 @@ SeqIn::SeqIn(RTC::Manager* manager)
 {
 }
 
-SeqIn::~SeqIn()
-{
-}
+SeqIn::~SeqIn() = default;
 
 
 

--- a/examples/SeqIO/SeqOut.cpp
+++ b/examples/SeqIO/SeqOut.cpp
@@ -52,9 +52,7 @@ SeqOut::SeqOut(RTC::Manager* manager)
 {
 }
 
-SeqOut::~SeqOut()
-{
-}
+SeqOut::~SeqOut() = default;
 
 
 

--- a/examples/Serializer/ConsoleInShort.cpp
+++ b/examples/Serializer/ConsoleInShort.cpp
@@ -50,9 +50,7 @@ ConsoleInShort::ConsoleInShort(RTC::Manager* manager)
 
 }
 
-ConsoleInShort::~ConsoleInShort()
-{
-}
+ConsoleInShort::~ConsoleInShort() = default;
 
 
 RTC::ReturnCode_t ConsoleInShort::onInitialize()

--- a/examples/Serializer/ConsoleOutDouble.cpp
+++ b/examples/Serializer/ConsoleOutDouble.cpp
@@ -50,9 +50,7 @@ ConsoleOutDouble::ConsoleOutDouble(RTC::Manager* manager)
 
 }
 
-ConsoleOutDouble::~ConsoleOutDouble()
-{
-}
+ConsoleOutDouble::~ConsoleOutDouble() = default;
 
 
 RTC::ReturnCode_t ConsoleOutDouble::onInitialize()

--- a/examples/Serializer/ShortToDoubleSerializer.cpp
+++ b/examples/Serializer/ShortToDoubleSerializer.cpp
@@ -18,7 +18,7 @@
 class ShortToDoubleSerializer : public RTC::CORBA_CdrSerializer<RTC::TimedDouble>
 {
 public:
-    ShortToDoubleSerializer(){}
+    ShortToDoubleSerializer() = default;
 
     bool deserialize(RTC::TimedDouble& data) override
     {

--- a/examples/SimpleIO/ConsoleIn.cpp
+++ b/examples/SimpleIO/ConsoleIn.cpp
@@ -50,9 +50,7 @@ ConsoleIn::ConsoleIn(RTC::Manager* manager)
 
 }
 
-ConsoleIn::~ConsoleIn()
-{
-}
+ConsoleIn::~ConsoleIn() = default;
 
 
 RTC::ReturnCode_t ConsoleIn::onInitialize()

--- a/examples/SimpleIO/ConsoleOut.cpp
+++ b/examples/SimpleIO/ConsoleOut.cpp
@@ -50,9 +50,7 @@ ConsoleOut::ConsoleOut(RTC::Manager* manager)
 
 }
 
-ConsoleOut::~ConsoleOut()
-{
-}
+ConsoleOut::~ConsoleOut() = default;
 
 
 RTC::ReturnCode_t ConsoleOut::onInitialize()

--- a/examples/SimpleService/MyServiceConsumer.cpp
+++ b/examples/SimpleService/MyServiceConsumer.cpp
@@ -41,9 +41,7 @@ MyServiceConsumer::MyServiceConsumer(RTC::Manager* manager)
 {
 }
 
-MyServiceConsumer::~MyServiceConsumer()
-{
-}
+MyServiceConsumer::~MyServiceConsumer() = default;
 
 
 RTC::ReturnCode_t MyServiceConsumer::onInitialize()

--- a/examples/SimpleService/MyServiceProvider.cpp
+++ b/examples/SimpleService/MyServiceProvider.cpp
@@ -35,9 +35,7 @@ MyServiceProvider::MyServiceProvider(RTC::Manager* manager)
 {
 }
 
-MyServiceProvider::~MyServiceProvider()
-{
-}
+MyServiceProvider::~MyServiceProvider() = default;
 
 
 RTC::ReturnCode_t MyServiceProvider::onInitialize()

--- a/examples/StaticFsm/Display.cpp
+++ b/examples/StaticFsm/Display.cpp
@@ -50,9 +50,7 @@ Display::Display(RTC::Manager* manager)
 
 }
 
-Display::~Display()
-{
-}
+Display::~Display() = default;
 
 
 RTC::ReturnCode_t Display::onInitialize()

--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -55,9 +55,7 @@ Inputbutton::Inputbutton(RTC::Manager* manager)
 
 }
 
-Inputbutton::~Inputbutton()
-{
-}
+Inputbutton::~Inputbutton() = default;
 
 
 RTC::ReturnCode_t Inputbutton::onInitialize()

--- a/examples/StaticFsm/Microwave.cpp
+++ b/examples/StaticFsm/Microwave.cpp
@@ -53,9 +53,7 @@ Microwave::Microwave(RTC::Manager* manager)
 
 }
 
-Microwave::~Microwave()
-{
-}
+Microwave::~Microwave() = default;
 
 
 RTC::ReturnCode_t Microwave::onInitialize()

--- a/examples/Throughput/Throughput.cpp
+++ b/examples/Throughput/Throughput.cpp
@@ -100,9 +100,7 @@ Throughput::Throughput(RTC::Manager* manager)
 /*!
  * @brief destructor
  */
-Throughput::~Throughput()
-{
-}
+Throughput::~Throughput() = default;
 
 
 

--- a/examples/Throughput/Throughput.h
+++ b/examples/Throughput/Throughput.h
@@ -434,7 +434,7 @@ class DataListener
   USE_CONNLISTENER_STATUS;
 public:
   DataListener(Throughput *comp) : m_comp(comp)  {}
-  ~DataListener() override {}
+  ~DataListener() override = default;
   ReturnCode operator()(ConnectorInfo&  /*info*/,
                           DataType& data) override
   {
@@ -450,7 +450,7 @@ class ConnListener
   USE_CONNLISTENER_STATUS;
 public:
   ConnListener(Throughput *comp) : m_comp(comp) {}
-  ~ConnListener() override {}
+  ~ConnListener() override = default;
   ReturnCode operator()(ConnectorInfo& info) override
   {
 // Connector Listener: ON_CONNECT

--- a/src/ext/local_service/nameservice_file/FileNameservice.cpp
+++ b/src/ext/local_service/nameservice_file/FileNameservice.cpp
@@ -368,9 +368,7 @@ namespace RTM
      * @brief Destructor
      * @endif
      */
-    NamingAction::~NamingAction()
-    {
-    }
+    NamingAction::~NamingAction() = default;
     
     /*!
      * @if jp

--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -169,13 +169,9 @@ namespace RTC
 
   //============================================================
   // FluentBit class
-  FluentBit::FluentBit()
-  {
-  }
+  FluentBit::FluentBit() = default;
 
-  FluentBit::~FluentBit()
-  {
-  }
+  FluentBit::~FluentBit() = default;
 
   bool FluentBit::init(const coil::Properties& prop)
   {

--- a/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.cpp
+++ b/src/ext/sdo/extended_fsm/ExtendedFsmServiceProvider.cpp
@@ -77,9 +77,7 @@ namespace RTC
    * @brief dtor
    * @endif
    */
-  ExtendedFsmServiceProvider::~ExtendedFsmServiceProvider()
-  {
-  }
+  ExtendedFsmServiceProvider::~ExtendedFsmServiceProvider() = default;
 
   /*!
    * @if jp

--- a/src/ext/sdo/logger/LoggerConsumer.cpp
+++ b/src/ext/sdo/logger/LoggerConsumer.cpp
@@ -43,9 +43,7 @@ namespace RTC
    * @brief dtor
    * @endif
    */
-  LoggerConsumer::~LoggerConsumer()
-  {
-  }
+  LoggerConsumer::~LoggerConsumer() = default;
 
   /*!
    * @if jp

--- a/src/ext/sdo/observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.h
@@ -419,7 +419,7 @@ namespace RTC
           m_last(std::chrono::steady_clock::now())
       {
       }
-      ~DataPortAction() override {}
+      ~DataPortAction() override = default;
 
       ReturnCode operator()(ConnectorInfo&  /*info*/,
                             ByteData&  /*data*/, const std::string& /*marsharingtype*/) override

--- a/src/lib/coil/common/coil/Async.h
+++ b/src/lib/coil/common/coil/Async.h
@@ -58,7 +58,7 @@ namespace coil
      *
      * @endif
      */
-    Async() {}
+    Async() = default;
 
     /*!
      * @if jp
@@ -75,7 +75,7 @@ namespace coil
      *
      * @endif
      */
-    ~Async() override {}
+    ~Async() override = default;
 
     /*!
      * @if jp
@@ -177,9 +177,7 @@ namespace coil
      *
      * @endif
      */
-    ~Async_t() override
-    {
-    }
+    ~Async_t() override = default;
 
     /*!
      * @if jp
@@ -345,9 +343,7 @@ namespace coil
      *
      * @endif
      */
-    ~Async_ref_t() override
-    {
-    }
+    ~Async_ref_t() override = default;
 
     /*!
      * @if jp

--- a/src/lib/coil/common/coil/ClockManager.cpp
+++ b/src/lib/coil/common/coil/ClockManager.cpp
@@ -26,9 +26,7 @@ namespace coil
   //============================================================
   // System Clock
   //============================================================
-  SystemClock::~SystemClock()
-  {
-  }
+  SystemClock::~SystemClock() = default;
   std::chrono::nanoseconds SystemClock::gettime() const
   {
     return std::chrono::system_clock::now().time_since_epoch();
@@ -44,13 +42,9 @@ namespace coil
   //============================================================
   // Logical Time Clock
   //============================================================
-  LogicalClock::LogicalClock()
-  {
-  }
+  LogicalClock::LogicalClock() = default;
 
-  LogicalClock::~LogicalClock()
-  {
-  }
+  LogicalClock::~LogicalClock() = default;
 
   std::chrono::nanoseconds LogicalClock::gettime() const
   {
@@ -70,13 +64,9 @@ namespace coil
   //============================================================
   // Adjusted Clock
   //============================================================
-  AdjustedClock::AdjustedClock()
-  {
-  }
+  AdjustedClock::AdjustedClock() = default;
 
-  AdjustedClock::~AdjustedClock()
-  {
-  }
+  AdjustedClock::~AdjustedClock() = default;
 
   std::chrono::nanoseconds AdjustedClock::gettime() const
   {

--- a/src/lib/coil/common/coil/ClockManager.h
+++ b/src/lib/coil/common/coil/ClockManager.h
@@ -51,7 +51,7 @@ namespace coil
   class IClock
   {
   public:
-    virtual ~IClock() {}
+    virtual ~IClock() = default;
     /*!
      * @if jp
      * @brief 時刻を取得する

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -546,9 +546,7 @@ namespace coil
     class FactoryEntry
     {
     public:
-      FactoryEntry()
-      {
-      }
+      FactoryEntry() = default;
 
       /*!
        * @if jp
@@ -631,7 +629,7 @@ namespace coil
      *
      * @endif
      */
-    GlobalFactory() {}
+    GlobalFactory() = default;
 
     /*!
      * @if jp
@@ -648,7 +646,7 @@ namespace coil
      *
      * @endif
      */
-    ~GlobalFactory() {}
+    ~GlobalFactory() = default;
 
     friend class Singleton<GlobalFactory>;
   };

--- a/src/lib/coil/common/coil/Logger.cpp
+++ b/src/lib/coil/common/coil/Logger.cpp
@@ -31,10 +31,7 @@ namespace coil
    * @brief Constructor
    * @endif
    */
-    LogStreamBuffer::LogStreamBuffer()
-    {
-    
-    }
+    LogStreamBuffer::LogStreamBuffer() = default;
     /*!
      * @if jp
      *
@@ -50,10 +47,7 @@ namespace coil
      *
      * @endif
      */
-    LogStreamBuffer::~LogStreamBuffer()
-    {
-
-    }
+    LogStreamBuffer::~LogStreamBuffer() = default;
 
     /*!
      * @if jp
@@ -260,11 +254,7 @@ namespace coil
      *
      * @endif
      */
-    LogStreamBuffer& LogStreamBuffer::operator=(const LogStreamBuffer& x)
-    {
-          this->m_streams = x.m_streams;
-          return *this;
-    }
+    LogStreamBuffer& LogStreamBuffer::operator=(const LogStreamBuffer& x) = default;
 
 
 
@@ -464,13 +454,6 @@ namespace coil
      *
      * @endif
      */
-    LogStream& LogStream::operator=(const LogStream& x)
-    {
-        this->m_minLevel = x.m_minLevel;
-        this->m_maxLevel = x.m_maxLevel;
-        this->m_logLevel = x.m_logLevel;
-        this->ostream_type = x.ostream_type;
-        return *this;
-    }
+    LogStream& LogStream::operator=(const LogStream& x) = default;
 
 } // namespace coil

--- a/src/lib/coil/common/coil/Logger.h
+++ b/src/lib/coil/common/coil/Logger.h
@@ -223,9 +223,7 @@ namespace coil
           {
           }
 
-          virtual ~Stream()
-          {
-          }
+          virtual ~Stream() = default;
 
           Stream(const Stream& x)
               : stream_(x.stream_), cleanup_(false)
@@ -542,7 +540,7 @@ namespace coil
        *
        * @endif
        */
-      virtual ~LogStream() {}
+      virtual ~LogStream() = default;
       LogStreamBuffer* ostream_type;
 
   private:

--- a/src/lib/coil/common/coil/PeriodicTaskBase.h
+++ b/src/lib/coil/common/coil/PeriodicTaskBase.h
@@ -58,7 +58,7 @@ namespace coil
      *
      * @endif
      */
-    ~PeriodicTaskBase() override {}
+    ~PeriodicTaskBase() override = default;
 
     /*!
      * @if jp

--- a/src/lib/coil/common/coil/Singleton.h
+++ b/src/lib/coil/common/coil/Singleton.h
@@ -158,7 +158,7 @@ namespace coil
      *
      * @endif
      */
-    Singleton() {}
+    Singleton() = default;
 
     /*!
      * @if jp
@@ -175,7 +175,7 @@ namespace coil
      *
      * @endif
      */
-    ~Singleton() {}
+    ~Singleton() = default;
 
   private:
     Singleton(const Singleton& x) = delete;

--- a/src/lib/coil/common/coil/Task.cpp
+++ b/src/lib/coil/common/coil/Task.cpp
@@ -28,9 +28,7 @@ namespace coil
    * @brief Constructor
    * @endif
    */
-  Task::Task()
-  {
-  }
+  Task::Task() = default;
 
   /*!
    * @if jp
@@ -39,9 +37,7 @@ namespace coil
    * @brief Destructor
    * @endif
    */
-  Task::~Task()
-  {
-  }
+  Task::~Task() = default;
 
   /*!
    * @if jp

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -198,7 +198,7 @@ namespace coil
    */
   struct escape_functor
   {
-    escape_functor() {}
+    escape_functor() = default;
     void operator()(const char c)
     {
       if      (c == '\t')  str += "\\t";

--- a/src/lib/coil/posix/coil/UUID.cpp
+++ b/src/lib/coil/posix/coil/UUID.cpp
@@ -103,7 +103,7 @@ namespace coil
 
 #if defined(COIL_OS_LINUX) || defined(COIL_OS_DARWIN) || defined(COIL_OS_QNX)
 
-  UUID_Generator::UUID_Generator() {}
+  UUID_Generator::UUID_Generator() = default;
 
   void UUID_Generator::init() {}
   UUID* UUID_Generator::generateUUID(int  /*varsion*/, int  /*variant*/)

--- a/src/lib/hrtm/component_manager.cpp
+++ b/src/lib/hrtm/component_manager.cpp
@@ -72,7 +72,5 @@ namespace hrtm
   {
   }
 
-  ComponentManager::~ComponentManager()
-  {
-  }
+  ComponentManager::~ComponentManager() = default;
 } // namespace hrtm

--- a/src/lib/hrtm/data_flow_component.cpp
+++ b/src/lib/hrtm/data_flow_component.cpp
@@ -22,9 +22,7 @@ namespace hrtm
     : RTC::DataFlowComponentBase(&RTC::Manager::instance())
   {
   }
-  DataFlowComponent::~DataFlowComponent()
-  {
-  }
+  DataFlowComponent::~DataFlowComponent() = default;
   RTC::ReturnCode_t DataFlowComponent::initialize()
   {
     return RTC::RTC_OK;

--- a/src/lib/hrtm/in_port.h
+++ b/src/lib/hrtm/in_port.h
@@ -31,9 +31,7 @@ namespace hrtm
       : RTC::InPort<DataType>(name, data)
     {
     }
-    virtual ~InPort()
-    {
-    }
+    virtual ~InPort() = default;
   };
 #else
   template<class DataType>

--- a/src/lib/hrtm/out_port.h
+++ b/src/lib/hrtm/out_port.h
@@ -31,9 +31,7 @@ namespace hrtm
       : RTC::OutPort<DataType>(name, data)
     {
     }
-    virtual ~OutPort()
-    {
-    }
+    virtual ~OutPort() = default;
   };
 #else
   template<class DataType>

--- a/src/lib/hrtm/properties.cpp
+++ b/src/lib/hrtm/properties.cpp
@@ -29,8 +29,6 @@ namespace utils
     : coil::Properties(defaults, num)
   {
   }
-  Properties::~Properties()
-  {
-  }
+  Properties::~Properties() = default;
 } // namespace utils
 } // namespace hrtm

--- a/src/lib/hrtm/statechart.h
+++ b/src/lib/hrtm/statechart.h
@@ -110,7 +110,7 @@ class State;
 // Data for states which don't declare own Data class.
 class EmptyData {
  public:
-  EmptyData() {}
+  EmptyData() = default;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -130,7 +130,7 @@ struct KeyInit {
 // and exit actions of user's top state.
 class EXPORT_DLL StateBase {
  public:
-  virtual ~StateBase() {}
+  virtual ~StateBase() = default;
 
   // Get unique name of state.
   static Key key() {
@@ -619,7 +619,7 @@ class SubStateInfo : public StateInfo {
 // Generic interface for event objects (available only to MachineBase)
 class EventBase {
  public:
-  virtual ~EventBase() {}
+  virtual ~EventBase() = default;
   virtual void dispatch(StateInfo &) = 0;
 };
 

--- a/src/lib/rtm/BufferBase.h
+++ b/src/lib/rtm/BufferBase.h
@@ -117,9 +117,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~BufferBase()
-    {
-    }
+    virtual ~BufferBase() = default;
 
     /*!
      * @if jp
@@ -595,9 +593,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~NullBuffer()
-    {
-    }
+    virtual ~NullBuffer() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/ByteDataStreamBase.cpp
+++ b/src/lib/rtm/ByteDataStreamBase.cpp
@@ -36,10 +36,7 @@ namespace RTC
      *
      * @endif
      */
-    ByteDataStreamBase::ByteDataStreamBase()
-    {
-
-    }
+    ByteDataStreamBase::ByteDataStreamBase() = default;
 
     /*!
      * @if jp
@@ -56,9 +53,7 @@ namespace RTC
      *
      * @endif
      */
-    ByteDataStreamBase::~ByteDataStreamBase()
-    {
-    }
+    ByteDataStreamBase::~ByteDataStreamBase() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/ByteDataStreamBase.h
+++ b/src/lib/rtm/ByteDataStreamBase.h
@@ -216,9 +216,7 @@ namespace RTC
      *
      * @endif
      */
-    ByteDataStream()
-    {
-    }
+    ByteDataStream() = default;
 
     /*!
      * @if jp
@@ -235,9 +233,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ByteDataStream() override
-    {
-    }
+    ~ByteDataStream() override = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/CORBA_CdrMemoryStream.h
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.h
@@ -429,9 +429,7 @@ namespace RTC
          *
          * @endif
          */
-        CORBA_CdrSerializer()
-        {
-        }
+        CORBA_CdrSerializer() = default;
 
         /*!
          * @if jp
@@ -448,9 +446,7 @@ namespace RTC
          *
          * @endif
          */
-        ~CORBA_CdrSerializer() override
-        {
-        }
+        ~CORBA_CdrSerializer() override = default;
 
         /*!
          * @if jp

--- a/src/lib/rtm/ComponentActionListener.cpp
+++ b/src/lib/rtm/ComponentActionListener.cpp
@@ -29,7 +29,7 @@ namespace RTC
    * @class PostComponentActionListener class
    * @endif
    */
-  PostComponentActionListener::~PostComponentActionListener() {}
+  PostComponentActionListener::~PostComponentActionListener() = default;
 
   /*!
    * @if jp
@@ -38,7 +38,7 @@ namespace RTC
    * @class PreComponentActionListener class
    * @endif
    */
-  PreComponentActionListener::~PreComponentActionListener() {}
+  PreComponentActionListener::~PreComponentActionListener() = default;
 
   /*!
    * @if jp
@@ -47,7 +47,7 @@ namespace RTC
    * @class PortActionListener class
    * @endif
    */
-  PortActionListener::~PortActionListener() {}
+  PortActionListener::~PortActionListener() = default;
 
   /*!
    * @if jp
@@ -56,7 +56,7 @@ namespace RTC
    * @class ExecutionContextActionListener class
    * @endif
    */
-  ExecutionContextActionListener::~ExecutionContextActionListener() {}
+  ExecutionContextActionListener::~ExecutionContextActionListener() = default;
 
 
 
@@ -70,9 +70,7 @@ namespace RTC
    * @class PreComponentActionListener holder class
    * @endif
    */
-  PreComponentActionListenerHolder::PreComponentActionListenerHolder()
-  {
-  }
+  PreComponentActionListenerHolder::PreComponentActionListenerHolder() = default;
 
 
   PreComponentActionListenerHolder::~PreComponentActionListenerHolder()
@@ -136,9 +134,7 @@ namespace RTC
    * @class PostComponentActionListener holder class
    * @endif
    */
-  PostComponentActionListenerHolder::PostComponentActionListenerHolder()
-  {
-  }
+  PostComponentActionListenerHolder::PostComponentActionListenerHolder() = default;
 
 
   PostComponentActionListenerHolder::~PostComponentActionListenerHolder()
@@ -201,9 +197,7 @@ namespace RTC
    * @class PortActionListener holder class
    * @endif
    */
-  PortActionListenerHolder::PortActionListenerHolder()
-  {
-  }
+  PortActionListenerHolder::PortActionListenerHolder() = default;
 
 
   PortActionListenerHolder::~PortActionListenerHolder()
@@ -266,9 +260,7 @@ namespace RTC
    * @class ExecutionContextActionListener holder class
    * @endif
    */
-  ExecutionContextActionListenerHolder::ExecutionContextActionListenerHolder()
-  {
-  }
+  ExecutionContextActionListenerHolder::ExecutionContextActionListenerHolder() = default;
 
 
   ExecutionContextActionListenerHolder::~ExecutionContextActionListenerHolder()
@@ -339,9 +331,7 @@ namespace RTC
      * @brief Constructor
      * @endif
      */
-  ComponentActionListeners::ComponentActionListeners()
-    {
-    }
+  ComponentActionListeners::ComponentActionListeners() = default;
     /*!
      * @if jp
      * @brief デストラクタ
@@ -349,8 +339,6 @@ namespace RTC
      * @brief Destructor
      * @endif
      */
-  ComponentActionListeners::~ComponentActionListeners()
-    {
-    }
+  ComponentActionListeners::~ComponentActionListeners() = default;
 } // namespace RTC
 

--- a/src/lib/rtm/ConfigAdmin.h
+++ b/src/lib/rtm/ConfigAdmin.h
@@ -200,7 +200,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~ConfigBase() {}
+    virtual ~ConfigBase() = default;
 
     // typedef of ConfigAdmin's member function
     typedef void (ConfigAdmin::*CallbackFunc)(const char*, const char*);
@@ -399,7 +399,7 @@ namespace RTC
      *
      * @endif
      */
-    ~Config() override {}
+    ~Config() override = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/ConfigurationListener.cpp
+++ b/src/lib/rtm/ConfigurationListener.cpp
@@ -29,7 +29,7 @@ namespace RTC
    * @class ConfigurationParamListener class
    * @endif
    */
-  ConfigurationParamListener::~ConfigurationParamListener() {}
+  ConfigurationParamListener::~ConfigurationParamListener() = default;
 
   /*!
    * @if jp
@@ -38,7 +38,7 @@ namespace RTC
    * @class ConfigurationSetNameListener class
    * @endif
    */
-  ConfigurationSetNameListener::~ConfigurationSetNameListener() {}
+  ConfigurationSetNameListener::~ConfigurationSetNameListener() = default;
 
   /*!
    * @if jp
@@ -47,7 +47,7 @@ namespace RTC
    * @class ConfigurationSetListener class
    * @endif
    */
-  ConfigurationSetListener::~ConfigurationSetListener() {}
+  ConfigurationSetListener::~ConfigurationSetListener() = default;
 
 
   //============================================================
@@ -58,9 +58,7 @@ namespace RTC
    * @class ConfigurationParamListener holder class
    * @endif
    */
-  ConfigurationParamListenerHolder::ConfigurationParamListenerHolder()
-  {
-  }
+  ConfigurationParamListenerHolder::ConfigurationParamListenerHolder() = default;
 
 
   ConfigurationParamListenerHolder::~ConfigurationParamListenerHolder()
@@ -126,9 +124,7 @@ namespace RTC
    * @class ConfigurationSetListener holder class
    * @endif
    */
-  ConfigurationSetListenerHolder::ConfigurationSetListenerHolder()
-  {
-  }
+  ConfigurationSetListenerHolder::ConfigurationSetListenerHolder() = default;
 
 
   ConfigurationSetListenerHolder::~ConfigurationSetListenerHolder()
@@ -193,9 +189,7 @@ namespace RTC
    * @class ConfigurationSetNameListener holder class
    * @endif
    */
-  ConfigurationSetNameListenerHolder::ConfigurationSetNameListenerHolder()
-  {
-  }
+  ConfigurationSetNameListenerHolder::ConfigurationSetNameListenerHolder() = default;
 
 
   ConfigurationSetNameListenerHolder::~ConfigurationSetNameListenerHolder()

--- a/src/lib/rtm/ConnectorBase.cpp
+++ b/src/lib/rtm/ConnectorBase.cpp
@@ -36,9 +36,7 @@ namespace RTC
    *
    * @endif
    */
-  ConnectorInfo::ConnectorInfo(const ConnectorInfo& info) : name(info.name), id(info.id), ports(info.ports), properties(info.properties)
-  {
-  }
+  ConnectorInfo::ConnectorInfo(const ConnectorInfo&) = default;
 
   /*!
    * @if jp
@@ -55,8 +53,6 @@ namespace RTC
    *
    * @endif
    */
-  ConnectorInfo::~ConnectorInfo()
-  {
-  }
+  ConnectorInfo::~ConnectorInfo() = default;
 } //namespace RTC
 

--- a/src/lib/rtm/ConnectorBase.h
+++ b/src/lib/rtm/ConnectorBase.h
@@ -95,9 +95,7 @@ namespace RTC
      *
      * @endif
      */
-    ConnectorInfo()
-    {
-    }
+    ConnectorInfo() = default;
 
     /*!
      * @if jp
@@ -227,7 +225,7 @@ namespace RTC
      * @brief Destructor
      * @endif
      */
-    virtual ~ConnectorBase() {}
+    virtual ~ConnectorBase() = default;
 
    /*!
      * @if jp

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -41,7 +41,7 @@ namespace RTC
    * @class ConnectorDataListener class
    * @endif
    */
-  ConnectorDataListener::~ConnectorDataListener() {}
+  ConnectorDataListener::~ConnectorDataListener() = default;
 
   /*!
    * @if jp
@@ -50,7 +50,7 @@ namespace RTC
    * @class ConnectorListener class
    * @endif
    */
-  ConnectorListener::~ConnectorListener() {}
+  ConnectorListener::~ConnectorListener() = default;
 
   /*!
    * @if jp
@@ -59,9 +59,7 @@ namespace RTC
    * @class ConnectorDataListener holder class
    * @endif
    */
-  ConnectorDataListenerHolder::ConnectorDataListenerHolder()
-  {
-  }
+  ConnectorDataListenerHolder::ConnectorDataListenerHolder() = default;
 
 
   ConnectorDataListenerHolder::~ConnectorDataListenerHolder()
@@ -132,9 +130,7 @@ namespace RTC
    * @class ConnectorListener holder class
    * @endif
    */
-  ConnectorListenerHolder::ConnectorListenerHolder()
-  {
-  }
+  ConnectorListenerHolder::ConnectorListenerHolder() = default;
 
 
   ConnectorListenerHolder::~ConnectorListenerHolder()
@@ -211,9 +207,7 @@ namespace RTC
    * @brief Constructor
    * @endif
    */
-  ConnectorListeners::ConnectorListeners()
-  {
-  }
+  ConnectorListeners::ConnectorListeners() = default;
   /*!
    * @if jp
    * @brief デストラクタ
@@ -221,9 +215,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  ConnectorListeners::~ConnectorListeners()
-  {
-  }
+  ConnectorListeners::~ConnectorListeners() = default;
 } // namespace RTC
 
 

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -521,7 +521,7 @@ namespace RTC
      * @brief Destructor
      * @endif
      */
-    ~ConnectorDataListenerT() override {}
+    ~ConnectorDataListenerT() override = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/CorbaConsumer.h
+++ b/src/lib/rtm/CorbaConsumer.h
@@ -343,7 +343,7 @@ namespace RTC
      *
      * @endif
      */
-    CorbaConsumer() = default;
+    CorbaConsumer();
 
     /*!
      * @if jp
@@ -559,5 +559,9 @@ namespace RTC
      */
     ObjectTypeVar m_var;
   };
+
+  // No inline for gcc warning, too big
+  template <class T, class U, class V>
+  CorbaConsumer<T, U, V>::CorbaConsumer() = default;
 } // namespace RTC
 #endif  // RTC_CORBACONSUMER_H

--- a/src/lib/rtm/CorbaConsumer.h
+++ b/src/lib/rtm/CorbaConsumer.h
@@ -94,7 +94,7 @@ namespace RTC
      *
      * @endif
      */
-    CorbaConsumerBase() {}
+    CorbaConsumerBase() = default;
 
     /*!
      * @if jp
@@ -343,7 +343,7 @@ namespace RTC
      *
      * @endif
      */
-    CorbaConsumer() {}
+    CorbaConsumer() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/CorbaNaming.cpp
+++ b/src/lib/rtm/CorbaNaming.cpp
@@ -63,6 +63,8 @@ namespace RTC
       }
   }
 
+  CorbaNaming::~CorbaNaming() = default; // No inline for gcc warning, too big
+
   /*!
    * @if jp
    * @brief ネーミングサービスの初期化

--- a/src/lib/rtm/CorbaNaming.h
+++ b/src/lib/rtm/CorbaNaming.h
@@ -132,7 +132,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~CorbaNaming() = default;
+    virtual ~CorbaNaming();
 
     /*!
      * @if jp

--- a/src/lib/rtm/CorbaNaming.h
+++ b/src/lib/rtm/CorbaNaming.h
@@ -132,7 +132,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~CorbaNaming() {}
+    virtual ~CorbaNaming() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/CorbaPort.cpp
+++ b/src/lib/rtm/CorbaPort.cpp
@@ -46,9 +46,7 @@ namespace RTC
    * @brief Virtual destructor
    * @endif
    */
-  CorbaPort::~CorbaPort()
-  {
-  }
+  CorbaPort::~CorbaPort() = default;
 
   /*!
    * @if jp
@@ -470,8 +468,6 @@ namespace RTC
    * @brief destructor
    * @endif
    */
-  CorbaPort::CorbaConsumerHolder::~CorbaConsumerHolder()
-  {
-  }
+  CorbaPort::CorbaConsumerHolder::~CorbaConsumerHolder() = default;
 
 } // namespace RTC

--- a/src/lib/rtm/DataFlowComponentBase.cpp
+++ b/src/lib/rtm/DataFlowComponentBase.cpp
@@ -43,9 +43,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  DataFlowComponentBase::~DataFlowComponentBase()
-  {
-  }
+  DataFlowComponentBase::~DataFlowComponentBase() = default;
 
 
   /*!

--- a/src/lib/rtm/DirectInPortBase.h
+++ b/src/lib/rtm/DirectInPortBase.h
@@ -59,7 +59,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-    ~DirectInPortBase() override{}
+    ~DirectInPortBase() override = default;
 
 
 

--- a/src/lib/rtm/DirectOutPortBase.h
+++ b/src/lib/rtm/DirectOutPortBase.h
@@ -58,9 +58,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	~DirectOutPortBase() override
-	{
-	}
+	~DirectOutPortBase() override = default;
 	/*!
 	* @if jp
 	* @brief データの取得

--- a/src/lib/rtm/DirectPortBase.h
+++ b/src/lib/rtm/DirectPortBase.h
@@ -57,7 +57,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-    virtual ~DirectPortBase(){}
+    virtual ~DirectPortBase() = default;
 
 
 

--- a/src/lib/rtm/ECFactory.cpp
+++ b/src/lib/rtm/ECFactory.cpp
@@ -45,9 +45,7 @@ namespace RTC
    * @brief Virtual destructor
    * @endif
    */
-  ECFactoryCXX::~ECFactoryCXX()
-  {
-  }
+  ECFactoryCXX::~ECFactoryCXX() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/ECFactory.h
+++ b/src/lib/rtm/ECFactory.h
@@ -130,7 +130,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~ECFactoryBase() {}
+    virtual ~ECFactoryBase() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/EventBase.h
+++ b/src/lib/rtm/EventBase.h
@@ -25,23 +25,23 @@ namespace RTC
   class EventBinderBase0
   {
   public:
-      EventBinderBase0(){}
-      virtual ~EventBinderBase0() {}
+      EventBinderBase0() = default;
+      virtual ~EventBinderBase0() = default;
       virtual void run() = 0;
   };
   template <class P0>class EventBinderBase1
   {
   public:
-      EventBinderBase1(){}
-      virtual ~EventBinderBase1() {}
+      EventBinderBase1() = default;
+      virtual ~EventBinderBase1() = default;
       virtual void run(P0& data) = 0;
   };
 
   class EventBase
   {
   public:
-      EventBase(){}
-      virtual ~EventBase(){}
+      EventBase() = default;
+      virtual ~EventBase() = default;
       virtual void operator()()=0;
   };
 
@@ -52,7 +52,7 @@ namespace RTC
           m_eb(eb)
       {
       }
-      ~Event0() override {}
+      ~Event0() override = default;
       void operator()() override
       {
           m_eb->run();
@@ -69,7 +69,7 @@ namespace RTC
           m_eb(eb), m_data(data)
       {
       }
-      ~Event1() override {}
+      ~Event1() override = default;
       void operator()() override
       {
           m_eb->run(m_data);

--- a/src/lib/rtm/EventPort.h
+++ b/src/lib/rtm/EventPort.h
@@ -52,7 +52,7 @@ namespace RTC
                  RingBuffer<EventBase*> &buffer)
       : m_fsm(fsm), m_eventName(event_name), m_handler(handler), m_buffer(buffer) {}
 
-    ~EventBinder0() override {}
+    ~EventBinder0() override = default;
 
     ReturnCode operator()(ConnectorInfo& info,
                                   ByteData&  /*data*/, const std::string& /*marshalingtype*/) override
@@ -91,7 +91,7 @@ namespace RTC
                  RingBuffer<EventBase*> &buffer)
       : m_fsm(fsm), m_eventName(event_name), m_handler(handler), m_buffer(buffer) {}
 
-    ~EventBinder1() override {}
+    ~EventBinder1() override = default;
 
     ReturnCode operator()(ConnectorInfo& info, P0& data) override
     {
@@ -122,9 +122,7 @@ namespace RTC
   public:
       EventConnListener(RingBuffer<EventBase*>&buffer, CdrBufferBase* m_thebuffer) :
           m_buffer(buffer), m_thebuffer(m_thebuffer) {}
-      ~EventConnListener() override
-      {
-      }
+      ~EventConnListener() override = default;
 
       ReturnCode operator()(ConnectorInfo& info) override
       {
@@ -242,7 +240,7 @@ namespace RTC
      *
      * @endif
      */
-    ~EventInPort() override{}
+    ~EventInPort() override = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/ExecutionContextBase.cpp
+++ b/src/lib/rtm/ExecutionContextBase.cpp
@@ -38,9 +38,7 @@ namespace RTC
    * @brief Virtual Destructor
    * @endif
    */
-  ExecutionContextBase::~ExecutionContextBase()
-  {
-  }
+  ExecutionContextBase::~ExecutionContextBase() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/Factory.cpp
+++ b/src/lib/rtm/Factory.cpp
@@ -65,9 +65,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  FactoryBase::~FactoryBase()
-  {
-  }
+  FactoryBase::~FactoryBase() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/FsmActionListener.cpp
+++ b/src/lib/rtm/FsmActionListener.cpp
@@ -29,7 +29,7 @@ namespace RTC
    * @class PostFsmActionListener class
    * @endif
    */
-  PostFsmActionListener::~PostFsmActionListener(){}
+  PostFsmActionListener::~PostFsmActionListener() = default;
 
   /*!
    * @if jp
@@ -38,7 +38,7 @@ namespace RTC
    * @class PreFsmActionListener class
    * @endif
    */
-  PreFsmActionListener::~PreFsmActionListener(){}
+  PreFsmActionListener::~PreFsmActionListener() = default;
 
   /*!
    * @if jp
@@ -47,7 +47,7 @@ namespace RTC
    * @class PortActionListener class
    * @endif
    */
-  FsmProfileListener::~FsmProfileListener(){}
+  FsmProfileListener::~FsmProfileListener() = default;
 
   /*!
    * @if jp
@@ -56,7 +56,7 @@ namespace RTC
    * @class PortActionListener class
    * @endif
    */
-  FsmStructureListener::~FsmStructureListener(){}
+  FsmStructureListener::~FsmStructureListener() = default;
 
   /*!
    * @if jp
@@ -65,9 +65,9 @@ namespace RTC
    * @class FsmActionListeners class
    * @endif
    */
-  FsmActionListeners::FsmActionListeners(){}
+  FsmActionListeners::FsmActionListeners() = default;
 
-  FsmActionListeners::~FsmActionListeners(){}
+  FsmActionListeners::~FsmActionListeners() = default;
 
   //============================================================
   /*!
@@ -77,9 +77,7 @@ namespace RTC
    * @class PreFsmActionListener holder class
    * @endif
    */
-  PreFsmActionListenerHolder::PreFsmActionListenerHolder()
-  {
-  }
+  PreFsmActionListenerHolder::PreFsmActionListenerHolder() = default;
 
   PreFsmActionListenerHolder::~PreFsmActionListenerHolder()
   {
@@ -138,9 +136,7 @@ namespace RTC
    * @class PostFsmActionListener holder class
    * @endif
    */
-  PostFsmActionListenerHolder::PostFsmActionListenerHolder()
-  {
-  }
+  PostFsmActionListenerHolder::PostFsmActionListenerHolder() = default;
 
   PostFsmActionListenerHolder::~PostFsmActionListenerHolder()
   {
@@ -197,9 +193,7 @@ namespace RTC
    * @class FsmProfileListener holder class
    * @endif
    */
-  FsmProfileListenerHolder::FsmProfileListenerHolder()
-  {
-  }
+  FsmProfileListenerHolder::FsmProfileListenerHolder() = default;
 
   FsmProfileListenerHolder::~FsmProfileListenerHolder()
   {
@@ -256,9 +250,7 @@ namespace RTC
    * @class FsmStructureListener holder class
    * @endif
    */
-  FsmStructureListenerHolder::FsmStructureListenerHolder()
-  {
-  }
+  FsmStructureListenerHolder::FsmStructureListenerHolder() = default;
 
   FsmStructureListenerHolder::~FsmStructureListenerHolder()
   {

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -149,7 +149,7 @@ namespace RTC
      *
      * @endif
      */
-    ~InPort() override {}
+    ~InPort() override = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -149,7 +149,7 @@ namespace RTC
      *
      * @endif
      */
-    ~InPort() override = default;
+    ~InPort() override;
 
     /*!
      * @if jp
@@ -839,6 +839,8 @@ namespace RTC
      */
     bool m_directNewData;
   };
+
+  template <class T> InPort<T>::~InPort() = default; // No inline for gcc warning, too big
 } // namespace RTC
 
 #endif  // RTC_INPORT_H

--- a/src/lib/rtm/InPortConnector.cpp
+++ b/src/lib/rtm/InPortConnector.cpp
@@ -44,9 +44,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  InPortConnector::~InPortConnector()
-  {
-  }
+  InPortConnector::~InPortConnector() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/InPortConsumer.h
+++ b/src/lib/rtm/InPortConsumer.h
@@ -91,7 +91,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~InPortConsumer() {}
+    virtual ~InPortConsumer() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortDirectProvider.cpp
+++ b/src/lib/rtm/InPortDirectProvider.cpp
@@ -42,9 +42,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  InPortDirectProvider::~InPortDirectProvider()
-  {
-  }
+  InPortDirectProvider::~InPortDirectProvider() = default;
 
   void InPortDirectProvider::init(coil::Properties& /*prop*/)
   {

--- a/src/lib/rtm/InPortProvider.cpp
+++ b/src/lib/rtm/InPortProvider.cpp
@@ -41,9 +41,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  InPortProvider::~InPortProvider()
-  {
-  }
+  InPortProvider::~InPortProvider() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -63,10 +63,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  InPortSHMProvider::~InPortSHMProvider()
-  {
-
-  }
+  InPortSHMProvider::~InPortSHMProvider() = default;
 
   void InPortSHMProvider::init(coil::Properties& /*prop*/)
   {

--- a/src/lib/rtm/ListenerHolder.h
+++ b/src/lib/rtm/ListenerHolder.h
@@ -156,9 +156,7 @@ namespace util
      * @brief ListenerHolder class ctor
      * @endif
      */
-    ListenerHolder()
-    {
-    }
+    ListenerHolder() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/LocalServiceBase.cpp
+++ b/src/lib/rtm/LocalServiceBase.cpp
@@ -27,8 +27,6 @@ namespace RTM
    * @brief destructor
    * @endif
    */
-  LocalServiceProfile::~LocalServiceProfile()
-  {
-  }
+  LocalServiceProfile::~LocalServiceProfile() = default;
 } //namespace RTM
 

--- a/src/lib/rtm/LocalServiceBase.h
+++ b/src/lib/rtm/LocalServiceBase.h
@@ -204,9 +204,7 @@ namespace RTM
      * @brief virtual destructor
      * @endif
      */
-    virtual ~LocalServiceBase()
-    {
-    }
+    virtual ~LocalServiceBase() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/LogstreamBase.h
+++ b/src/lib/rtm/LogstreamBase.h
@@ -67,7 +67,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~LogstreamBase(){}
+    virtual ~LogstreamBase() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/LogstreamFile.h
+++ b/src/lib/rtm/LogstreamFile.h
@@ -59,7 +59,7 @@ namespace RTC
        *
        * @endif
        */
-      FileStreamBase(){}
+      FileStreamBase() = default;
       /*!
        * @if jp
        *
@@ -75,7 +75,7 @@ namespace RTC
        *
        * @endif
        */
-      ~FileStreamBase() override {}
+      ~FileStreamBase() override = default;
       /*!
        * @if jp
        *

--- a/src/lib/rtm/Macho.h
+++ b/src/lib/rtm/Macho.h
@@ -385,7 +385,7 @@ namespace Macho {
 	// and exit actions of user's top state.
 	class _StateSpecification {
 	public:
-		virtual ~_StateSpecification() {}
+		virtual ~_StateSpecification() = default;
 
 		static bool isChild(Key  /*key*/) {
 			return false;
@@ -842,7 +842,7 @@ namespace Macho {
 	// Generic interface for event objects (available only to MachineBase)
 	class _IEventBase {
 	public:
-		virtual ~_IEventBase() {}
+		virtual ~_IEventBase() = default;
 		virtual void dispatch(_StateInstance &) = 0;
 	};
 
@@ -1133,7 +1133,7 @@ namespace Macho {
 	// the data of the initializer object.
 	class _Initializer {
 	public:
-		virtual ~_Initializer() {}
+		virtual ~_Initializer() = default;
 
 		// Create copy of initializer.
 		virtual _Initializer * clone() = 0;

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -85,10 +85,8 @@ namespace RTC
   {
     return m_name == comp->getInstanceName();
   }
-  Manager::FactoryPredicate::~FactoryPredicate()
-  {}
-  Manager::Finalized::~Finalized()
-  {}
+  Manager::FactoryPredicate::~FactoryPredicate() = default;
+  Manager::Finalized::~Finalized() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/ManagerActionListener.cpp
+++ b/src/lib/rtm/ManagerActionListener.cpp
@@ -29,9 +29,7 @@ namespace RTM
    * @class ManagerActionListener class
    * @endif
    */
-  ManagerActionListener::~ManagerActionListener()
-  {
-  }
+  ManagerActionListener::~ManagerActionListener() = default;
 
   /*!
    * @if jp
@@ -40,9 +38,7 @@ namespace RTM
    * @class ManagerActionListenerHolder class
    * @endif
    */
-  ManagerActionListenerHolder::~ManagerActionListenerHolder()
-  {
-  }
+  ManagerActionListenerHolder::~ManagerActionListenerHolder() = default;
 
   /*!
    * @if jp
@@ -51,9 +47,7 @@ namespace RTM
    * @class ManagerActionListeners class
    * @endif
    */
-  ManagerActionListeners::~ManagerActionListeners()
-  {
-  }
+  ManagerActionListeners::~ManagerActionListeners() = default;
 
   /*!
    * @if jp
@@ -120,9 +114,7 @@ namespace RTM
    * @class ModuleActionListener class
    * @endif
    */
-  ModuleActionListener::~ModuleActionListener()
-  {
-  }
+  ModuleActionListener::~ModuleActionListener() = default;
 
   /*!
    * @if jp
@@ -131,9 +123,7 @@ namespace RTM
    * @class ModuleActionListener holder class
    * @endif
    */
-  ModuleActionListenerHolder::~ModuleActionListenerHolder()
-  {
-  }
+  ModuleActionListenerHolder::~ModuleActionListenerHolder() = default;
 
   /*!
    * @if jp
@@ -204,9 +194,7 @@ namespace RTM
    * @brief RtcLifecycleActionListener class
    * @endif
    */
-  RtcLifecycleActionListener::~RtcLifecycleActionListener()
-  {
-  }
+  RtcLifecycleActionListener::~RtcLifecycleActionListener() = default;
 
   /*!
    * @if jp
@@ -215,9 +203,7 @@ namespace RTM
    * @brief Destructor
    * @endif
    */
-  RtcLifecycleActionListenerHolder::~RtcLifecycleActionListenerHolder()
-  {
-  }
+  RtcLifecycleActionListenerHolder::~RtcLifecycleActionListenerHolder() = default;
 
   /*!
    * @if jp
@@ -312,9 +298,7 @@ namespace RTM
    * @brief Destructor
    * @endif
    */
-  NamingActionListener::~NamingActionListener()
-  {
-  }
+  NamingActionListener::~NamingActionListener() = default;
 
   /*!
    * @if jp
@@ -323,9 +307,7 @@ namespace RTM
    * @brief Destructor
    * @endif
    */
-  NamingActionListenerHolder::~NamingActionListenerHolder()
-  {
-  }
+  NamingActionListenerHolder::~NamingActionListenerHolder() = default;
 
   /*!
    * @if jp
@@ -396,9 +378,7 @@ namespace RTM
    * @brief Destructor
    * @endif
    */
-  LocalServiceActionListener::~LocalServiceActionListener()
-  {
-  }
+  LocalServiceActionListener::~LocalServiceActionListener() = default;
 
   /*!
    * @if jp
@@ -407,9 +387,7 @@ namespace RTM
    * @brief Destructor
    * @endif
    */
-  LocalServiceActionListenerHolder::~LocalServiceActionListenerHolder()
-  {
-  }
+  LocalServiceActionListenerHolder::~LocalServiceActionListenerHolder() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -89,9 +89,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  ManagerConfig::~ManagerConfig()
-  {
-  }
+  ManagerConfig::~ManagerConfig() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1597,9 +1597,7 @@ namespace RTM
         }
   }
 
-  CompParam::~CompParam()
-  {
-  }
+  CompParam::~CompParam() = default;
 
   std::string CompParam::vendor()
     {

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -762,7 +762,7 @@ namespace RTC
     class UnloadPred
     {
     public:
-      UnloadPred() {}
+      UnloadPred() = default;
       void operator()(DLLEntity* dll)
       {
         dll->dll.close();

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -280,10 +280,7 @@ namespace RTC_exp
 
   }
 
-  MultilayerCompositeEC::ChildTask::~ChildTask()
-  {
-
-  }
+  MultilayerCompositeEC::ChildTask::~ChildTask() = default;
 
   void MultilayerCompositeEC::ChildTask::addComponent(RTC::LightweightRTObject_ptr rtc)
   {

--- a/src/lib/rtm/NamingManager.cpp
+++ b/src/lib/rtm/NamingManager.cpp
@@ -550,9 +550,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  NamingManager::~NamingManager()
-  {
-  }
+  NamingManager::~NamingManager() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/NamingManager.h
+++ b/src/lib/rtm/NamingManager.h
@@ -76,7 +76,7 @@ namespace RTC
      *
      * @endif
      */
-    NamingBase() {}
+    NamingBase() = default;
 
     /*!
      * @if jp
@@ -89,7 +89,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~NamingBase() {}
+    virtual ~NamingBase() = default;
 
     /*!
      * @if jp
@@ -281,7 +281,7 @@ namespace RTC
      *
      * @endif
      */
-    ~NamingOnCorba() override {}
+    ~NamingOnCorba() override = default;
 
     /*!
      * @if jp
@@ -470,7 +470,7 @@ namespace RTC
      *
      * @endif
      */
-	 ~NamingOnManager() override{}
+	 ~NamingOnManager() override = default;
     
     /*!
      * @if jp

--- a/src/lib/rtm/NamingServiceNumberingPolicy.h
+++ b/src/lib/rtm/NamingServiceNumberingPolicy.h
@@ -78,7 +78,7 @@ namespace RTM
      *
      * @endif
      */
-	  ~NamingServiceNumberingPolicy() override{}
+	  ~NamingServiceNumberingPolicy() override = default;
     
     /*!
      * @if jp

--- a/src/lib/rtm/NodeNumberingPolicy.h
+++ b/src/lib/rtm/NodeNumberingPolicy.h
@@ -79,7 +79,7 @@ namespace RTM
      *
      * @endif
      */
-	  ~NodeNumberingPolicy() override{}
+	  ~NodeNumberingPolicy() override = default;
     
     /*!
      * @if jp

--- a/src/lib/rtm/NumberingPolicy.h
+++ b/src/lib/rtm/NumberingPolicy.h
@@ -81,7 +81,7 @@ namespace RTM
      *
      * @endif
      */
-    ~ProcessUniquePolicy() override{}
+    ~ProcessUniquePolicy() override = default;
     
     /*!
      * @if jp

--- a/src/lib/rtm/NumberingPolicyBase.h
+++ b/src/lib/rtm/NumberingPolicyBase.h
@@ -76,7 +76,7 @@ namespace RTM
      *
      * @endif
      */
-    virtual ~NumberingPolicyBase() {}
+    virtual ~NumberingPolicyBase() = default;
     
     /*!
      * @if jp

--- a/src/lib/rtm/ObjectManager.h
+++ b/src/lib/rtm/ObjectManager.h
@@ -69,7 +69,7 @@ public:
    *
    * @endif
    */
-  ObjectManager() {}
+  ObjectManager() = default;
 
   /*!
    * @if jp
@@ -86,7 +86,7 @@ public:
    *
    * @endif
    */
-  ~ObjectManager() {}
+  ~ObjectManager() = default;
 
   /*!
    * @if jp
@@ -273,7 +273,7 @@ protected:
    */
   struct Objects
   {
-    ~Objects(){}
+    ~Objects() = default;
     mutable std::mutex _mutex;
     ObjectVector _obj;
   };

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -141,8 +141,7 @@ namespace RTC
      *
      * @endif
      */
-    ~OutPort() override
-    = default;
+    ~OutPort() override;
 
     /*!
      * @if jp
@@ -534,6 +533,8 @@ namespace RTC
     bool m_directNewData;
     DataType m_directValue;
   };
+
+  template <class T> OutPort<T>::~OutPort() = default; // No inline for gcc warning, too big
 } // namespace RTC
 
 #endif  // RTC_OUTPORT_H

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -142,8 +142,7 @@ namespace RTC
      * @endif
      */
     ~OutPort() override
-    {
-    }
+    = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -62,9 +62,7 @@ namespace RTC
    */
   struct OutPortBase::connector_cleanup
   {
-    connector_cleanup()
-    {
-    }
+    connector_cleanup() = default;
     void operator()(OutPortConnector* c)
     {
       delete c;

--- a/src/lib/rtm/OutPortConnector.cpp
+++ b/src/lib/rtm/OutPortConnector.cpp
@@ -43,9 +43,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortConnector::~OutPortConnector()
-  {
-  }
+  OutPortConnector::~OutPortConnector() = default;
   /*!
    * @if jp
    * @brief ConnectorInfo 取得

--- a/src/lib/rtm/OutPortConsumer.h
+++ b/src/lib/rtm/OutPortConsumer.h
@@ -186,7 +186,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OutPortConsumer() {}
+    virtual ~OutPortConsumer() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
@@ -42,9 +42,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortCorbaCdrConsumer::~OutPortCorbaCdrConsumer()
-  {
-  }
+  OutPortCorbaCdrConsumer::~OutPortCorbaCdrConsumer() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/OutPortDSConsumer.cpp
+++ b/src/lib/rtm/OutPortDSConsumer.cpp
@@ -40,9 +40,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortDSConsumer::~OutPortDSConsumer()
-  {
-  }
+  OutPortDSConsumer::~OutPortDSConsumer() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/OutPortDirectConsumer.cpp
+++ b/src/lib/rtm/OutPortDirectConsumer.cpp
@@ -39,9 +39,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortDirectConsumer::~OutPortDirectConsumer()
-  {
-  } 
+  OutPortDirectConsumer::~OutPortDirectConsumer() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/OutPortDirectProvider.cpp
+++ b/src/lib/rtm/OutPortDirectProvider.cpp
@@ -41,10 +41,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortDirectProvider::~OutPortDirectProvider()
-  {
-
-  }
+  OutPortDirectProvider::~OutPortDirectProvider() = default;
   
   /*!
    * @if jp

--- a/src/lib/rtm/OutPortProvider.cpp
+++ b/src/lib/rtm/OutPortProvider.cpp
@@ -29,9 +29,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortProvider::~OutPortProvider()
-  {
-  }
+  OutPortProvider::~OutPortProvider() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/OutPortSHMProvider.cpp
+++ b/src/lib/rtm/OutPortSHMProvider.cpp
@@ -70,10 +70,7 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortSHMProvider::~OutPortSHMProvider()
-  {
-
-  }
+  OutPortSHMProvider::~OutPortSHMProvider() = default;
   
   /*!
    * @if jp

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -49,9 +49,7 @@ namespace SDOPackage
    * @brief Destructor
    * @endif
    */
-  PeriodicECOrganization::~PeriodicECOrganization()
-  {
-  }
+  PeriodicECOrganization::~PeriodicECOrganization() = default;
 
   /*!
    * @if jp
@@ -587,7 +585,7 @@ namespace RTC
   public:
     explicit setCallback(::SDOPackage::PeriodicECOrganization* org)
            : m_org(org) {}
-    ~setCallback() override {}
+    ~setCallback() override = default;
     void operator()(const coil::Properties&  /*config_set*/) override
     {
       m_org->updateDelegatedPorts();
@@ -603,7 +601,7 @@ namespace RTC
   public:
     explicit addCallback(::SDOPackage::PeriodicECOrganization* org)
            : m_org(org) {}
-    ~addCallback() override {}
+    ~addCallback() override = default;
     void operator()(const coil::Properties&  /*config_set*/) override
     {
       m_org->updateDelegatedPorts();

--- a/src/lib/rtm/PortAdmin.cpp
+++ b/src/lib/rtm/PortAdmin.cpp
@@ -109,6 +109,8 @@ namespace RTC
   {
   }
 
+  PortAdmin::~PortAdmin() = default; // No inline for gcc warning, too big
+
   /*!
    * @if jp
    * @brief PortServiceList の取得

--- a/src/lib/rtm/PortAdmin.h
+++ b/src/lib/rtm/PortAdmin.h
@@ -88,7 +88,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PortAdmin() {}
+    virtual ~PortAdmin() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/PortAdmin.h
+++ b/src/lib/rtm/PortAdmin.h
@@ -88,7 +88,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PortAdmin() = default;
+    virtual ~PortAdmin();
 
     /*!
      * @if jp

--- a/src/lib/rtm/PortCallback.h
+++ b/src/lib/rtm/PortCallback.h
@@ -68,7 +68,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~ConnectionCallback() {}
+    virtual ~ConnectionCallback() = default;
 
     /*!
      * @if jp
@@ -137,7 +137,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~DisconnectCallback() {}
+    virtual ~DisconnectCallback() = default;
     /*!
      * @if jp
      *
@@ -205,7 +205,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OnWrite() {}
+    virtual ~OnWrite() = default;
 
     /*!
      * @if jp
@@ -270,7 +270,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OnWriteConvert() {}
+    virtual ~OnWriteConvert() = default;
 
     /*!
      * @if jp
@@ -337,7 +337,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OnRead() {}
+    virtual ~OnRead() = default;
 
     /*!
      * @if jp
@@ -399,7 +399,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~OnReadConvert() {}
+    virtual ~OnReadConvert() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/PortConnectListener.cpp
+++ b/src/lib/rtm/PortConnectListener.cpp
@@ -50,7 +50,7 @@ namespace RTC
    * @class PortConnectListener class
    * @endif
    */
-  PortConnectListener::~PortConnectListener() {}
+  PortConnectListener::~PortConnectListener() = default;
 
   /*!
    * @if jp
@@ -84,7 +84,7 @@ namespace RTC
    * @class PortConnectRetListener class
    * @endif
    */
-  PortConnectRetListener::~PortConnectRetListener() {}
+  PortConnectRetListener::~PortConnectRetListener() = default;
 
   //============================================================
   /*!
@@ -94,9 +94,7 @@ namespace RTC
    * @class PortConnectListener holder class
    * @endif
    */
-  PortConnectListenerHolder::PortConnectListenerHolder()
-  {
-  }
+  PortConnectListenerHolder::PortConnectListenerHolder() = default;
 
 
   PortConnectListenerHolder::~PortConnectListenerHolder()
@@ -159,9 +157,7 @@ namespace RTC
    * @class PortConnectRetListener holder class
    * @endif
    */
-  PortConnectRetListenerHolder::PortConnectRetListenerHolder()
-  {
-  }
+  PortConnectRetListenerHolder::PortConnectRetListenerHolder() = default;
 
 
   PortConnectRetListenerHolder::~PortConnectRetListenerHolder()
@@ -224,13 +220,9 @@ namespace RTC
    * @class PortConnectListeners  class
    * @endif
    */
-  PortConnectListeners::PortConnectListeners()
-  {
-  }
+  PortConnectListeners::PortConnectListeners() = default;
 
-  PortConnectListeners::~PortConnectListeners()
-  {
-  }
+  PortConnectListeners::~PortConnectListeners() = default;
 
 } // namespace RTC
 

--- a/src/lib/rtm/PublisherBase.h
+++ b/src/lib/rtm/PublisherBase.h
@@ -76,7 +76,7 @@ namespace RTC
      *
      * @endif
      */
-    virtual ~PublisherBase() {}
+    virtual ~PublisherBase() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -3024,9 +3024,7 @@ namespace RTC
       m_insref = obj;
   }
 
-  RTObject_impl::SdoServiceConsumerTerminator::SdoServiceConsumerTerminator()
-    {
-    }
+  RTObject_impl::SdoServiceConsumerTerminator::SdoServiceConsumerTerminator() = default;
   void RTObject_impl::SdoServiceConsumerTerminator::setSdoServiceConsumer(SdoServiceAdmin* sdoservice, const char* id)
     {
       m_sdoservice = sdoservice;

--- a/src/lib/rtm/RingBuffer.h
+++ b/src/lib/rtm/RingBuffer.h
@@ -139,8 +139,7 @@ namespace RTC
      * @endif
      */
     ~RingBuffer() override
-    {
-    }
+    = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/RingBuffer.h
+++ b/src/lib/rtm/RingBuffer.h
@@ -138,8 +138,7 @@ namespace RTC
      *
      * @endif
      */
-    ~RingBuffer() override
-    = default;
+    ~RingBuffer() override;
 
     /*!
      * @if jp
@@ -1066,6 +1065,8 @@ namespace RTC
      */
     condition m_full;
   };
+
+  template <class T> RingBuffer<T>::~RingBuffer() = default; // no-inline because of its size.
 } // namespace RTC
 
 #endif  // RTC_RINGBUFFER_H

--- a/src/lib/rtm/SdoConfiguration.cpp
+++ b/src/lib/rtm/SdoConfiguration.cpp
@@ -116,9 +116,7 @@ namespace SDOPackage
    * @brief Virtual destructor
    * @endif
    */
-  Configuration_impl::~Configuration_impl()
-  {
-  }
+  Configuration_impl::~Configuration_impl() = default;
 
 
   //============================================================

--- a/src/lib/rtm/SdoOrganization.cpp
+++ b/src/lib/rtm/SdoOrganization.cpp
@@ -69,9 +69,7 @@ namespace SDOPackage
    * @brief Virtual destructor
    * @endif
    */
-  Organization_impl::~Organization_impl()
-  {
-  }
+  Organization_impl::~Organization_impl() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/SdoServiceConsumerBase.h
+++ b/src/lib/rtm/SdoServiceConsumerBase.h
@@ -143,7 +143,7 @@ namespace RTC
      * @brief virtual destructor
      * @endif
      */
-    virtual ~SdoServiceConsumerBase() {}
+    virtual ~SdoServiceConsumerBase() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/SdoServiceProviderBase.h
+++ b/src/lib/rtm/SdoServiceProviderBase.h
@@ -142,7 +142,7 @@ namespace RTC
      * @brief virtual destructor
      * @endif
      */
-    ~SdoServiceProviderBase() override {}
+    ~SdoServiceProviderBase() override = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/SdoServiceProviderBase.h
+++ b/src/lib/rtm/SdoServiceProviderBase.h
@@ -142,7 +142,7 @@ namespace RTC
      * @brief virtual destructor
      * @endif
      */
-    ~SdoServiceProviderBase() override = default;
+    ~SdoServiceProviderBase() override;
 
     /*!
      * @if jp
@@ -240,6 +240,9 @@ namespace RTC
      */
     virtual void finalize() = 0;
   };
+
+  // No inline for gcc warning, too big
+  SdoServiceProviderBase::~SdoServiceProviderBase() = default;
 
     /*!
      * @if jp

--- a/src/lib/rtm/SimulatorExecutionContext.cpp
+++ b/src/lib/rtm/SimulatorExecutionContext.cpp
@@ -49,10 +49,7 @@ namespace RTC
    * @brief Destructor 
    * @endif
    */
-  SimulatorExecutionContext::~SimulatorExecutionContext()
-  {
-
-  }
+  SimulatorExecutionContext::~SimulatorExecutionContext() = default;
 
 
   /*!

--- a/src/lib/rtm/StateMachine.h
+++ b/src/lib/rtm/StateMachine.h
@@ -296,8 +296,7 @@ namespace RTC_Utils
     }
 
     virtual ~StateMachine()
-    {
-    }
+    = default;
 
     StateMachine(const StateMachine& other)
       : m_num(other.m_num),

--- a/src/lib/rtm/StateMachine.h
+++ b/src/lib/rtm/StateMachine.h
@@ -257,6 +257,7 @@ namespace RTC_Utils
    *
    * @endif
    */
+
   template <class State,
             class Listener,
             class States = StateHolder<State>,
@@ -295,8 +296,7 @@ namespace RTC_Utils
     {
     }
 
-    virtual ~StateMachine()
-    = default;
+    virtual ~StateMachine();
 
     StateMachine(const StateMachine& other)
       : m_num(other.m_num),
@@ -979,6 +979,11 @@ namespace RTC_Utils
       m_states.curr = curr;
     }
   };
+
+  // No inline for gcc warning, too big
+  template <class T, class U, class V, class W>
+  StateMachine<T, U, V, W>::~StateMachine() = default;
+
 } // namespace RTC_Utils
 
 #endif  // RTC_STATEMACHINE_H

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -116,7 +116,7 @@ namespace RTC
       : Macho::Machine<TOP>(), rtComponent(comp)
     {
     }
-    ~Machine() override {}
+    ~Machine() override = default;
     virtual RingBuffer<EventBase*>& getBuffer()
     {
         return m_buffer;
@@ -168,9 +168,7 @@ namespace RTC
       : Macho::Link<C, P>(instance), rtComponent(nullptr)
     {
     }
-    ~Link() override
-    {
-    }
+    ~Link() override = default;
 
     void setrtc()
     {

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -96,9 +96,7 @@ namespace RTC
     setDateFormat(m_dateFormat.c_str());
   }
 
-  Logger::~Logger()
-  {
-  }
+  Logger::~Logger() = default;
 
   /*!
    * @if jp

--- a/src/lib/rtm/Timestamp.h
+++ b/src/lib/rtm/Timestamp.h
@@ -62,7 +62,7 @@ namespace RTC
     USE_CONNLISTENER_STATUS;
   public:
     Timestamp(const char* ts_type) : m_tstype(ts_type) {}
-    ~Timestamp() override {}
+    ~Timestamp() override = default;
     ReturnCode operator()(ConnectorInfo& info, DataType& data) override
     {
       if (info.properties["timestamp_policy"] != m_tstype)


### PR DESCRIPTION
# Description of the Change

C++11 に従いデフォルトのコンストラクターや operator= は "= default" で作成する。

変更するとなぜか gcc がインライン展開時に大きくなりすぎるという警告を出す箇所がある。
そこはクラス外で定義することインライン展開しないように変更する。

別 Issue でデフォルト初期値を設定したので、コンストラクター記述が不要になったクラスが増えるかもしれません。次にツールかける機会があればそのときに。

（デフォルト定義で間に合う場所は、手動で書かない方が保守性も可読性も上なのではという気もします。）

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
