### PR TITLE
Modernize escape().

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -169,31 +169,6 @@ namespace coil
 
   /*!
    * @if jp
-   * @brief 文字列をエスケープするためのFunctor
-   * @else
-   * @brief Functor to escape string
-   * @endif
-   */
-  struct escape_functor
-  {
-    escape_functor() = default;
-    void operator()(const char c)
-    {
-      if      (c == '\t')  str += "\\t";
-      else if (c == '\n')  str += "\\n";
-      else if (c == '\f')  str += "\\f";
-      else if (c == '\r')  str += "\\r";
-      else if (c == '\\')  str += "\\\\";
-      else
-        {
-          str.push_back(c);
-        }
-    }
-    std::string str;
-  };
-
-  /*!
-   * @if jp
    * @brief 文字列をエスケープする
    * @else
    * @brief Escape string
@@ -201,8 +176,21 @@ namespace coil
    */
   std::string escape(const std::string& str)
   {
-    return for_each(str.begin(), str.end(), escape_functor()).str;
-  }
+    std::string ret;
+    ret.reserve(str.length()*2);
+    std::for_each(str.begin(), str.end(), [&ret](char c) {
+      switch (c)
+      {
+        case '\t': ret += "\\t"; break;
+        case '\n': ret += "\\n"; break;
+        case '\f': ret += "\\f"; break;
+        case '\r': ret += "\\r"; break;
+        case '\\': ret += "\\\\"; break;
+        default: ret += c; break;
+      }
+    });
+    return ret;
+   }
 
   /*!
    * @if jp

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -184,6 +184,7 @@ namespace coil
    * LF -> "\n" <br>
    * CR -> "\r" <br>
    * FF -> "\f" <br>
+   * \  -> "\\" <br>
    * シングルクオート、ダブルクオートについてはとくに処理はしない。
    *
    * @param str エスケープ処理対象文字列
@@ -199,6 +200,7 @@ namespace coil
    * LF -> "\n" <br>
    * CR -> "\r" <br>
    * FF -> "\f" <br>
+   * \  -> "\\" <br>
    * Single quote and double quote are not processed.
    *
    * @param str The target string for the escape


### PR DESCRIPTION
## Description of the Change

* coil::escape() を C++11 対応に変更する。
  functor をラムダに変更。
*  実装とドキュメントが違った部分を修正する。
   \\ も escape されていた。
  ※ 今回の変更で動作が変わったわけではない。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  