### PR TITLE
[compat, bugfix] fix the wrong argument of removePostFsmActionListener

### DIFF
--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.cpp
@@ -812,7 +812,7 @@ namespace RTC
         removePostFsmActionListener(POST_ON_EXIT,
                                     m_fsmaction.postOnFsmExitListener);
       m_rtobj->
-        removePostFsmActionListener(POST_ON_EXIT,
+        removePostFsmActionListener(POST_ON_STATE_CHANGE,
                                     m_fsmaction.postOnFsmStateChangeListener);
   }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#599 


## Description of the Change

- 実引数の指定が正しくないため修正する
  - POST_ON_EXIT から POST_ON_STATE_CHANGE に変更

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
