### PR TITLE
Modernize erase[Head|Tail|BothEnds]Blank().

### DIFF
--- a/src/ext/transport/OpenSplice/OpenSpliceManager.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceManager.cpp
@@ -544,12 +544,12 @@ namespace RTC
       
       coil::create_process(comin, comout);
       
-      std::string xmlstr;
-      for (auto& c : comout)
+      std::string tmp;
+      for (auto const& c : comout)
       {
-          xmlstr.append(c);
+          tmp.append(c);
       }
-      coil::eraseBothEndsBlank(xmlstr);
+      std:: string xmlstr{coil::eraseBothEndsBlank(std::move(tmp))};
 
       rapidxml::xml_document<> doc;
       try

--- a/src/ext/transport/OpenSplice/OpenSpliceMessageInfo.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceMessageInfo.cpp
@@ -120,10 +120,10 @@ const char* InterfaceDataTypesFile::idlpath = "${RTM_IDL_PATH}/InterfaceDataType
 void OpenSpliceMessageInfoInit(const coil::Properties& prop)
 {
     std::string datalist = prop.getProperty("opensplice.datatypes", "ALL");
-    coil::vstring datatypes = coil::split(datalist, ",");
-    for (auto& datatype : datatypes)
+    coil::vstring datatypes;
+    for (auto& datatype : coil::split(datalist, ","))
     {
-        coil::eraseBothEndsBlank(datatype);
+        datatypes.emplace_back(coil::eraseBothEndsBlank(std::move(datatype)));
     }
 
     RTC::appendOpenSpliceMessageInfo<RTC::TimedState, BasicDataTypeFile>(datatypes);

--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -310,16 +310,8 @@ namespace coil
   {
     for (long i = 0; i < num && defaults[i][0] != '\0' ; i += 2)
       {
-        std::string key(defaults[i]);
-        std::string invalue(defaults[i + 1]);
-
-        coil::eraseHeadBlank(key);
-        coil::eraseTailBlank(key);
-
-        coil::eraseHeadBlank(invalue);
-        coil::eraseTailBlank(invalue);
-
-        setDefault(key, invalue);
+        setDefault(eraseBothEndsBlank(defaults[i]),
+                   eraseBothEndsBlank(defaults[i + 1]));
       }
   }
 
@@ -353,7 +345,7 @@ namespace coil
       {
         std::string tmp = std::string();
         coil::getlinePortable(inStream, tmp);
-        coil::eraseHeadBlank(tmp);
+        tmp = coil::eraseHeadBlank(std::move(tmp));
 
         // Skip comments or empty lines
         if (tmp.empty())
@@ -383,15 +375,8 @@ namespace coil
 
         std::string key, invalue;
         splitKeyValue(pline, key, invalue);
-        key = coil::unescape(key);
-        coil::eraseHeadBlank(key);
-        coil::eraseTailBlank(key);
-
-        invalue = coil::unescape(invalue);
-        coil::eraseHeadBlank(invalue);
-        coil::eraseTailBlank(invalue);
-
-        setProperty(key, invalue);
+        setProperty(eraseBothEndsBlank(coil::unescape(key)),
+                    eraseBothEndsBlank(std::move(invalue)));
         pline.clear();
       }
   }
