### PR TITLE
Moderize eraseBlank().

### DIFF
--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -86,7 +86,7 @@ RTC::ReturnCode_t Inputbutton::onExecute(RTC::UniqueId  /*ec_id*/)
   std::getline(std::cin, cmd);
 
   coil::vstring cmds = coil::split(cmd, " ");
-  coil::eraseBlank(cmds[0]);
+  cmds[0] = coil::eraseBlank(std::move(cmds[0]));
 
   std::cout << "[command]: " << cmds[0];
   if (cmds.size() > 1)

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -292,22 +292,12 @@ namespace coil
    * @brief Erase blank characters of string
    * @endif
    */
-  void eraseBlank(std::string& str)
+  std::string eraseBlank(std::string str) noexcept
   {
-    std::string::iterator it(str.begin());
-
-    while (it != str.end())
-      {
-        if (*it == ' ' || *it == '\t')
-          {
-            it = str.erase(it);
-          }
-        else
-          {
-            ++it;
-          }
-      }
-
+    str.erase(std::remove_if(str.begin(), str.end(),
+                [](unsigned char x){ return std::isblank(x); }),
+              str.end());
+    return str;
   }
 
   /*!

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -251,18 +251,21 @@ namespace coil
    * 空白文字として扱うのは' '(スペース)と'\\t'(タブ)。
    *
    * @param str 空白文字削除処理文字列
+   * @return 空白除去済み文字列
    *
    * @else
    * @brief Erase blank characters of string
+   * @return The erased string
    *
    * Erase blank characters that exist at the head of the given string.
    * Space ' 'and tab '\\t' are supported as the blank character.
    *
    * @param str The target blank characters of string for the erase
+   * @return The string which is erased the whitespaces.
    *
    * @endif
    */
-  void eraseBlank(std::string& str);
+  std::string eraseBlank(std::string str) noexcept;
 
   /*!
    * @if jp

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -126,8 +126,8 @@ namespace RTC
 
       CdrMemoryStreamInit<DataType>();
 
-      std::string serializer_types = coil::flatten(coil::GlobalFactory < ByteDataStream<DataType> >::instance().getIdentifiers());
-      coil::eraseBlank(serializer_types);
+      std::string serializer_types{coil::eraseBlank(coil::flatten(
+        coil::GlobalFactory<ByteDataStream<DataType>>::instance().getIdentifiers()))};
 
       RTC_DEBUG(("available serializer_types: %s", serializer_types.c_str()));
 

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -115,15 +115,13 @@ namespace RTC
 	  m_directport = this;
 
       CdrMemoryStreamInit<DataType>();
-      
-          
-      std::string serializer_types = coil::flatten(coil::GlobalFactory < ByteDataStream<DataType> >::instance().getIdentifiers());
-      coil::eraseBlank(serializer_types);
+
+      std::string serializer_types{coil::eraseBlank(coil::flatten(
+        coil::GlobalFactory<ByteDataStream<DataType>>::instance().getIdentifiers()))};
 
       RTC_DEBUG(("available serializer_types: %s", serializer_types.c_str()));
 
       addProperty("dataport.serializer_type", serializer_types.c_str());
-
     }
 
     /*!

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -90,10 +90,8 @@ namespace RTC
 
     // publisher list
     PublisherFactory& factory(PublisherFactory::instance());
-    std::string pubs = coil::flatten(factory.getIdentifiers());
-
     // blank characters are deleted for RTSE's bug
-    coil::eraseBlank(pubs);
+    std::string pubs{coil::eraseBlank(coil::flatten(factory.getIdentifiers()))};
     RTC_DEBUG(("available subscription_type: %s",  pubs.c_str()));
     addProperty("dataport.subscription_type", pubs.c_str());
     // FSM4RTC formal/16-04-01 p.25


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Description of the Change

coil::eraseBlank() のムーブ (C++11) 対応を行う。
よって、
 - 関数の戻り値を受け取ることができる。
 - char配列を受け取ることができる。（変数でも、リテラルでも）
 - std::move 使用で文字列バッファの確保とコピーは発生しない。（確保がないので例外も発生しない。）

coil::flatten() の戻り値に対して実行しているものが多いけれど、coil::flatten() の第二引数のデフォルトに
なぜかスペースが仕込まれていることが原因ではないかという心配あり。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  eraseBlank() はテスト済み。呼び出し側は未テスト。
