### PR TITLE
Modernize includes().

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -504,8 +504,7 @@ namespace coil
    */
   bool includes(const std::string& list, std::string value, bool ignore_case)
   {
-    vstring vlist(split(list, ","));
-    return includes(vlist, std::move(value), ignore_case);
+    return includes(split(list, ","), std::move(value), ignore_case);
   }
 
   /*!


### PR DESCRIPTION
## Description of the Change

includes() を C++11 に対応する。
中間変数を置かないことで 文字列配列を move する。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
