### PR TITLE
Modernize replaceString().

### DIFF
--- a/src/ext/local_service/nameservice_file/FileNameservice.cpp
+++ b/src/ext/local_service/nameservice_file/FileNameservice.cpp
@@ -314,8 +314,8 @@ namespace RTM
       if (fs == "flat")
         {
           RTC_DEBUG(("file_structure = flat"));
-          std::string d(m_profile.properties["context_delimiter"]);
-          coil::replaceString(ns_path, "/", d);
+          std::string const& d(m_profile.properties["context_delimiter"]);
+          ns_path = coil::replaceString(std::move(ns_path), "/", d);
           pathstring += ns_path;
         }
       else if (fs == "tree")

--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -142,8 +142,7 @@ namespace RTC
   
   void FluentBitStream::write(int level, const std::string &name, const std::string &date, const std::string &mes)
   {
-    std::string message = mes;
-    coil::replaceString(message, "\"", "\'");
+    std::string message{coil::replaceString(mes, "\"", "\'")};
     std::streamsize insize(message.size());
     for (std::streamsize i(0); i < insize; ++i, ++m_pos)
       {

--- a/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
@@ -140,8 +140,7 @@ namespace RTC
         coil::vstring typelist = coil::split(data, ":");
         if (typelist.size() == 3)
         {
-            m_dataType = typelist[1];
-            coil::replaceString(m_dataType, "/", "::");
+            m_dataType = coil::replaceString(std::move(typelist[1]), "/", "::");
         }
         else
         {

--- a/src/ext/transport/OpenSplice/OpenSpliceMessageInfo.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceMessageInfo.cpp
@@ -47,17 +47,14 @@ namespace RTC
             {
                 return "";
             }
-
-            coil::replaceString(strlist[1], "/", "::");
-            return strlist[1];
+            return coil::replaceString(std::move(strlist[1]), "/", "::");
         }
 
         std::string idl_path() override
         {
             std::string path = coil::replaceEnv(IDLPATH::idlpath);
-            coil::replaceString(path, "//", "/");
-            coil::replaceString(path, "\\\\", "\\");
-            return path;
+            path = coil::replaceString(std::move(path), "//", "/");
+            return coil::replaceString(std::move(path), "\\\\", "\\");
         }
     };
 

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -333,21 +333,17 @@ namespace coil
    * @brief Replace string
    * @endif
    */
-  unsigned int replaceString(std::string& str, const std::string& from,
-                     const std::string& to)
+  std::string replaceString(std::string str, const std::string& from,
+                            const std::string& to)
   {
-    std::string::size_type pos(0);
-    unsigned int cnt(0);
-
-    while (pos != std::string::npos)
+    if (from.empty()) { return str; }
+    for (std::string::size_type pos{str.find(from, 0)};
+         pos != std::string::npos;
+         pos = str.find(from, pos + to.length()))
       {
-        pos = str.find(from, pos);
-        if (pos == std::string::npos) break;
-        str.replace(pos, from.size(), to);
-        pos += to.size();
-        ++cnt;
+        str.replace(pos, from.length(), to);
       }
-    return cnt;
+    return str;
   }
 
   /*!

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -373,6 +373,7 @@ namespace coil
    * @param str 置き換え処理対象文字列
    * @param from 置換元文字
    * @param to 置換先文字
+   * @return 置き換え後文字列
    *
    * @else
    * @brief Replace string
@@ -382,11 +383,12 @@ namespace coil
    * @param str The target characters of string for replacement processing
    * @param from Characters of replacement source
    * @param to Characters of replacement destination
+   * @return The replaced string.
    *
    * @endif
    */
-  unsigned int replaceString(std::string& str, const std::string& from,
-                             const std::string& to);
+  std::string replaceString(std::string str, const std::string& from,
+                            const std::string& to);
 
   /*!
    * @if jp

--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -1095,9 +1095,8 @@ namespace CORBA_RTCUtil
       {
         return RTC::PortService::_nil();
       }
-    std::string rtc_name = port_name;
-    coil::replaceString(rtc_name, "." + p.back(), "");
-    RTC::RTCList rtcs = nm->string_to_component(rtc_name);
+    RTC::RTCList rtcs = nm->string_to_component(
+      coil::replaceString(port_name, "." + p.back(), ""));
 
     if (rtcs.length() < 1)
       {

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2586,8 +2586,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 				  ports.push_back(param_itr.second);
 				  continue;
 			  }
-			  std::string tmp = param_itr.first;
-			  coil::replaceString(tmp, "port", "");
+              std::string tmp{coil::replaceString(param_itr.first, "port", "")};
               std::string::size_type pos = param_itr.first.find("port");
 
 			  int val = 0;
@@ -2945,10 +2944,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 		  {
 			  if (bl[j].binding_type != CosNaming::nobject) { continue; }
 			  std::string tmp(cns.toString(bl[j].binding_name));
-			  std::string nspath;
-			  nspath = "/" + nsname + "/" + tmp;
+			  std::string nspath{coil::replaceString('/' + nsname + '/' + tmp, "\\", "")};
 			  // ### TODO: All escape characteres should be removed. ###
-			  coil::replaceString(nspath, "\\", "");
 			  CORBA::Object_var obj = cns.resolveStr(nspath.c_str());
 			  RTC::PortService_var portsvc = RTC::PortService::_narrow(obj);
 			  if (CORBA::is_nil(portsvc)) { continue; }

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1545,9 +1545,7 @@ namespace RTM
       size_t pos = mgrname.find("manager_");
       if (pos != std::string::npos)
         {
-          std::string id = mgrname;
-          coil::replaceString(id, "manager_", "");
-          
+          std::string id{coil::replaceString(mgrname, "manager_", "")};
           int val = 0;
           if (coil::stringTo<int>(val, id.c_str()))
             {

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -364,8 +364,7 @@ namespace RTC
 
     while (it != it_end)
       {
-        std::string f((*it) + "/" + fname);
-        coil::replaceString(f, "//", "/");
+        std::string f{coil::replaceString((*it) + "/" + fname, "//", "/")};
         if (fileExist(f))
           {
             return f;
@@ -495,9 +494,8 @@ namespace RTC
         // reformat file path and remove cached files
         for (auto & f : flist)
           {
-            coil::replaceString(f, "\\", "/");
-            coil::replaceString(f, "//", "/");
-            addNewFile(f, modules);
+            addNewFile(coil::replaceString(coil::replaceString(
+                         std::move(f), "\\", "/"), "//", "/"), modules);
           }
       }
       std::sort(modules.begin(), modules.end());

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -682,9 +682,7 @@ namespace RTC
     ::SDOPackage::SDOList sdos;
     for (auto & member : m_members)
       {
-          coil::replaceString(member, "|", "");
-          member = coil::eraseBothEndsBlank(std::move(member));
-
+        member = coil::eraseBothEndsBlank(coil::replaceString(std::move(member), "|", ""));
         RTObject_impl* rtc = mgr.getComponent(member.c_str());
         if (rtc == nullptr) {
           continue;

--- a/src/lib/rtm/SdoServiceAdmin.cpp
+++ b/src/lib/rtm/SdoServiceAdmin.cpp
@@ -500,11 +500,8 @@ namespace RTC
 
   std::string SdoServiceAdmin::ifrToKey(std::string& ifr)
   {
-    coil::vstring ifrvstr = coil::split(ifr, ":");
-    std::string str{coil::toLower(std::move(ifrvstr[1]))};
-    coil::replaceString(str, ".", "_");
-    coil::replaceString(str, "/", ".");
-    return str;
+    return coil::replaceString(coil::replaceString(coil::toLower(
+             coil::split(ifr, ":")[1]), ".", "_"), "/", ".");
   }
 
 

--- a/src/lib/rtm/SystemLogger.cpp
+++ b/src/lib/rtm/SystemLogger.cpp
@@ -111,9 +111,12 @@ namespace RTC
    */
   void Logger::setDateFormat(const char* format)
   {
-    m_dateFormat = std::string(format);
-    m_msEnable = coil::replaceString(m_dateFormat, "%Q", "#m#");
-    m_usEnable = coil::replaceString(m_dateFormat, "%q", "#u#");
+    std::string fmt(format);
+    m_msEnable = std::string::npos != fmt.find("%Q");
+    m_usEnable = std::string::npos != fmt.find("%q");
+    if (m_msEnable){ fmt = coil::replaceString(std::move(fmt), "%Q", "#m#"); }
+    if (m_usEnable){ fmt = coil::replaceString(std::move(fmt), "%q", "#u#"); }
+    m_dateFormat = std::move(fmt);
   }
 
   void Logger::setClockType(const std::string& clocktype)
@@ -168,19 +171,19 @@ namespace RTC
 #endif
 
     std::string fmt(buf);
-    if (m_msEnable > 0)
+    if (m_msEnable)
       {
         auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(tm - sec);
         std::stringstream msec("");
         msec << std::setfill('0') << std::setw(3) << ms.count();
-        coil::replaceString(fmt, "#m#", msec.str());
+        fmt = coil::replaceString(std::move(fmt), "#m#", msec.str());
       }
-    if (m_usEnable > 0)
+    if (m_usEnable)
       {
         auto us = std::chrono::duration_cast<std::chrono::microseconds>(tm - sec);
         std::stringstream usec("");
         usec << std::setfill('0') << std::setw(6) << us.count();
-        coil::replaceString(fmt, "#u#", usec.str());
+        fmt = coil::replaceString(std::move(fmt), "#u#", usec.str());
       }
 
     return fmt;

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -500,8 +500,8 @@ namespace RTC
     static const char* const m_levelString[];
     static const char* const m_levelOutputString[];
     static const char* const m_levelColor[];
-    int m_msEnable{0};
-    int m_usEnable{0};
+    bool m_msEnable{false};
+    bool m_usEnable{false};
   };
 
 

--- a/utils/rtcprof/rtcprof.cpp
+++ b/utils/rtcprof/rtcprof.cpp
@@ -40,9 +40,8 @@ int main(int argc, char* argv[])
   // notice: coil::dirname brakes original string
   // 
   // file name with full path
-  std::string fullname(argv[1]);
+  std::string fullname{coil::replaceString(argv[1], "\\", "/")};
   // directory name
-  coil::replaceString(fullname, "\\", "/");
   std::string dirname(coil::dirname(const_cast<char*>(fullname.c_str())));
   // basename
   std::string basename(coil::basename(fullname.c_str()));


### PR DESCRIPTION
## Description of the Change

replaceString() を C++11 対応するとともに、 from = "" の時にうまく動かないバグを修正する。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
