### PR TITLE
Modernize unique_sv

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -839,8 +839,14 @@ namespace coil
     std::unordered_set<std::string> set{std::make_move_iterator(sv.begin()),
                                         std::make_move_iterator(sv.end()),
                                         sv.size()};
+#if (defined(__GNUC__) && (__GNUC__ < 5) && !defined(__clang__))    \
+    || (defined(_MSC_VER) && (_MSC_VER < 1900))
+    sv.clear();
+    for (auto&& itr : set) { sv.emplace_back(std::move(itr)); }
+#else
     sv.assign(std::make_move_iterator(set.begin()),
               std::make_move_iterator(set.end()));
+#endif
     return sv;
   }
 

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -29,6 +29,7 @@
 #include <cctype>
 #include <utility>
 #include <cstdio>
+#include <unordered_set>
 #include <coil/OS.h>
 
 #ifdef __QNX__
@@ -660,23 +661,6 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief リスト内の文字列を検索する Functor
-   * @else
-   * @brief Functor to find string in a list
-   * @endif
-   */
-  struct unique_strvec
-  {
-    void operator()(const std::string& s)
-    {
-      if (std::find(str.begin(), str.end(), s) == str.end())
-        return str.push_back(s);
-    }
-    vstring str;
-  };
-
-  /*!
-   * @if jp
    * @brief 与えられた文字列をstd::stringに変換
    * @else
    * @brief Convert the given string to std::string.
@@ -852,7 +836,12 @@ namespace coil
    */
   vstring unique_sv(vstring sv)
   {
-    return std::for_each(sv.begin(), sv.end(), unique_strvec()).str;
+    std::unordered_set<std::string> set{std::make_move_iterator(sv.begin()),
+                                        std::make_move_iterator(sv.end()),
+                                        sv.size()};
+    sv.assign(std::make_move_iterator(set.begin()),
+              std::make_move_iterator(set.end()));
+    return sv;
   }
 
   /*!

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1639,8 +1639,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             endpoints.insert(endpoints.begin(), ":2810");
           }
       }
-    coil::vstring tmp(endpoints);
-    endpoints = coil::unique_sv(tmp);
+    endpoints = coil::unique_sv(std::move(endpoints));
   }
 
   void Manager::createORBEndpointOption(std::string& opt,
@@ -2308,7 +2307,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
     // Merge Properties. type_prop is merged properties
     comp->setProperties(prop);
     type_prop << name_prop;
-    type_prop["config_file"] = coil::flatten(coil::unique_sv(config_fname));
+    type_prop["config_file"]
+      = coil::flatten(coil::unique_sv(std::move(config_fname)));
     comp->setProperties(type_prop);
 
     //------------------------------------------------------------


### PR DESCRIPTION
## Description of the Change

unique_sv を C++11 に対応する。
処理速度とメモリ効率が大分上がっていて、1万要素で30倍、10万要素で300倍くらいはやい。
要素が少ないときも move によりメモリ確保の回数が少なくなっている。

Visual Studio 2013 と gcc-4.9 (Debian 8) でビルドエラーになるため、回避コードが入っている。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