@@ -613,12 +598,8 @@ namespace coil
       {
         if ((str[i] == ':' || str[i] == '=') && !coil::isEscaped(str, i))
           {
-            key   = str.substr(0, i);  // substr(0, i) returns 0...(i-1) chars.
-            coil::eraseHeadBlank(key);
-            coil::eraseTailBlank(key);
-            value = str.substr(i + 1);
-            coil::eraseHeadBlank(value);
-            coil::eraseTailBlank(value);
+            key = eraseBothEndsBlank(str.substr(0, i));
+            value = eraseBothEndsBlank(str.substr(i + 1));
             return;
           }
         ++i;
@@ -630,12 +611,8 @@ namespace coil
       {
         if ((str[i] == ' ') && !coil::isEscaped(str, i))
           {
-            key   = str.substr(0, i);  // substr(0, i) returns 0...(i-1) chars.
-            coil::eraseHeadBlank(key);
-            coil::eraseTailBlank(key);
-            value = str.substr(i + 1);
-            coil::eraseHeadBlank(value);
-            coil::eraseTailBlank(value);
+            key = eraseBothEndsBlank(str.substr(0, i));
+            value = eraseBothEndsBlank(str.substr(i + 1));
             return;
           }
         ++i;

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -286,10 +286,9 @@ namespace coil
    * @brief Erase the head blank characters of string
    * @endif
    */
-  void eraseHeadBlank(std::string& str)
+  std::string eraseHeadBlank(std::string str) noexcept
   {
-    if (str.empty()) return;
-    while (str[0] == ' ' || str[0] == '\t') str.erase(0, 1);
+    return str.erase(0, str.find_first_not_of(" \t"));
   }
 
   /*!
@@ -299,12 +298,9 @@ namespace coil
    * @brief Erase the tail blank characters of string
    * @endif
    */
-  void eraseTailBlank(std::string& str)
+  std::string eraseTailBlank(std::string str) noexcept
   {
-    if (str.empty()) return;
-    while ((str[str.size() - 1] == ' ' || str[str.size() - 1] == '\t') &&
-           !isEscaped(str, str.size() - 1))
-      str.erase(str.size() - 1, 1);
+    return str.erase(str.find_last_not_of(" \t") + 1); // npos + 1 = 0
   }
 
   /*!
@@ -314,10 +310,9 @@ namespace coil
    * @brief Erase the head blank and the tail blank characters of string
    * @endif
    */
-  void eraseBothEndsBlank(std::string& str)
+  std::string eraseBothEndsBlank(std::string str) noexcept
   {
-    eraseHeadBlank(str);
-    eraseTailBlank(str);
+    return eraseHeadBlank(eraseTailBlank(std::move(str)));
   }
 
   /*!
@@ -329,8 +324,7 @@ namespace coil
    */
   std::string normalize(std::string& str)
   {
-    eraseBothEndsBlank(str);
-    return toLower(std::move(str));
+    return toLower(eraseBothEndsBlank(std::move(str)));
   }
 
   /*!
@@ -371,7 +365,7 @@ namespace coil
     using size = std::string::size_type;
     vstring results(0);
     size delim_size = delimiter.size();
-    size found_pos(0), begin_pos(0), pre_pos(0), substr_size(0);
+    size found_pos(0), begin_pos(0), pre_pos(0);
 
     if (input.empty()) { return results; }
 
@@ -381,9 +375,7 @@ namespace coil
         found_pos = input.find(delimiter, begin_pos);
         if (found_pos == std::string::npos)
           {
-            std::string substr(input.substr(pre_pos));
-            eraseHeadBlank(substr);
-            eraseTailBlank(substr);
+            std::string substr{eraseBothEndsBlank(input.substr(pre_pos))};
             if (!(substr.empty() && ignore_empty))
               {
                 results.push_back(substr);
@@ -392,10 +384,8 @@ namespace coil
           }
         if (found_pos >= pre_pos)
           {
-            substr_size = found_pos - pre_pos;
-            std::string substr(input.substr(pre_pos, substr_size));
-            eraseHeadBlank(substr);
-            eraseTailBlank(substr);
+            size end = found_pos - pre_pos;
+            std::string substr{eraseBothEndsBlank(input.substr(pre_pos, end))};
             if (!(substr.empty() && ignore_empty))
               {
                 results.push_back(substr);

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -279,18 +279,21 @@ namespace coil
    * 空白文字として扱うのは' '(スペース)と'\\t'(タブ)。
    *
    * @param str 先頭空白文字削除処理文字列
+   * @return 空白除去済み文字列
    *
    * @else
    * @brief Erase the head blank characters of string
+   * @return The erased string
    *
    * Erase the blank characters that exist at the head of the given string.
    * Space ' 'and tab '\\t' are supported as the blank character.
    *
    * @param str The target head blank characters of string for the erase
+   * @return The string which is erased the head blnak.
    *
    * @endif
    */
-  void eraseHeadBlank(std::string& str);
+  std::string eraseHeadBlank(std::string str) noexcept;
 
   /*!
    * @if jp
@@ -300,6 +303,7 @@ namespace coil
    * 空白文字として扱うのは' '(スペース)と'\\t'(タブ)。
    *
    * @param str 末尾空白文字削除処理文字列
+   * @return 空白除去済み文字列
    *
    * @else
    * @brief Erase the tail blank characters of string
@@ -309,10 +313,11 @@ namespace coil
    * character.
    *
    * @param str The target tail blank characters of string for the erase
+   * @return The erased string
    *
    * @endif
    */
-  void eraseTailBlank(std::string& str);
+  std::string eraseTailBlank(std::string str) noexcept;
 
   /*!
    * @if jp
@@ -321,7 +326,7 @@ namespace coil
    * 与えられた文字列の先頭および末尾に存在する空白文字を削除する。
    * 空白文字として扱うのは' '(スペース)と'\\t'(タブ)。
    *
-   * @param str 先頭末尾空白文字削除処理文字列
+   * @return 空白除去済み文字列
    *
    * @else
    * @brief Erase the head blank and the tail blank characters of string
@@ -334,7 +339,7 @@ namespace coil
    *
    * @endif
    */
-  void eraseBothEndsBlank(std::string& str);
+  std::string eraseBothEndsBlank(std::string str) noexcept;
 
   /*!
    * @if jp

--- a/src/lib/coil/posix/coil/Routing.cpp
+++ b/src/lib/coil/posix/coil/Routing.cpp
@@ -149,15 +149,14 @@ namespace coil
 
     do
       {
-        char str[512];
-        fgets(str, 512, fp);
-        std::string line(str);
+        std::array<char, 512> str;
+        fgets(&str[0], str.size(), fp);
+        std::string line{coil::eraseHeadBlank(&str[0])};
 
         if (std::string::npos == line.find("inet ")) { continue; }
 
         line.erase(line.end() - 1);
-        coil::eraseHeadBlank(line);
-        coil::vstring vs(coil::split(line, " "));
+        coil::vstring vs{coil::split(line, " ")};
         if (vs.size() == 6)
           {
             ipaddr = vs[1];

--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -130,15 +130,13 @@ namespace coil
       Buf[size] = '\0';
       ReadFile(rPipe, Buf.get(), size, &len, nullptr);
 
-      out = coil::split(std::string(Buf.get()), "\n");
-
-      for(auto & o : out)
+      for(auto&& o : coil::split(std::string(Buf.get()), "\n"))
       {
           if (!o.empty() && o.back() == '\r')
           {
               o.erase(o.size() - 1);
           }
-          coil::eraseBothEndsBlank(o);
+          out.emplace_back(coil::eraseBothEndsBlank(std::move(o)));
       }
 
       delete lpcommand;

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1085,11 +1085,9 @@ namespace RTC
     template <class DataType>
     ReturnCode notifyIn(ConnectorInfo& info, DataType& typeddata)
     {
-        std::string marshaling_type = info.properties.getProperty("marshaling_type", "corba");
-        marshaling_type = info.properties.getProperty("in.marshaling_type", marshaling_type);
-
-        coil::eraseBothEndsBlank(marshaling_type);
-
+        std::string type = info.properties.getProperty("marshaling_type", "corba");
+        std::string marshaling_type{coil::eraseBothEndsBlank(
+          info.properties.getProperty("in.marshaling_type", type))};
         return notify(info, typeddata, marshaling_type);
     }
 
@@ -1116,11 +1114,9 @@ namespace RTC
     template <class DataType>
     ReturnCode notifyOut(ConnectorInfo& info, DataType& typeddata)
     {
-        std::string marshaling_type = info.properties.getProperty("marshaling_type", "corba");
-        marshaling_type = info.properties.getProperty("out.marshaling_type", marshaling_type);
-
-        coil::eraseBothEndsBlank(marshaling_type);
-
+        std::string type = info.properties.getProperty("marshaling_type", "corba");
+        std::string marshaling_type{coil::eraseBothEndsBlank(
+          info.properties.getProperty("out.marshaling_type", type))};
         return notify(info, typeddata, marshaling_type);
     }
     /*!

--- a/src/lib/rtm/InPortPullConnector.cpp
+++ b/src/lib/rtm/InPortPullConnector.cpp
@@ -51,9 +51,9 @@ namespace RTC
     m_consumer->setBuffer(m_buffer);
     m_consumer->setListener(info, &m_listeners);
 
-    m_marshaling_type = info.properties.getProperty("marshaling_type", "corba");
-    m_marshaling_type = info.properties.getProperty("in.marshaling_type", m_marshaling_type);
-    coil::eraseBothEndsBlank(m_marshaling_type);
+    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    m_marshaling_type = coil::eraseBothEndsBlank(
+      info.properties.getProperty("in.marshaling_type", type));
 
     onConnect();
   }

--- a/src/lib/rtm/InPortPushConnector.cpp
+++ b/src/lib/rtm/InPortPushConnector.cpp
@@ -58,10 +58,9 @@ namespace RTC
         m_sync_readwrite = true;
     }
 
-    m_marshaling_type = info.properties.getProperty("marshaling_type", "corba");
-    m_marshaling_type = info.properties.getProperty("in.marshaling_type", m_marshaling_type);
-    coil::eraseBothEndsBlank(m_marshaling_type);
-    
+    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    m_marshaling_type = coil::eraseBothEndsBlank(
+      info.properties.getProperty("in.marshaling_type", type));
 
     onConnect();
   }

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -240,10 +240,9 @@ namespace RTC
         if (begin_pos != std::string::npos && end_pos != std::string::npos &&
             begin_pos < end_pos)
           {
-            initfunc = itr.substr(begin_pos + 1, end_pos - (begin_pos + 1));
-            filename = itr.substr(0, begin_pos);
-            coil::eraseBothEndsBlank(initfunc);
-            coil::eraseBothEndsBlank(filename);
+            initfunc = coil::eraseBothEndsBlank(
+              itr.substr(begin_pos + 1, end_pos - (begin_pos + 1)));
+            filename = coil::eraseBothEndsBlank(itr.substr(0, begin_pos));
           }
         else
           {
@@ -292,10 +291,9 @@ namespace RTC
         if (begin_pos != std::string::npos && end_pos != std::string::npos &&
             begin_pos < end_pos)
           {
-            initfunc = mod.substr(begin_pos + 1, end_pos - (begin_pos + 1));
-            filename = mod.substr(0, begin_pos);
-            coil::eraseBothEndsBlank(initfunc);
-            coil::eraseBothEndsBlank(filename);
+            initfunc = coil::eraseBothEndsBlank(
+              mod.substr(begin_pos + 1, end_pos - (begin_pos + 1)));
+            filename = coil::eraseBothEndsBlank(mod.substr(0, begin_pos));
           }
         else
           {
@@ -1235,11 +1233,9 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 
 
 	{
-		coil::vstring lmpm_ = coil::split(m_config["manager.preload.modules"], ",");
-		for (auto & itr : lmpm_)
+		for (auto & itr : coil::split(m_config["manager.preload.modules"], ","))
 		{
-			std::string mpm_ = itr;
-			coil::eraseBothEndsBlank(mpm_);
+			std::string mpm_{coil::eraseBothEndsBlank(std::move(itr))};
 			if (mpm_.empty())
 			{
 				continue;
@@ -1499,8 +1495,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
         {
             if (i % 2 == 0)
             {
-                coil::eraseBothEndsBlank(opts[i]);
-                coil::vstring olist = coil::split(opts[i], " ");
+                coil::vstring olist{
+                  coil::split(coil::eraseBothEndsBlank(opts[i]), " ")};
                 std::copy(olist.begin(), olist.end(), std::back_inserter(args));
             }
             else
@@ -2570,12 +2566,9 @@ std::vector<coil::Properties> Manager::getLoadableModules()
   {
 	  RTC_TRACE(("Connection pre-connection: %s",
 		  m_config["manager.components.preconnect"].c_str()));
-	  std::vector<std::string> connectors;
-	  connectors = coil::split(m_config["manager.components.preconnect"], ",");
-      for (auto & connector : connectors)
+      for (auto&& connector : coil::split(m_config["manager.components.preconnect"], ","))
 	  {
-		  
-		  coil::eraseBothEndsBlank(connector);
+		  connector = coil::eraseBothEndsBlank(std::move(connector));
 		  if (connector.empty())
 		  {
 			  continue;
@@ -2662,11 +2655,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
               coil::Properties prop;
 
               for (auto & config : configs) {
-                  std::string key = config.first;
-                  std::string value = config.second;
-                  coil::eraseBothEndsBlank(key);
-                  coil::eraseBothEndsBlank(value);
-
+                  std::string key{coil::eraseBothEndsBlank(config.first)};
+                  std::string value{coil::eraseBothEndsBlank(config.second)};
                   prop["dataport." + key] = value;
               }
 
@@ -2723,11 +2713,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 			  coil::Properties prop;
 
 			  for (auto & config : configs) {
-				  std::string key = config.first;
-				  std::string value = config.second;
-				  coil::eraseBothEndsBlank(key);
-				  coil::eraseBothEndsBlank(value);
-
+				  std::string key{coil::eraseBothEndsBlank(std::move(config.first))};
+				  std::string value{coil::eraseBothEndsBlank(std::move(config.second))};
 				  prop["dataport." + key] = value;
 			  }
 
@@ -2759,13 +2746,10 @@ std::vector<coil::Properties> Manager::getLoadableModules()
   {
 	  RTC_TRACE(("Components pre-activation: %s",
 		  m_config["manager.components.preactivation"].c_str()));
-	  std::vector<std::string> comps;
-	  comps = coil::split(m_config["manager.components.preactivation"],
-		  ",");
 
-      for (auto & c : comps)
+      for (auto & c : coil::split(m_config["manager.components.preactivation"], ","))
 	  {
-		  coil::eraseBothEndsBlank(c);
+		  c = coil::eraseBothEndsBlank(std::move(c));
 		  if (!c.empty())
 		  {
 			  RTC::RTObject_ptr comp_ref;

--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -179,17 +179,10 @@ namespace RTC
               std::string::size_type pos(opt_arg.find(':'));
               if (pos != std::string::npos)
                 {
-                  std::string key = opt_arg.substr(0, pos);
-                  std::string value = opt_arg.substr(pos + 1);
-
-                  key = coil::unescape(key);
-                  coil::eraseHeadBlank(key);
-                  coil::eraseTailBlank(key);
-
-                  value = coil::unescape(value);
-                  coil::eraseHeadBlank(value);
-                  coil::eraseTailBlank(value);
-
+                  std::string key{coil::eraseBothEndsBlank(coil::unescape(
+                    opt_arg.substr(0, pos)))};
+                  std::string value{coil::eraseBothEndsBlank(coil::unescape(
+                    opt_arg.substr(pos + 1)))};
                   m_argprop[key] = value;
                 }
             }

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -937,8 +937,7 @@ namespace RTM
     ::RTC::RTCList_var crtcs = new ::RTC::RTCList();
 
     // check argument
-    std::string tmp(name);
-    coil::eraseHeadBlank(tmp);
+    std::string tmp{coil::eraseHeadBlank(name)};
     if (tmp.empty()) { return crtcs._retn(); }
 
     std::vector<RTC::RTObject_impl*> rtcs = m_mgr.getComponents();

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -46,10 +46,14 @@ namespace RTC
   ModuleManager::ModuleManager(coil::Properties& prop)
     : rtclog("ModuleManager"), m_properties(prop)
   {
-    m_configPath      = coil::split(prop[CONFIG_PATH], ",");
-    for_each(m_configPath.begin(), m_configPath.end(), coil::eraseHeadBlank);
-    m_loadPath        = coil::split(prop[MOD_LOADPTH], ",");
-    for_each(m_loadPath.begin(), m_loadPath.end(), coil::eraseHeadBlank);
+    for (auto path : coil::split(prop[CONFIG_PATH], ","))
+    {
+      m_configPath.emplace_back(coil::eraseHeadBlank(std::move(path)));
+    }
+    for (auto path : coil::split(prop[MOD_LOADPTH], ","))
+    {
+      m_loadPath.emplace_back(coil::eraseHeadBlank(std::move(path)));
+    }
     m_absoluteAllowed = coil::toBool(prop[ALLOW_ABSPATH], "yes", "no", false);
     m_downloadAllowed = coil::toBool(prop[ALLOW_URL], "yes", "no", false);
     m_initFuncSuffix  = prop[INITFUNC_SFX];
@@ -572,10 +576,8 @@ namespace RTC
             std::string::size_type pos(out.find(':'));
             if (pos != std::string::npos)
               {
-                  std::string key(out.substr(0, pos));
-                  coil::eraseBothEndsBlank(key);
-                  p[key] = out.substr(pos + 1);
-                  coil::eraseBothEndsBlank(p[key]);
+                  std::string key{coil::eraseBothEndsBlank(out.substr(0, pos))};
+                  p[key] = coil::eraseBothEndsBlank(out.substr(pos + 1));
               }
             
           }

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -155,24 +155,18 @@ namespace RTC_exp
       RTC::ReturnCode_t ret = ExecutionContextBase::bindComponent(rtc);
       ::RTC::Manager &mgr = ::RTC::Manager::instance();
       std::string threads_str = rtc->getProperties()["conf.default.members"];
-      coil::vstring threads = coil::split(threads_str, "|");
-
-      for (auto & thread : threads)
+      for (auto const & thread : coil::split(threads_str, "|"))
       {
           std::vector<RTC::LightweightRTObject_ptr> rtcs;
-          coil::vstring members = coil::split(thread, ",");
-
-          for (auto member : members)
+          for (auto&& member : coil::split(thread, ","))
           {
-              coil::eraseBothEndsBlank(member);
-
+              member =  coil::eraseBothEndsBlank(std::move(member));
               if (member.empty())
               {
                   continue;
               }
               else
               {
-                  
                   RTC::RTObject_impl* comp = mgr.getComponent(member.c_str());
                   if (comp == nullptr)
                   {

--- a/src/lib/rtm/OutPortPullConnector.cpp
+++ b/src/lib/rtm/OutPortPullConnector.cpp
@@ -59,9 +59,9 @@ namespace RTC
         m_sync_readwrite = true;
     }
 
-    m_marshaling_type = info.properties.getProperty("marshaling_type", "corba");
-    m_marshaling_type = info.properties.getProperty("out.marshaling_type", m_marshaling_type);
-    coil::eraseBothEndsBlank(m_marshaling_type);
+    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    m_marshaling_type = coil::eraseBothEndsBlank(
+      info.properties.getProperty("out.marshaling_type", type));
 
     onConnect();
   }

--- a/src/lib/rtm/OutPortPushConnector.cpp
+++ b/src/lib/rtm/OutPortPushConnector.cpp
@@ -60,9 +60,8 @@ namespace RTC
     m_publisher->setBuffer(m_buffer);
     m_publisher->setListener(m_profile, &m_listeners);
 
-    m_marshaling_type = info.properties.getProperty("marshaling_type", "corba");
-    m_marshaling_type = info.properties.getProperty("out.marshaling_type", m_marshaling_type);
-    coil::eraseBothEndsBlank(m_marshaling_type);
+    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    m_marshaling_type = coil::eraseBothEndsBlank(info.properties.getProperty("out.marshaling_type", type));
 
     onConnect();
   }

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -683,7 +683,7 @@ namespace RTC
     for (auto & member : m_members)
       {
           coil::replaceString(member, "|", "");
-          coil::eraseBothEndsBlank(member);
+          member = coil::eraseBothEndsBlank(std::move(member));
 
         RTObject_impl* rtc = mgr.getComponent(member.c_str());
         if (rtc == nullptr) {


### PR DESCRIPTION
## Description of the Change

3つの関数 erase[Head|Tail|BothEnds]Blank() を C++11 対応に置き換える。
効果は #596  と同様。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
