### PR TITLE
Fix bugs of path-check functions.

### DIFF
--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -556,6 +556,7 @@ namespace coil
   bool isURL(const std::string& str);
   bool isIPv4(const std::string& str);
   bool isIPv6(const std::string& str);
+  bool isIPPort(const std::string& str);
 
   /*!
    * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
stringutil の下記関数にバグがある。

* isAbsolutePath()
   - 短い文字列の場合に範囲外アクセスが発生する。
* isURL()
   - 短い文字列の場合に範囲外アクセスが発生する。
* isIPv4()
  - ポートの表現が正しいことを判定していない
  - ポートが記述されると IP が正しく判定されない
  - 8進表記を true とする場合がある （はじく場合もある）
    "011.011.011.011" exp=(false)
    "011.011.011.0143" exp=(false)
    "011.011.0143.011" exp=(false)
* isIPv6()
  - 空文字列を渡すと無限ループする。
  - "]:" を含む文字列の場合に範囲外アクセスが発生することがある。
  - ポートの表現が正しいことを判定していない
  - 省略記法は受け付けないようなコメントがあるが、 true となる
    "::1" exp=(false)
    ”1::" exp=(false)
    "1:1:1:1::1:1" exp=(false)
  - ただの文字列で true となる
    "abcd" exp=(false)
  - セパレータだけで true となる
    ":::::::" exp=(false)
  - 部分しかない壊れた表現でも true となる
    "1:2:3:4:5:6:7" exp=(false)

## Description of the Change

上記の問題をすべて修正する。
isIPv4(), isIPv6() でのポート判定はするべきなのかどうかは迷うが、
現在の使用箇所をみると判定することが正しくないためチェックしないようにする。
代わりに参考として isIPPort() を用意するので必要ならここから正規表現を流用すれば良い。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
