### PR TITLE
Modernize getlinePortable().

### DIFF
--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -343,9 +343,7 @@ namespace coil
 
     while (!inStream.eof())
       {
-        std::string tmp = std::string();
-        coil::getlinePortable(inStream, tmp);
-        tmp = coil::eraseHeadBlank(std::move(tmp));
+        std::string tmp{coil::eraseHeadBlank(coil::getlinePortable(inStream))};
 
         // Skip comments or empty lines
         if (tmp.empty())

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -118,7 +118,7 @@ namespace coil
    * @brief Read a line from input stream
    * @endif
    */
-  int getlinePortable(std::istream& istr, std::string& line)
+  std::string getlinePortable(std::istream& istr)
   {
     char c;
     std::stringstream s;
@@ -142,8 +142,7 @@ namespace coil
             s << c;
           }
       }
-    line = s.str();
-    return static_cast<int>(line.size());
+    return s.str();
   }
 
   /*!

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -131,9 +131,7 @@ namespace coil
    * もしくは混在していてもよい。
    *
    * @param istr 入力ストリーム
-   * @param line 読み込んだ文字列を格納する変数
-   *
-   * @return 改行文字を除く読み込んだ文字列の長さ
+   * @return 読み込んだ文字列を格納する変数
    *
    * @else
    * @brief Read a line from input stream
@@ -142,13 +140,11 @@ namespace coil
    * UNIX, Windows or mixed line feed code is acceptable.
    *
    * @param istr The input stream.
-   * @param line The output variable to store string to be read.
-   *
-   * @return The length of read string except line feed character.
+   * @return The string to be read.
    *
    * @endif
    */
-  int getlinePortable(std::istream& istr, std::string& line);
+  std::string getlinePortable(std::istream& istr);
 
   /*!
    * @if jp


### PR DESCRIPTION
## Description of the Change

getlinePortable() の戻り値を std::string に変更する。
他の stringutils の API と親和性が上がったくらいで、処理速度は変わらない。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
