### PR TITLE
pkg_install_ubuntu.shでのOpenRTMのGPG公開鍵登録処理変更

### DIFF
--- a/scripts/pkg_install_ubuntu.sh
+++ b/scripts/pkg_install_ubuntu.sh
@@ -312,7 +312,7 @@ create_srclist () {
 # ソースリスト更新関数の定義
 #---------------------------------------
 update_source_list () {
-  rtmsite=`grep "$openrtm_repo" /etc/apt/sources.list`
+  rtmsite=`apt-cache policy | grep "http://$reposerver"`
   if test "x$rtmsite" = "x" ; then
     echo $msg4
     echo $msg5
@@ -327,7 +327,7 @@ update_source_list () {
     fi
   fi
   # 公開鍵登録
-  apt-key adv --keyserver keys.gnupg.net --recv-keys 4BCE106E087AFAC0
+  wget -O- --no-check-certificate https://openrtm.org/pub/openrtm.key | apt-key add -
 }
 
 #----------------------------------------


### PR DESCRIPTION
close #612 

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Description of the Change

pkg_install_ubuntu.sh を修正した。

- GPG公開鍵の取得・登録処理を変更
  - キーサーバから取得する処理が動作しない環境があるため、https://openrtm.org/pub/openrtm.key に配置した鍵を使うように変更した

- /etc/apt/sources.list への登録済み判定を変更
  - grepの文字列検索だけで判断すると、openrtm.org がコメントアウトされている場合も登録済みと判定してしまい、openrtm パッケージのインストールに失敗するケースに対応した
  - 登録済みかどうかは apt-cache policy の結果から判断するように変更した
  - 登録されていれば、下記が戻ってくる（Ubuntu18.04の場合）
```
$ apt-cache policy | grep "http://openrtm.org"
 500 http://openrtm.org/pub/Linux/ubuntu bionic/main amd64 Packages
```



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [ ] Did you succeed the build?  （ソースビルドは行っていない）
- 下記環境で pkg_install_ubuntu.sh を実行してopenrtmパッケージのインストール動作を確認した
- Vagrant環境
  - OpenRTMのGPG公開鍵が登録済、未登録時の各動作
  - /etc/apt/sources.list で openrtm.org が登録時、コメントアウト時の各動作

- Docker環境
  - 下記Dockerfile使用
```
FROM ubuntu:18.04
RUN set -x \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
  wget\
  gnupg\
  && wget --no-check-certificate https://raw.githubusercontent.com/n-kawauchi/OpenRTM-aist/change_gpg_key_regist/scripts/pkg_install_ubuntu.sh -O pkg_install_ubuntu.sh
RUN chmod a+x ./pkg_install_ubuntu.sh&& \
    ./pkg_install_ubuntu.sh -l c++ -d --yes
```
