### PR TITLE
Moderize toLower().

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -110,27 +110,16 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief std::tolowerをchar型引数、char型戻り値でラップした関数
-   * @else
-   * @brief 
-   * @endif
-   */
-  char tolower_(char c)
-  {
-      return static_cast<char>(std::tolower(static_cast<int>(c)));
-  }
-
-  /*!
-   * @if jp
    * @brief 小文字への変換
    * @else
    * @brief Lowercase String Transformation
    * @endif
    */
-  void toLower(std::string& str)
+  std::string toLower(std::string str) noexcept
   {
     std::transform(str.begin(), str.end(), str.begin(),
-                   tolower_);
+                   [](unsigned char x){ return std::tolower(x); });
+    return str;
   }
 
   /*!
@@ -361,8 +350,7 @@ namespace coil
   std::string normalize(std::string& str)
   {
     eraseBothEndsBlank(str);
-    toLower(str);
-    return str;
+    return toLower(std::move(str));
   }
 
   /*!
@@ -485,12 +473,11 @@ namespace coil
    */
   bool includes(const vstring& list, std::string value, bool ignore_case)
   {
-    if (ignore_case) { toLower(value); }
-
-    for (auto str : list)
+    std::string const& v{ignore_case ? toLower(std::move(value)) : value};
+    for (auto const& str : list)
       {
-        if (ignore_case) { toLower(str); }
-        if (str == value) return true;
+        std::string const& x{ignore_case ? toLower(str) : str};
+        if (v == x) return true;
       }
     return false;
   }

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -106,6 +106,7 @@ namespace coil
    * 与えられた文字列を小文字に変換
    *
    * @param str 入力文字列
+   * @return 変換後文字列
    *
    * @else
    * @brief Lowercase String Transformation
@@ -113,10 +114,11 @@ namespace coil
    * This function transforms a given string to lowercase letters
    *
    * @param str The input string
+   * @return The converted string
    *
    * @endif
    */
-  void toLower(std::string& str);
+  std::string toLower(std::string str) noexcept;
 
   /*!
    * @if jp

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2517,9 +2517,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
   {
     ip = false; ip_list.resize(0);
 
-    std::string ep_prop;
-    ep_prop = m_config.getProperty("corba.endpoint_property", "ipv4");
-    coil::toLower(ep_prop);
+    std::string ep_prop{coil::toLower(
+      m_config.getProperty("corba.endpoint_property", "ipv4"))};
 
     std::string::size_type pos = ep_prop.find(ipver);
     if (pos == std::string::npos) { return; }

--- a/src/lib/rtm/SdoServiceAdmin.cpp
+++ b/src/lib/rtm/SdoServiceAdmin.cpp
@@ -120,9 +120,7 @@ namespace RTC
     ::coil::vstring activeProviderTypes;
     for (auto & enabledProviderType : enabledProviderTypes)
       {
-        std::string provtype(enabledProviderType);
-        coil::toLower(provtype);
-        if (provtype == "all")
+        if (coil::toLower(enabledProviderType) == "all")
           {
             activeProviderTypes = availableProviderTypes;
             RTC_DEBUG(("sdo.service.provider.enabled_services: ALL"));
@@ -180,10 +178,9 @@ namespace RTC
                prop["sdo.service.consumer.available_services"].c_str()));
 
     // If types include '[Aa][Ll][Ll]', all types enabled in this RTC
-    for (auto consumerType : m_consumerTypes)
+    for (auto const& consumerType : m_consumerTypes)
       {
-        coil::toLower(consumerType);
-        if (consumerType == "all")
+        if (coil::toLower(consumerType) == "all")
           {
             m_allConsumerEnabled = true;
             RTC_DEBUG(("sdo.service.consumer.enabled_services: ALL"));
@@ -503,11 +500,11 @@ namespace RTC
 
   std::string SdoServiceAdmin::ifrToKey(std::string& ifr)
   {
-    ::coil::vstring ifrvstr = ::coil::split(ifr, ":");
-    ::coil::toLower(ifrvstr[1]);
-    ::coil::replaceString(ifrvstr[1], ".", "_");
-    ::coil::replaceString(ifrvstr[1], "/", ".");
-    return ifrvstr[1];
+    coil::vstring ifrvstr = coil::split(ifr, ":");
+    std::string str{coil::toLower(std::move(ifrvstr[1]))};
+    coil::replaceString(str, ".", "_");
+    coil::replaceString(str, "/", ".");
+    return str;
   }
 
 


### PR DESCRIPTION
## Description of the Change

coil::toLower() のムーブ （C++11) を行う。
効果は #596 と同じです。
また stringutil のヘルパー関数の宣言がないという警告も同時に対応されます。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?   toLower（）はテスト済み。呼び出し元は未テスト。
