### PR TITLE
Make Argv.argv writable.

### DIFF
--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -1032,30 +1032,25 @@ namespace coil
    */
   class Argv
   {
-    char** m_argv{nullptr};
-    size_t m_size{0};
+    std::vector<char*> m_argv;
+    std::vector<std::vector<char>> m_args;
   public:
     Argv() = default;
     Argv(const vstring& args);
-    ~Argv();
     // Non copyable: Implement this when you need.
-    Argv(const Argv&) = delete;
-    Argv& operator=(const Argv&) = delete;
-    // Movable
-    Argv(Argv&& x) noexcept { *this = std::move(x); }
-    Argv& operator=(Argv&& x) noexcept
-    {
-      if(this != &x)
-        {
-          m_argv = x.m_argv;
-          m_size = x.m_size;
-          x.m_argv = nullptr;
-          x.m_size = 0;
-        }
-      return *this;
-    }
-    char** get() { return m_argv;}
-    size_t size() { return m_size; }
+    Argv(Argv const&) = delete;
+    Argv& operator=(Argv const&) = delete;
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+    // Visual Studio 2013: not support default move operations.
+    Argv(Argv&&) noexcept;
+    Argv& operator=(Argv&&) noexcept;
+#else
+    Argv(Argv&&) = default;
+    Argv& operator=(Argv&&) = default;
+#endif
+    ~Argv();
+    char** get() noexcept { return size() == 0 ? nullptr : m_argv.data(); }
+    size_t size() const noexcept { return m_args.size(); }
   };
 
   /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

omniORB の中で argv の書き換えが行われており、
その結果として argv にあるそれぞれの文字列を順に解放する処理で解放漏れが発生している。

## Description of the Change

- C配列ではなく、std::vector を使用する。
   これでクラスと同じ生存期間となる。
- コピーされると、アドレス配列 (m_argv) の中身が不正になるのでムーブを使用する。
   ただし VS2013 はムーブ操作を自動生成しない (=C++11未対応） ので手作りする。
- コピーは使用者がいないので未実装 (delete 指定)
   使いたい人がいれば実装してください

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
