### PR TITLE
Modernize toUpper().

### DIFF
--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
@@ -164,9 +164,9 @@ namespace RTC
       {
         flag = false;
       }
-    for(auto & o : observed)
+    for(auto&& o : observed)
       {
-        coil::toUpper(o);
+        o = coil::toUpper(std::move(o));
         if (o == "COMPONENT_PROFILE")
           {
             flags[RTC::COMPONENT_PROFILE] = true;

--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -172,9 +172,9 @@ namespace RTC
       {
         flag = false;
       }
-    for (auto & observed : observedlist)
+    for (auto&& observed : observedlist)
       {
-        coil::toUpper(observed);
+        observed = coil::toUpper(std::move(observed));
         if (observed == "COMPONENT_PROFILE")
           {
             flags[OpenRTM::COMPONENT_PROFILE] = true;

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -82,19 +82,6 @@ namespace coil
     return str;
   }
 
-
-  /*!
-   * @if jp
-   * @brief std::toupperをchar型引数、char型戻り値でラップした関数
-   * @else
-   * @brief
-   * @endif
-   */
-  char toupper_(char c)
-  {
-      return static_cast<char>(std::toupper(static_cast<int>(c)));
-  }
-
   /*!
    * @if jp
    * @brief 大文字への変換
@@ -102,10 +89,11 @@ namespace coil
    * @brief Uppercase String Transformation
    * @endif
    */
-  void toUpper(std::string& str)
+  std::string toUpper(std::string str) noexcept
   {
     std::transform(str.begin(), str.end(), str.begin(),
-                   toupper_);
+                   [](unsigned char x){ return std::toupper(x); });
+    return str;
   }
 
   /*!
@@ -441,21 +429,6 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief 大文字に変換する Functor
-   * @else
-   * @brief Functor to convert to capital letters
-   * @endif
-   */
-  struct Toupper
-  {
-    void operator()(char &c)
-    {
-      c = static_cast<char>(toupper(static_cast<int>(c)));
-    }
-  };
-
-  /*!
-   * @if jp
    * @brief 与えられた文字列をbool値に変換する
    * @else
    * @brief Convert given string into bool value
@@ -464,13 +437,11 @@ namespace coil
   bool toBool(std::string str, std::string yes, std::string no,
               bool default_value)
   {
-    std::for_each(str.begin(), str.end(), Toupper());
-    std::for_each(yes.begin(), yes.end(), Toupper());
-    std::for_each(no.begin(),  no.end(),  Toupper());
+    std::string s = toUpper(std::move(str));
 
-    if (str.find(yes) != std::string::npos)
+    if (s.find(toUpper(std::move(yes))) != std::string::npos)
       return true;
-    else if (str.find(no) != std::string::npos)
+    else if (s.find(toUpper(std::move(no))) != std::string::npos)
       return false;
     else
       return default_value;

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -87,6 +87,7 @@ namespace coil
    * 与えられた文字列を大文字に変換
    *
    * @param str 入力文字列
+   * @return 変換後文字列
    *
    * @else
    * @brief Uppercase String Transformation
@@ -94,10 +95,11 @@ namespace coil
    * This function transforms a given string to uppercase letters
    *
    * @param str The input string
+   * @return The converted string
    *
    * @endif
    */
-  void toUpper(std::string& str);
+  std::string toUpper(std::string str) noexcept;
 
   /*!
    * @if jp


### PR DESCRIPTION
## Description of the Change

coil::toUpper() のムーブ （C++11) を行う。
効果は #596 と同じです。
また stringutil のヘルパー関数の宣言がないという警告も同時に対応されます。

そもそも toUpper() は廃止すべきと思う。
使用箇所すべてを見回すと toLower() で代替できることがわかる。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?   toUpper（）はテスト済み。呼び出し元は未テスト。