### PR TITLE
Modernize unescape().

### DIFF
--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -375,7 +375,7 @@ namespace coil
 
         std::string key, invalue;
         splitKeyValue(pline, key, invalue);
-        setProperty(eraseBothEndsBlank(coil::unescape(key)),
+        setProperty(eraseBothEndsBlank(coil::unescape(std::move(key))),
                     eraseBothEndsBlank(std::move(invalue)));
         pline.clear();
       }

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -206,61 +206,42 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief 文字列をアンエスケープするためのFunctor
-   * @else
-   * @brief Functor to unescape string
-   * @endif
-   */
-  struct unescape_functor
-  {
-    unescape_functor()  {}
-    void operator()(char c)
-    {
-      if (c == '\\')
-        {
-          ++count;
-          if ((count % 2) == 0)
-            {
-              str.push_back(c);
-            }
-        }
-      else
-        {
-          if (count > 0 && ((count % 2) != 0))
-            {
-              count = 0;
-              if      (c == 't')  str.push_back('\t');
-              else if (c == 'n')  str.push_back('\n');
-              else if (c == 'f')  str.push_back('\f');
-              else if (c == 'r')  str.push_back('\r');
-              else if (c == '\"') str.push_back('\"');
-              else if (c == '\'') str.push_back('\'');
-              else
-                {
-                  str.push_back(c);
-                }
-            }
-          else
-            {
-              count = 0;
-              str.push_back(c);
-            }
-        }
-    }
-    std::string str;
-    int count{0};
-  };
-
-  /*!
-   * @if jp
    * @brief 文字列のエスケープを戻す
    * @else
    * @brief Unescape string
    * @endif
    */
-  std::string unescape(const std::string& str)
+  std::string unescape(std::string str) noexcept
   {
-    return for_each(str.begin(), str.end(), unescape_functor()).str;
+    std::string::size_type wp{0};
+    bool is_escaped{false};
+
+    for(std::string::size_type rp{0}; rp < str.length(); ++rp)
+      {
+        if (!is_escaped)
+          {
+            if (str[rp] != '\\')
+              str[wp++] = str[rp];
+            else
+              is_escaped = true;
+          }
+        else
+          {
+            is_escaped = false;
+            switch (str[rp])
+            {
+              case 't':  str[wp++] = '\t'; break;
+              case 'n':  str[wp++] = '\n'; break;
+              case 'f':  str[wp++] = '\f'; break;
+              case 'r':  str[wp++] = '\r'; break;
+              case '\"': str[wp++] = '\"'; break;
+              case '\'': str[wp++] = '\''; break;
+              default: str[wp++] = str[rp]; break;
+            }
+          }
+      }
+    str.resize(wp);
+    return str;
   }
 
   /*!

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -220,7 +220,9 @@ namespace coil
    * "\f" -> FF <br>
    * "\"" -> "  <br>
    * "\'" -> '  <br>
-   * ※エスケープ処理の完全な逆変換にはなっていないため、注意が必要。
+   * "\\" -> \  <br>
+   * - エスケープ処理の完全な逆変換にはなっていないため、注意が必要。
+   * - 文字列の終端が "\\" の場合は単に削除される。
    *
    * @param str アンエスケープ処理対象文字列
    *
@@ -237,7 +239,9 @@ namespace coil
    * "\f" -> FF <br>
    * "\"" -> "  <br>
    * "\'" -> '  <br>
-   * Note: This is not complete inversion of the escape processing.
+   * "\\" -> \  <br>
+   * Note1: This is not complete inversion of the escape processing.
+   * Note2: If the end of the string is "\\", remove it.
    *
    * @param str The target string for the unescape
    *
@@ -245,7 +249,7 @@ namespace coil
    *
    * @endif
    */
-  std::string unescape(const std::string& str);
+  std::string unescape(std::string str) noexcept;
 
   /*!
    * @if jp


### PR DESCRIPTION
## Description of the Change

* coil::unescape() を C++11 対応に変更する。
  メモリ確保しないように引数の直接書き換えを行うことで高速化する。また、例外もない (noexcept) 。
*  実装とドキュメントが違った部分を修正する。
   \\ も unescape されていた。
   また、終端が \\ の場合は、単に削除されていた。
  ※ 今回の変更でこれらの動作が変わったわけではない。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
