### PR TITLE
Use make_move_iterator() and emplace_back().

### DIFF
--- a/examples/Analyzer/Analyzer.cpp
+++ b/examples/Analyzer/Analyzer.cpp
@@ -185,7 +185,7 @@ RTC::ReturnCode_t Analyzer::onExecute(RTC::UniqueId  /*ec_id*/)
 
 	{
 		std::lock_guard<std::mutex> guard(m_mu);
-		m_datalist.push_back(m_out);
+		m_datalist.emplace_back(m_out);
 	}
 	std::this_thread::sleep_until(start + m_sleep_time);
 

--- a/examples/SeqIO/SeqIn.cpp
+++ b/examples/SeqIO/SeqIn.cpp
@@ -189,16 +189,16 @@ RTC::ReturnCode_t SeqIn::onExecute(RTC::UniqueId  /*ec_id*/)
   std::vector<int> in_size;
   std::vector<int>::iterator it;
   in_size.reserve(10);
-  in_size.push_back(d_size);
-  in_size.push_back(f_size);
-  in_size.push_back(l_size);
-  in_size.push_back(s_size);
-  in_size.push_back(o_size);
-  in_size.push_back(ds_size);
-  in_size.push_back(fs_size);
-  in_size.push_back(ls_size);
-  in_size.push_back(ss_size);
-  in_size.push_back(os_size);
+  in_size.emplace_back(d_size);
+  in_size.emplace_back(f_size);
+  in_size.emplace_back(l_size);
+  in_size.emplace_back(s_size);
+  in_size.emplace_back(o_size);
+  in_size.emplace_back(ds_size);
+  in_size.emplace_back(fs_size);
+  in_size.emplace_back(ls_size);
+  in_size.emplace_back(ss_size);
+  in_size.emplace_back(os_size);
   
   it = std::max_element(in_size.begin(), in_size.end());
   

--- a/examples/SimpleService/MyServiceConsumer.cpp
+++ b/examples/SimpleService/MyServiceConsumer.cpp
@@ -113,7 +113,7 @@ RTC::ReturnCode_t MyServiceConsumer::onExecute(RTC::UniqueId  /*ec_id*/)
       std::cout << " get_echo_history : get input messsage history." << std::endl;
       std::cout << " get_value_history: get input value history." << std::endl;
       std::cout << "> ";
-      
+
       std::string args;
       std::string::size_type pos;
       std::vector<std::string> argv;
@@ -122,18 +122,18 @@ RTC::ReturnCode_t MyServiceConsumer::onExecute(RTC::UniqueId  /*ec_id*/)
 #else
       std::getline(std::cin, args);
 #endif
-      
+
       pos = args.find_first_of(' ');
       if (pos != std::string::npos)
-	{
-	  argv.push_back(args.substr(0, pos));
-	  argv.push_back(args.substr(++pos));
-	}
+        {
+          argv.emplace_back(args.substr(0, pos));
+          argv.emplace_back(args.substr(++pos));
+        }
       else
-	{
-	  argv.push_back(args);
-	}
-      
+        {
+          argv.emplace_back(std::move(args));
+        }
+
       if (async_echo != nullptr && async_echo->finished())
         {
           std::cout << "echo() finished: " <<  m_result << std::endl;

--- a/src/ext/local_service/nameservice_file/FileNameservice.cpp
+++ b/src/ext/local_service/nameservice_file/FileNameservice.cpp
@@ -196,7 +196,7 @@ namespace RTM
                 }
               RTC_INFO(("RTC %s's IOR has been successfully registered: %s",
                         filename.string().c_str(), filepath.string().c_str()));
-              m_files.push_back(filepath.string());
+              m_files.emplace_back(filepath.string());
             }
           catch (...)
             {
@@ -390,7 +390,7 @@ namespace RTM
       CORBA::String_var ior =
         RTC::Manager::instance().getORB()->object_to_string(objref);
       coil::vstring ns_info;
-      ns_info.push_back(static_cast<const char*>(ior));
+      ns_info.emplace_back(static_cast<const char*>(ior));
       m_fns.onRegisterNameservice(name, ns_info);
     }
     

--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -57,7 +57,7 @@ namespace RTC
     // Default lib-input setting
     FlbHandler flbhandler = flb_input(s_flbContext, (char*)"lib", nullptr);
     flb_input_set(s_flbContext, flbhandler, "tag", prop.getName(), NULL);
-    m_flbIn.push_back(flbhandler);
+    m_flbIn.emplace_back(flbhandler);
 
     const std::vector<coil::Properties*>& leaf(prop.getLeaf());
 
@@ -99,7 +99,7 @@ namespace RTC
     FlbHandler flbout = flb_output(s_flbContext,
                                    (char*)plugin.c_str(), nullptr);
 
-    m_flbOut.push_back(flbout);
+    m_flbOut.emplace_back(flbout);
     const std::vector<Properties*>& leaf = prop.getLeaf();
     for(auto & lprop : leaf)
       {
@@ -115,7 +115,7 @@ namespace RTC
     
     FlbHandler flbin = flb_input(s_flbContext,
                                  (char*)plugin.c_str(), nullptr);
-    m_flbIn.push_back(flbin);
+    m_flbIn.emplace_back(flbin);
     const std::vector<Properties*>& leaf = prop.getLeaf();
     for(auto & lprop : leaf)
       {

--- a/src/ext/sdo/observer/ComponentObserverConsumer.cpp
+++ b/src/ext/sdo/observer/ComponentObserverConsumer.cpp
@@ -460,7 +460,7 @@ namespace RTC
                                                     m_inportInterval);
         inport->addConnectorDataListener(ON_RECEIVED,
                                                     action);
-        m_recievedactions.push_back(action);
+        m_recievedactions.emplace_back(action);
 
       }
     const std::vector<OutPortBase*>& outports = m_rtobj->getOutPorts();
@@ -472,7 +472,7 @@ namespace RTC
                                                     m_outportInterval);
         outport->addConnectorDataListener(ON_SEND,
                                               action);
-        m_sendactions.push_back(action);
+        m_sendactions.emplace_back(action);
       }
   }
 

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.h
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.h
@@ -632,7 +632,7 @@ namespace RTC
       
       for(CORBA::ULong i=0;i < data.data.length();i++)
       {
-        msg.data.push_back(static_cast<convertedType>(data.data[i]));
+        msg.data.emplace_back(static_cast<convertedType>(data.data[i]));
       }
       
       

--- a/src/ext/transport/ROSTransport/ROSSerializer.h
+++ b/src/ext/transport/ROSTransport/ROSSerializer.h
@@ -393,7 +393,7 @@ namespace RTC
       MessageType msg;
       for(size_t i=0;i < data.data.length();i++)
       {
-        msg.data.push_back(static_cast<convertedType>(data.data[static_cast<CORBA::ULong>(i)]));
+        msg.data.emplace_back(static_cast<convertedType>(data.data[static_cast<CORBA::ULong>(i)]));
       }
       
       

--- a/src/ext/transport/ROSTransport/ROSTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.cpp
@@ -446,7 +446,7 @@ namespace RTC
         {
           subscriber->connectTCP(caller_id, topic, xmlrpc_uri);
         }
-        new_.push_back(xmlrpc_uri);
+        new_.emplace_back(xmlrpc_uri);
       }
       
       for(auto & old_uri : old_)
@@ -492,7 +492,7 @@ namespace RTC
 
     if(!existPublisher(publisher))
     {
-      m_publishers.push_back(publisher);
+      m_publishers.emplace_back(publisher);
     }
   }
 
@@ -515,7 +515,7 @@ namespace RTC
   {
     if(!existSubscriber(subscriber))
     {
-      m_subscribers.push_back(subscriber);
+      m_subscribers.emplace_back(subscriber);
     }
     
   }

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -202,7 +202,7 @@ namespace coil
 
       while (it != it_end)
         {
-          idlist.push_back(it->first);
+          idlist.emplace_back(it->first);
           ++it;
         }
       return idlist;
@@ -404,7 +404,7 @@ namespace coil
       std::lock_guard<std::mutex> guard(m_mutex);
       for (ObjectMapIt it(m_objects.begin()); it != m_objects.end(); ++it)
         {
-          objects.push_back(it->first);
+          objects.emplace_back(it->first);
         }
       return objects;
     }

--- a/src/lib/coil/common/coil/Logger.cpp
+++ b/src/lib/coil/common/coil/Logger.cpp
@@ -145,7 +145,7 @@ namespace coil
         std::vector<LogStreamBuffer*> buffs;
         for(auto & s : m_streams)
         {
-            buffs.push_back(s.stream_);
+            buffs.emplace_back(s.stream_);
         }
         return buffs;
     }

--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -260,7 +260,7 @@ namespace coil
           {
             next = new Properties(k.c_str());
             next->root = curr;
-            curr->leaf.push_back(next);
+            curr->leaf.emplace_back(next);
           }
         curr = next;
       }
@@ -291,7 +291,7 @@ namespace coil
           {
             next = new Properties(k.c_str());
             next->root = curr;
-            curr->leaf.push_back(next);
+            curr->leaf.emplace_back(next);
           }
         curr = next;
       }
@@ -641,12 +641,12 @@ namespace coil
         if ((str[end_it] == delim) && !coil::isEscaped(str, end_it))
           {
             // substr(0, i) returns 0...(i-1) chars.
-            value.push_back(str.substr(begin_it, end_it - begin_it));
+            value.emplace_back(str.substr(begin_it, end_it - begin_it));
             begin_it = end_it + 1;
           }
         ++end_it;
       }
-    value.push_back(str.substr(begin_it, end_it));
+    value.emplace_back(str.substr(begin_it, end_it));
     return true;
   }
 
@@ -702,7 +702,7 @@ namespace coil
       }
     else
       {
-        names.push_back(curr_name);
+        names.emplace_back(curr_name);
       }
     return;
   }
@@ -856,16 +856,16 @@ namespace coil
 
   void Properties::_dump(std::vector<std::string>& out, const Properties& curr, int index) const
   {
-      if (index != 0) out.push_back(indent(index) + "- " + curr.name);
+      if (index != 0) out.emplace_back(indent(index) + "- " + curr.name);
       if (curr.leaf.empty())
       {
           if (!curr.set_value)
           {
-              out.push_back(": " + curr.default_value);
+              out.emplace_back(": " + curr.default_value);
           }
           else
           {
-              out.push_back(": " + curr.value);
+              out.emplace_back(": " + curr.value);
           }
           return;
       }

--- a/src/lib/coil/posix/coil/Affinity.cpp
+++ b/src/lib/coil/posix/coil/Affinity.cpp
@@ -40,7 +40,7 @@ namespace coil
       {
         if (CPU_ISSET(i, &cpu_set))
           {
-            cpu_mask.push_back(static_cast<unsigned int>(i)+1);
+            cpu_mask.emplace_back(static_cast<unsigned int>(i)+1);
           }
       }
 #endif
@@ -75,7 +75,7 @@ namespace coil
         int num;
         if (coil::stringTo(num, maskstr.c_str()))
           {
-            mask.push_back(num);
+            mask.emplace_back(num);
           }
       }
     return setProcCpuAffinity(mask);
@@ -99,7 +99,7 @@ namespace coil
       {
         if (CPU_ISSET(i, &cpu_set))
           {
-            cpu_mask.push_back(static_cast<unsigned int>(i)+1);
+            cpu_mask.emplace_back(static_cast<unsigned int>(i)+1);
           }
       }
 #endif
@@ -134,7 +134,7 @@ namespace coil
         int num;
         if (coil::stringTo(num, maskstr.c_str()))
           {
-            mask.push_back(num);
+            mask.emplace_back(num);
           }
       }
     return setThreadCpuAffinity(mask);

--- a/src/lib/coil/posix/coil/File.cpp
+++ b/src/lib/coil/posix/coil/File.cpp
@@ -89,12 +89,12 @@ namespace coil
       if (stat(fullpath.c_str(), &stat_buf) != 0) { continue; }
       if ((stat_buf.st_mode & S_IFMT) == S_IFDIR)
         {
-	  findFile(fullpath, filename, filelist);
+          findFile(fullpath, filename, filelist);
           continue;
         }
       if(dname == filename)
         {
-          filelist.push_back(fullpath);
+          filelist.emplace_back(std::move(fullpath));
         }
      }
   }
@@ -131,20 +131,20 @@ namespace coil
     for (int i = 0; i < files; ++i)
       {
         std::string dname = namelist[i]->d_name;
-	if (dname != "." || dname != "..") { continue; }
+        if (dname != "." || dname != "..") { continue; }
 
         std::string fullpath = dir + "/" + dname;
         struct stat stat_buf;
         if(stat(fullpath.c_str(), &stat_buf) != 0) { continue; }
         if ((stat_buf.st_mode & S_IFMT) == S_IFDIR)
-	  {
+          {
             getFileList(fullpath, ext, filelist); // recursive call
             continue;
           }
         coil::vstring filesp = coil::split(dname, ".");
         if(filesp.back() == ext)
           {
-            filelist.push_back(fullpath);
+            filelist.emplace_back(std::move(fullpath));
           }
       }
   }

--- a/src/lib/coil/posix/coil/File.h
+++ b/src/lib/coil/posix/coil/File.h
@@ -138,11 +138,11 @@ namespace coil
 
     while ((ent = ::readdir(dir_ptr)) != nullptr)
       {
+        std::string fname(ent->d_name);
         bool match(true);
         if (has_glob)
           {
             const char* globc(glob_str);
-            std::string fname(ent->d_name);
             for (size_t i(0); i < fname.size() && *globc != '\0'; ++i, ++globc)
               {
                 if (*globc == '*')
@@ -184,7 +184,7 @@ namespace coil
                     globc[1] != '\0' && globc[1] != '*') { match = false; }
               }
           }
-        if (match) { flist.push_back(ent->d_name); }
+        if (match) { flist.emplace_back(std::move(fname)); }
       }
     ::closedir(dir_ptr);
 

--- a/src/lib/coil/posix/coil/Process.cpp
+++ b/src/lib/coil/posix/coil/Process.cpp
@@ -87,7 +87,7 @@ namespace coil
           {
             line.erase(line.size() - 1);
           }
-        out.push_back(line);
+        out.emplace_back(line);
       } while (feof(fd) == 0);
     
     (void) pclose(fd);

--- a/src/lib/coil/win32/coil/Affinity.cpp
+++ b/src/lib/coil/win32/coil/Affinity.cpp
@@ -43,7 +43,7 @@ namespace coil
 		{
 			if ((processMask & (static_cast<DWORD_PTR>(0x00000001) << i)) != 0U)
 			{
-				cpu_mask.push_back(i);
+				cpu_mask.emplace_back(i);
 			}
 		}
       return true;
@@ -71,7 +71,7 @@ namespace coil
         int num;
         if (coil::stringTo(num, maskstr.c_str()))
           {
-            mask.push_back(num);
+            mask.emplace_back(num);
           }
       }
     return setProcCpuAffinity(mask);
@@ -99,7 +99,7 @@ namespace coil
         int num;
         if (coil::stringTo(num, maskstr.c_str()))
           {
-            mask.push_back(num);
+            mask.emplace_back(num);
           }
       }
     return setThreadCpuAffinity(mask);

--- a/src/lib/coil/win32/coil/File.cpp
+++ b/src/lib/coil/win32/coil/File.cpp
@@ -351,11 +351,11 @@ namespace coil
 
     while ((ent = coil::readdir(dir_ptr)) != nullptr)
       {
+        std::string fname(ent->d_name);
         bool match(true);
         if (has_glob)
           {
             const char* globc(glob_str);
-            std::string fname(ent->d_name);
             for (size_t i(0); i < fname.size() && *globc != '\0'; ++i, ++globc)
               {
                 if (*globc == '*')
@@ -397,7 +397,7 @@ namespace coil
                     globc[1] != '\0' && globc[1] != '*') { match = false; }
               }
           }
-        if (match) { flist.push_back(ent->d_name); }
+        if (match) { flist.emplace_back(std::move(fname)); }
       }
     coil::closedir(dir_ptr);
 
@@ -455,7 +455,7 @@ namespace coil
         
           if (ifs.is_open())
           {
-              filelist.push_back(file_fff);
+              filelist.emplace_back(file_fff);
           }
         
       }
@@ -522,7 +522,7 @@ namespace coil
               }
               else {
                   std::string ret = dir + "\\" + win32fd.cFileName;
-                  filelist.push_back(ret);
+                  filelist.emplace_back(ret);
               }
           } while (FindNextFile(hFind, &win32fd));
       }

--- a/src/lib/hrtm/statechart.cpp
+++ b/src/lib/hrtm/statechart.cpp
@@ -208,7 +208,7 @@ void MachineBase::add_deferred_event(EventBase * event,
       return;
     }
     deferred_events_[name] = event;
-    deferred_names_.push_back(name);
+    deferred_names_.emplace_back(name);
   } catch (std::exception& /*ex*/) {  // NOLINT
   }
 }

--- a/src/lib/rtm/CORBA_IORUtil.cpp
+++ b/src/lib/rtm/CORBA_IORUtil.cpp
@@ -331,7 +331,7 @@ namespace CORBA_IORUtil
           {
             IIOP::ProfileBody pBody;
             IIOP::unmarshalProfile(ior.profiles[i], pBody);
-            addr.push_back(pBody.address);
+            addr.emplace_back(pBody.address);
             extractAddrs(pBody.components, addr);
           }
         else if (ior.profiles[i].tag == IOP::TAG_MULTIPLE_COMPONENTS)
@@ -367,7 +367,7 @@ namespace CORBA_IORUtil
             IIOP::Address v;
             v.host = e.unmarshalRawString();
             v.port <<= e;
-            addr.push_back(v);
+            addr.emplace_back(v);
           }
       }
 #else // ORB_IS_RTORB

--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -562,11 +562,11 @@ namespace CORBA_RTCUtil
       {
         RTC::PortProfile* pp = ports[i]->get_port_profile();
 #ifdef ORB_IS_TAO
-		std::string s(pp->name);
+        std::string s(pp->name);
 #else
         std::string s(static_cast<char*>(pp->name));
 #endif
-        names.push_back(s);
+        names.emplace_back(std::move(s));
       }
     return names;
   }
@@ -599,11 +599,11 @@ namespace CORBA_RTCUtil
         if (prop["port.port_type"] == "DataInPort")
           {
 #ifdef ORB_IS_TAO
-			std::string s(pp->name);
+            std::string s(pp->name);
 #else
             std::string s(static_cast<char*>(pp->name));
 #endif
-            names.push_back(s);
+            names.emplace_back(std::move(s));
           }
       }
     return names;
@@ -637,11 +637,11 @@ namespace CORBA_RTCUtil
         if (prop["port.port_type"] == "DataOutPort")
           {
 #ifdef ORB_IS_TAO
-			std::string s(pp->name);
+            std::string s(pp->name);
 #else
             std::string s(static_cast<char*>(pp->name));
 #endif
-            names.push_back(s);
+            names.emplace_back(std::move(s));
           }
       }
     return names;
@@ -677,11 +677,11 @@ namespace CORBA_RTCUtil
         if (prop["port.port_type"] == "CorbaPort")
           {
 #ifdef ORB_IS_TAO
-			std::string s(pp->name);
+            std::string s(pp->name);
 #else
             std::string s(static_cast<char*>(pp->name));
 #endif
-            names.push_back(s);
+            names.emplace_back(std::move(s));
           }
       }
     return names;
@@ -707,7 +707,7 @@ namespace CORBA_RTCUtil
     RTC::ConnectorProfileList conprof = (*port->get_connector_profiles());
     for (unsigned int i = 0; i < conprof.length(); i++)
       {
-        names.push_back(std::string(conprof[i].name));
+        names.emplace_back(conprof[i].name);
       }
     return names;
   }
@@ -735,7 +735,7 @@ namespace CORBA_RTCUtil
     RTC::ConnectorProfileList conprof = (*port->get_connector_profiles());
     for (unsigned int i = 0; i < conprof.length(); i++)
       {
-        names.push_back(std::string(conprof[i].name));
+        names.emplace_back(conprof[i].name);
       }
     return names;
   }
@@ -760,7 +760,7 @@ namespace CORBA_RTCUtil
     RTC::ConnectorProfileList conprof = (*port->get_connector_profiles());
     for (unsigned int i = 0; i < conprof.length(); i++)
       {
-        names.push_back(std::string(conprof[i].connector_id));
+        names.emplace_back(conprof[i].connector_id);
       }
     return names;
   }
@@ -788,7 +788,7 @@ namespace CORBA_RTCUtil
     RTC::ConnectorProfileList conprof = (*port->get_connector_profiles());
     for (unsigned int i = 0; i < conprof.length(); i++)
       {
-        names.push_back(std::string(conprof[i].connector_id));
+        names.emplace_back(conprof[i].connector_id);
       }
     return names;
   }

--- a/src/lib/rtm/CORBA_SeqUtil.h
+++ b/src/lib/rtm/CORBA_SeqUtil.h
@@ -423,7 +423,7 @@ namespace CORBA_SeqUtil
         CORBA_Object obj = (objlist.cobj())->_buffer[i];
         CORBA::String_var str_var = orb->object_to_string2(obj);
 #endif
-        iorlist.push_back(str_var.in());
+        iorlist.emplace_back(str_var.in());
       }
     return iorlist;
   }

--- a/src/lib/rtm/ConfigAdmin.cpp
+++ b/src/lib/rtm/ConfigAdmin.cpp
@@ -280,7 +280,7 @@ namespace RTC
 
     coil::Properties& p(m_configsets.getNode(node));
     p << config_set;
-    m_newConfig.push_back(node);
+    m_newConfig.emplace_back(std::move(node));
 
     m_changed = true;
     m_active = false;
@@ -497,7 +497,7 @@ namespace RTC
   void
   ConfigAdmin::onUpdateParam(const char* config_param, const char* config_value)
   {
-    m_changedParam.push_back(config_param);
+    m_changedParam.emplace_back(config_param);
     m_listeners.configparam_[ON_UPDATE_CONFIG_PARAM].notify(config_param,
                                                             config_value);
   }

--- a/src/lib/rtm/ConfigAdmin.h
+++ b/src/lib/rtm/ConfigAdmin.h
@@ -699,7 +699,7 @@ namespace RTC
       if (isExist(param_name)) { return false; }
       if (!trans(var, def_val)) { return false; }
       Config<VarType>* c = new Config<VarType>(param_name, var, def_val, trans);
-      m_params.push_back(c);
+      m_params.emplace_back(c);
       c->setCallback(this, &RTC::ConfigAdmin::onUpdateParam);
       update(getActiveId(), param_name);
       return true;

--- a/src/lib/rtm/CorbaNaming.cpp
+++ b/src/lib/rtm/CorbaNaming.cpp
@@ -989,7 +989,7 @@ namespace RTC
         found_pos = input.find(delimiter, begin_pos);
         if (found_pos == std::string::npos)
           {
-            results.push_back(input.substr(pre_pos));
+            results.emplace_back(input.substr(pre_pos));
             break;
           }
         if ('\\' == input.at(found_pos - 1))
@@ -1002,7 +1002,7 @@ namespace RTC
 
         if (substr_size > 0)
           {
-            results.push_back(input.substr(pre_pos, substr_size));
+            results.emplace_back(input.substr(pre_pos, substr_size));
           }
         begin_pos = found_pos + delim_size;
         pre_pos   = found_pos + delim_size;

--- a/src/lib/rtm/CorbaPort.cpp
+++ b/src/lib/rtm/CorbaPort.cpp
@@ -97,7 +97,7 @@ namespace RTC
     try
       {
         CorbaProviderHolder providerholder(type_name, instance_name, &provider);
-        m_providers.push_back(providerholder);
+        m_providers.emplace_back(std::move(providerholder));
       }
     catch (...)
       {
@@ -133,7 +133,7 @@ namespace RTC
         return false;
       }
 
-    m_consumers.push_back(CorbaConsumerHolder(type_name,
+    m_consumers.emplace_back(CorbaConsumerHolder(type_name,
                                               instance_name,
                                               &consumer));
 

--- a/src/lib/rtm/ExecutionContextWorker.cpp
+++ b/src/lib/rtm/ExecutionContextWorker.cpp
@@ -286,7 +286,7 @@ namespace RTC_impl
         std::lock_guard<std::mutex> guard(m_addedMutex);
         RTC::ExecutionContextService_var ec = getECRef();
         RTC::ExecutionContextHandle_t id = comp->attach_context(ec);
-        m_addedComps.push_back(new RTObjectStateMachine(id, comp));
+        m_addedComps.emplace_back(new RTObjectStateMachine(id, comp));
       }
     catch (CORBA::Exception& e)
       {
@@ -333,7 +333,7 @@ namespace RTC_impl
     // rtc is owner of this EC
     RTC::LightweightRTObject_var comp
       = RTC::LightweightRTObject::_duplicate(rtc->getObjRef());
-    m_comps.push_back(new RTObjectStateMachine(id, comp));
+    m_comps.emplace_back(new RTObjectStateMachine(id, comp));
     RTC_DEBUG(("bindComponent() succeeded."));
 
     return RTC::RTC_OK;
@@ -365,7 +365,7 @@ namespace RTC_impl
       }
     {
       std::lock_guard<std::mutex> removeGuard(m_removedMutex);
-      m_removedComps.push_back(rtobj);
+      m_removedComps.emplace_back(rtobj);
     }
     // if EC is stopping, update component list immediately.
     {
@@ -382,7 +382,7 @@ namespace RTC_impl
       std::lock_guard<std::mutex> addedGuard(m_addedMutex);
       for (auto & m_addedComp : m_addedComps)
         {
-          m_comps.push_back(m_addedComp);
+          m_comps.emplace_back(std::move(m_addedComp));
           RTC_TRACE(("Component added."));
         }
       m_addedComps.clear();

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -249,7 +249,7 @@ namespace RTC
                 size_t r = con->getBuffer()->readable();
                 if (r > 0)
                 {
-                    names.push_back(con->name());
+                    names.emplace_back(con->name());
                 }
             }
             
@@ -373,7 +373,7 @@ namespace RTC
                 size_t r = con->getBuffer()->readable();
                 if (r == 0)
                 {
-                    names.push_back(con->name());
+                    names.emplace_back(con->name());
                 }
             }
 

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -180,7 +180,7 @@ namespace RTC
 
     for (auto & connector : m_connectors)
       {
-        profs.push_back(connector->profile());
+        profs.emplace_back(connector->profile());
       }
 
     return profs;
@@ -198,7 +198,7 @@ namespace RTC
     coil::vstring ids;
     for (auto & connector : m_connectors)
       {
-        ids.push_back(connector->id());
+        ids.emplace_back(connector->id());
       }
     RTC_TRACE(("getConnectorIds(): %s", coil::flatten(ids).c_str()));
     return ids;
@@ -216,7 +216,7 @@ namespace RTC
     coil::vstring names;
     for (auto & connector : m_connectors)
       {
-        names.push_back(connector->name());
+        names.emplace_back(connector->name());
       }
     RTC_TRACE(("getConnectorNames(): %s", coil::flatten(names).c_str()));
     return names;
@@ -961,7 +961,7 @@ namespace RTC
           }
         RTC_TRACE(("InPortPushConnector created"));
 
-        m_connectors.push_back(connector);
+        m_connectors.emplace_back(connector);
         RTC_PARANOID(("connector push backed: %d", m_connectors.size()));
         return connector;
       }
@@ -1039,7 +1039,7 @@ namespace RTC
 			
 		}
 
-        m_connectors.push_back(connector);
+        m_connectors.emplace_back(connector);
         RTC_PARANOID(("connector push backed: %d", m_connectors.size()));
         return connector;
       }

--- a/src/lib/rtm/ListenerHolder.h
+++ b/src/lib/rtm/ListenerHolder.h
@@ -190,7 +190,7 @@ namespace util
                      bool autoclean)
     {
       std::lock_guard<std::mutex> guard(m_mutex);
-      m_listeners.push_back(Entry(listener, autoclean));
+      m_listeners.emplace_back(listener, autoclean);
     }
 
     /*!

--- a/src/lib/rtm/LocalServiceAdmin.cpp
+++ b/src/lib/rtm/LocalServiceAdmin.cpp
@@ -143,7 +143,7 @@ namespace RTM
     RTM::LocalServiceProfileList profs(0);
     for (auto & service : m_services)
       {
-        profs.push_back(service->getProfile());
+        profs.emplace_back(service->getProfile());
       }
     return profs;
   }
@@ -208,7 +208,7 @@ namespace RTM
     RTC_TRACE(("LocalServiceAdmin::addLocalService(%s)",
                service->getProfile().name.c_str()));
     std::lock_guard<std::mutex> guard(m_services_mutex);
-    m_services.push_back(service);
+    m_services.emplace_back(service);
     return true;
   }
 

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -365,7 +365,7 @@ namespace RTC
       {
         if (std::count(s_files.begin(), s_files.end(), file) > 0) { continue; }
         m_fileName = file;
-        s_files.push_back(file);
+        s_files.emplace_back(file);
 
         std::string fname{coil::normalize(file)};
         if (fname == "stdout")

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -577,7 +577,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
     props.reserve(factories.size());
     for(auto & factorie : factories)
       {
-        props.push_back(factorie->profile());
+        props.emplace_back(factorie->profile());
       }
     return props;
   }
@@ -1501,7 +1501,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             }
             else
             {
-                args.push_back(opts[i]);
+                args.emplace_back(opts[i]);
             }
          }
          // TAO's ORB_init needs argv[0] as command name.
@@ -1918,7 +1918,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
         int num;
         if (coil::stringTo(num, c.c_str()))
         {
-            cpu_list.push_back(num);
+            cpu_list.emplace_back(num);
             RTC_DEBUG(("CPU affinity int value: %d added.", num));
         }
     }
@@ -2128,7 +2128,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
   {
     RTC_TRACE(("Manager::notifyFinalized()"));
     std::lock_guard<std::mutex> guard(m_finalized.mutex);
-    m_finalized.comps.push_back(comp);
+    m_finalized.comps.emplace_back(comp);
   }
 
   /*!
@@ -2257,7 +2257,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             RTC_INFO(("Component instance conf file: %s loaded.",
                       m_config[name_conf].c_str()));
             RTC_DEBUG_STR((name_prop));
-            config_fname.push_back(m_config[name_conf]);
+            config_fname.emplace_back(m_config[name_conf]);
           }
       }
     if (m_config.findNode(category + "." + inst_name) != nullptr)
@@ -2271,7 +2271,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             RTC_DEBUG_STR((name_prop));
             if (m_config.findNode("config_file") != nullptr)
               {
-                config_fname.push_back(m_config["config_file"]);
+                config_fname.emplace_back(m_config["config_file"]);
               }
           }
       }
@@ -2284,7 +2284,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             RTC_INFO(("Component type conf file: %s loaded.",
                       m_config[type_conf].c_str()));
             RTC_DEBUG_STR((type_prop));
-            config_fname.push_back(m_config[type_conf]);
+            config_fname.emplace_back(m_config[type_conf]);
           }
       }
     if (m_config.findNode(category + "." + type_name) != nullptr)
@@ -2298,7 +2298,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             RTC_DEBUG_STR((type_prop));
             if (m_config.findNode("config_file") != nullptr)
               {
-                config_fname.push_back(m_config["config_file"]);
+                config_fname.emplace_back(m_config["config_file"]);
               }
           }
       }
@@ -2377,7 +2377,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
         if (c == '%')
           {
             ++count;
-            if ((count % 2) == 0) str.push_back((*it));
+            if ((count % 2) == 0) str.push_back(*it);
           }
         else if (c == '$')
           {
@@ -2479,8 +2479,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                 std::find(ipv4_list.begin(), ipv4_list.end(), ipv4_count)
                 != ipv4_list.end())
               {
-                epstr.push_back(tmp);
-                epstr_ipv4.push_back(tmp);
+                epstr.emplace_back(tmp);
+                epstr_ipv4.emplace_back(std::move(tmp));
               }
             ipv4_count += 1;
           }
@@ -2491,8 +2491,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                 std::find(ipv6_list.begin(), ipv6_list.end(), ipv6_count)
                 != ipv6_list.end())
               {
-                epstr.push_back(tmp);
-                epstr_ipv6.push_back(tmp);
+                epstr.emplace_back(tmp);
+                epstr_ipv6.emplace_back(std::move(tmp));
               }
             ipv6_count += 1;
           }
@@ -2541,7 +2541,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
         int n;
         if (coil::stringTo(n, num.c_str()))
           {
-            ip_list.push_back(n);
+            ip_list.emplace_back(n);
           }
       }
     return;
@@ -2577,27 +2577,26 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 		  }
 
 		  std::string port0_str = coil::split(connector, "?")[0];
-		  coil::mapstring param = coil::urlparam2map(connector);
 
 		  coil::vstring ports;
 		  coil::mapstring configs;
 
-		  for (auto & param_itr : param) {
-			  if (param_itr.first == "port")
+		  for (auto & param : coil::urlparam2map(connector)) {
+			  if (param.first == "port")
 			  {
-				  ports.push_back(param_itr.second);
+				  ports.emplace_back(std::move(param.second));
 				  continue;
 			  }
-              std::string tmp{coil::replaceString(param_itr.first, "port", "")};
-              std::string::size_type pos = param_itr.first.find("port");
+              std::string tmp{coil::replaceString(param.first, "port", "")};
+              std::string::size_type pos = param.first.find("port");
 
 			  int val = 0;
               if (coil::stringTo<int>(val, tmp.c_str()) && pos != std::string::npos)
 			  {
-				  ports.push_back(param_itr.second);
+				  ports.emplace_back(std::move(param.second));
 				  continue;
 			  }
-			  configs[param_itr.first] = param_itr.second;
+			  configs[param.first] = std::move(param.second);
 		  }
 
 		  if (configs.count("dataflow_type") == 0)

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1615,7 +1615,9 @@ std::vector<coil::Properties> Manager::getLoadableModules()
     if (m_config.findNode("corba.endpoint") != nullptr)
       {
         coil::vstring tmp(coil::split(m_config["corba.endpoint"], ","));
-        endpoints.insert(endpoints.end(), tmp.begin(), tmp.end());
+        endpoints.insert(endpoints.end(),
+                         std::make_move_iterator(tmp.begin()),
+                         std::make_move_iterator(tmp.end()));
         RTC_DEBUG(("corba.endpoint: %s", m_config["corba.endpoint"].c_str()));
       }
     // If this process has master manager,
@@ -1628,11 +1630,11 @@ std::vector<coil::Properties> Manager::getLoadableModules()
         coil::vstring mmm(coil::split(mm, ":"));
         if (mmm.size() == 2)
           {
-            endpoints.insert(endpoints.begin(), std::string(":") + mmm[1]);
+            endpoints.emplace(endpoints.begin(), std::string(":") + mmm[1]);
           }
         else
           {
-            endpoints.insert(endpoints.begin(), ":2810");
+            endpoints.emplace(endpoints.begin(), ":2810");
           }
       }
     endpoints = coil::unique_sv(std::move(endpoints));

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -2333,7 +2333,7 @@ namespace RTC
     {
       void operator()(FactoryBase* f)
       {
-        modlist.push_back(f->profile().getProperty("implementation_id"));
+        modlist.emplace_back(f->profile().getProperty("implementation_id"));
       }
       std::vector<std::string> modlist;
     };

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1288,7 +1288,7 @@ namespace RTM
                     std::string name = sleave_prop["manager.instance_name"];
                     if (isProcessIDManager(name))
                       {
-                        slaves_names.push_back(name);
+                        slaves_names.emplace_back(std::move(name));
                       }
                   }
                 catch (...)

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -335,7 +335,9 @@ namespace RTC
         getModuleProfiles(lang, modules, tmpprops);
         RTC_DEBUG(("Modile profile size: %d (newly founded modules)",
                    tmpprops.size()));
-        m_modprofs.insert(m_modprofs.end(), tmpprops.begin(), tmpprops.end());
+        m_modprofs.insert(m_modprofs.end(),
+                          std::make_move_iterator(tmpprops.begin()),
+                          std::make_move_iterator(tmpprops.end()));
       }
     RTC_DEBUG(("Modile profile size: %d", m_modprofs.size()));
     // 3. removing module profiles for which module file does not exist
@@ -488,7 +490,9 @@ namespace RTC
             coil::getFileList(path, suffixe, tmp);
             RTC_DEBUG(("File list (path:%s, ext:%s): %s", path.c_str(),
                        suffixe.c_str(), coil::flatten(tmp).c_str()));
-            flist.insert(flist.end(), tmp.begin(), tmp.end());
+            flist.insert(flist.end(),
+                         std::make_move_iterator(tmp.begin()),
+                         std::make_move_iterator(tmp.end()));
           }
 
         // reformat file path and remove cached files

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -280,7 +280,7 @@ namespace RTC
 
     while (it != it_end)
       {
-        m_loadPath.push_back(*it);
+        m_loadPath.emplace_back(*it);
         ++it;
       }
 
@@ -301,7 +301,7 @@ namespace RTC
     std::vector<coil::Properties> modules(0);
     for (auto & dll : dlls)
       {
-        modules.push_back(dll->properties);
+        modules.emplace_back(dll->properties);
       }
     return modules;
   }
@@ -540,7 +540,7 @@ namespace RTC
     if (!exists)
       {
         RTC_DEBUG(("New module: %s", fpath.c_str()));
-        modules.push_back(fpath);
+        modules.emplace_back(fpath);
       }
   }
 
@@ -561,7 +561,6 @@ namespace RTC
 
     for (const auto & module : modules)
       {
-          
         std::string cmd(lprop["profile_cmd"]);
         cmd += " \"" + module + "\"";
 
@@ -571,32 +570,27 @@ namespace RTC
               std::cerr << "create_process faild" << std::endl;
               continue;
           }
-        coil::Properties p;
-        
+
+        coil::Properties props;
         for (auto & out : outlist)
           {
             std::string::size_type pos(out.find(':'));
             if (pos != std::string::npos)
               {
                   std::string key{coil::eraseBothEndsBlank(out.substr(0, pos))};
-                  p[key] = coil::eraseBothEndsBlank(out.substr(pos + 1));
+                  props[key] = coil::eraseBothEndsBlank(out.substr(pos + 1));
               }
-            
           }
-
-        
-        
 
         RTC_DEBUG(("rtcprof cmd sub process done."));
-        if (p["implementation_id"].empty()) 
-          { 
-            m_loadfailmods.push_back(module);
+        if (props["implementation_id"].empty())
+          {
+            m_loadfailmods.emplace_back(module);
             continue;
           }
-        p["module_file_name"] = coil::basename(module.c_str());
-        p["module_file_path"] = module;
-        modprops.push_back(p);
-        
+        props["module_file_name"] = coil::basename(module.c_str());
+        props["module_file_path"] = module;
+        modprops.emplace_back(std::move(props));
       }
 #endif
   }

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -178,7 +178,7 @@ namespace RTC_exp
                   {
                       continue;
                   }
-                  rtcs.push_back(rtobj);
+                  rtcs.emplace_back(rtobj);
               }
           }
           addTask(rtcs);
@@ -238,7 +238,7 @@ namespace RTC_exp
           addRTCToTask(ct, rtc);
       }
 
-      m_tasklist.push_back(ct);
+      m_tasklist.emplace_back(ct);
 
       // Start task in suspended mode
       task->suspend();
@@ -278,7 +278,7 @@ namespace RTC_exp
 
   void MultilayerCompositeEC::ChildTask::addComponent(RTC::LightweightRTObject_ptr rtc)
   {
-      m_rtcs.push_back(rtc);
+      m_rtcs.emplace_back(rtc);
   }
 
   void MultilayerCompositeEC::ChildTask::updateCompList()
@@ -290,7 +290,7 @@ namespace RTC_exp
           if (comp != nullptr)
           {
               rtc = m_rtcs.erase(rtc);
-              m_comps.push_back(comp);
+              m_comps.emplace_back(comp);
           }
           else
           {

--- a/src/lib/rtm/NamingManager.cpp
+++ b/src/lib/rtm/NamingManager.cpp
@@ -568,7 +568,7 @@ namespace RTC
     name = createNamingObj(method, name_server);
 
     std::lock_guard<std::mutex> guard(m_namesMutex);
-    m_names.push_back(new NamingService(method, name_server, name));
+    m_names.emplace_back(new NamingService(method, name_server, name));
   }
 
   /*!
@@ -736,7 +736,7 @@ namespace RTC
       // unbindObject modifiy m_compNames
       for (auto & compName : m_compNames)
         {
-          names.push_back(compName->name);
+          names.emplace_back(compName->name);
         }
       for (auto & name : names)
         {
@@ -750,7 +750,7 @@ namespace RTC
       // unbindObject modifiy m_mgrNames
       for (auto & mgrName : m_mgrNames)
         {
-          names.push_back(mgrName->name);
+          names.emplace_back(mgrName->name);
         }
       for (auto & name : names)
         {
@@ -773,7 +773,7 @@ namespace RTC
 
     for (auto & compName : m_compNames)
       {
-        comps.push_back(const_cast<RTObject_impl*>(compName->rtobj));
+        comps.emplace_back(const_cast<RTObject_impl*>(compName->rtobj));
       }
     return comps;
   }
@@ -857,7 +857,7 @@ namespace RTC
             return;
           }
       }
-    m_compNames.push_back(new Comps(name, rtobj));
+    m_compNames.emplace_back(new Comps(name, rtobj));
     return;
   }
   /*!
@@ -878,7 +878,7 @@ namespace RTC
             return;
           }
       }
-    m_portNames.push_back(new Port(name, port));
+    m_portNames.emplace_back(new Port(name, port));
     return;
   }
   void NamingManager::registerMgrName(const char* name,
@@ -892,7 +892,7 @@ namespace RTC
             return;
           }
       }
-    m_mgrNames.push_back(new Mgr(name, mgr));
+    m_mgrNames.emplace_back(new Mgr(name, mgr));
     return;
   }
 

--- a/src/lib/rtm/NumberingPolicy.cpp
+++ b/src/lib/rtm/NumberingPolicy.cpp
@@ -47,7 +47,7 @@ namespace RTM
     catch (ObjectNotFound& e)
       {
         (void)(e);
-        m_objects.push_back(obj);
+        m_objects.emplace_back(obj);
         return coil::otos(static_cast<int>(m_objects.size() - 1));
       }
   }

--- a/src/lib/rtm/ObjectManager.h
+++ b/src/lib/rtm/ObjectManager.h
@@ -122,7 +122,7 @@ public:
                       Predicate(obj));
     if (it == m_objects._obj.end())
       {
-        m_objects._obj.push_back(obj);
+        m_objects._obj.emplace_back(obj);
         return true;
       }
     return false;

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -251,7 +251,7 @@ namespace RTC
                     RTC::ConnectorProfile prof(findConnProfile(id));
                     (*m_onConnectionLost)(prof);
                   }
-                disconnect_ids.push_back(id);
+                disconnect_ids.emplace_back(id);
               }
           }
       }

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -193,7 +193,7 @@ namespace RTC
     ConnectorInfoList profs;
     for (auto & connector : m_connectors)
       {
-        profs.push_back(connector->profile());
+        profs.emplace_back(connector->profile());
       }
     return profs;
   }
@@ -210,7 +210,7 @@ namespace RTC
     coil::vstring ids;
     for (auto & connector : m_connectors)
       {
-        ids.push_back(connector->id());
+        ids.emplace_back(connector->id());
       }
     RTC_TRACE(("getConnectorIds(): %s", coil::flatten(ids).c_str()));
     return ids;
@@ -228,7 +228,7 @@ namespace RTC
     coil::vstring names;
     for (auto & connector : m_connectors)
       {
-        names.push_back(connector->name());
+        names.emplace_back(connector->name());
       }
     RTC_TRACE(("getConnectorNames(): %s", coil::flatten(names).c_str()));
     return names;
@@ -999,7 +999,7 @@ namespace RTC
           }
         // end of direct interface_type
 
-        m_connectors.push_back(connector);
+        m_connectors.emplace_back(connector);
         RTC_PARANOID(("connector pushback done: size = %d",
                       m_connectors.size()));
         return connector;
@@ -1055,7 +1055,7 @@ namespace RTC
 			connector->setPullDirectMode();
 		}
 
-        m_connectors.push_back(connector);
+        m_connectors.emplace_back(connector);
         RTC_PARANOID(("connector pushback done: size = %d",
                       m_connectors.size()));
         return connector;

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -80,7 +80,7 @@ namespace SDOPackage
         addOrganizationToTarget(member);
         addParticipantToEC(member);
         addPort(member, m_expPorts);
-        m_rtcMembers.push_back(member);
+        m_rtcMembers.emplace_back(member);
       }
 
     CORBA::Boolean result;
@@ -129,7 +129,7 @@ namespace SDOPackage
         addOrganizationToTarget(member);
         addParticipantToEC(member);
         addPort(member, m_expPorts);
-        m_rtcMembers.push_back(member);
+        m_rtcMembers.emplace_back(member);
       }
 
     CORBA::Boolean result;

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -608,7 +608,7 @@ namespace RTC_exp
         int num;
         if (coil::stringTo(num, cpu.c_str()))
           {
-            m_cpu.push_back(num);
+            m_cpu.emplace_back(num);
             RTC_DEBUG(("CPU affinity int value: %d added.", num));
           }
       }

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -935,7 +935,7 @@ namespace RTC
           if (!checkPorts((*clist)[i].ports))
             {
               const char* id((*clist)[i].connector_id);
-              connector_ids.push_back(id);
+              connector_ids.emplace_back(id);
               RTC_WARN(("Dead connection: %s", id));
             }
         }

--- a/src/lib/rtm/PortProfileHelper.cpp
+++ b/src/lib/rtm/PortProfileHelper.cpp
@@ -117,7 +117,7 @@ namespace RTC
   {
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    m_ifProfiles.push_back(if_prof);
+    m_ifProfiles.emplace_back(if_prof);
     return;
   }
 
@@ -211,7 +211,7 @@ namespace RTC
   {
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    m_connProfiles.push_back(conn_profile);
+    m_connProfiles.emplace_back(conn_profile);
   }
 
 

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -1616,7 +1616,7 @@ namespace RTC
       }
 
     inport.init(m_properties.getNode(propkey));
-    m_inports.push_back(&inport);
+    m_inports.emplace_back(&inport);
     return ret;
   }
 
@@ -1657,7 +1657,7 @@ namespace RTC
       }
 
     outport.init(m_properties.getNode(propkey));
-    m_outports.push_back(&outport);
+    m_outports.emplace_back(&outport);
     return ret;
   }
 
@@ -2804,9 +2804,9 @@ namespace RTC
           {
             RTC_DEBUG(("p_name is empty"));
           }
-        ec_args.push_back(p);
         RTC_DEBUG(("New EC properties stored:"));
         RTC_DEBUG_STR((p));
+        ec_args.emplace_back(std::move(p));
       }
     return RTC::RTC_OK;
   }
@@ -2854,7 +2854,7 @@ namespace RTC
       }
     if (ret_global == RTC::RTC_OK && ret_private != RTC::RTC_OK)
       {
-        ec_args.push_back(global_props);
+        ec_args.emplace_back(std::move(global_props));
       }
     return RTC::RTC_OK;
   }
@@ -2926,7 +2926,7 @@ namespace RTC
         RTC_DEBUG(("EC (%s) created.", ec_type.c_str()));
 
         ec->init(ec_arg);
-        m_eclist.push_back(ec);
+        m_eclist.emplace_back(ec);
         ec->bindComponent(this);
       }
 
@@ -3000,7 +3000,7 @@ namespace RTC
               }
           }
         ec->init(default_opts);
-        m_eclist.push_back(ec);
+        m_eclist.emplace_back(ec);
         ec->bindComponent(this);
       }
     return ret;

--- a/src/lib/rtm/SdoServiceAdmin.cpp
+++ b/src/lib/rtm/SdoServiceAdmin.cpp
@@ -102,27 +102,27 @@ namespace RTC
   {
     //------------------------------------------------------------
     // SDO service provider
-    ::coil::vstring enabledProviderTypes
-      = ::coil::split(prop["sdo.service.provider.enabled_services"], ",", true);
+    coil::vstring enabledProviderTypes{
+      coil::split(prop["sdo.service.provider.enabled_services"], ",", true)};
     RTC_DEBUG(("sdo.service.provider.enabled_services: %s",
                prop["sdo.service.provider.enabled_services"].c_str()));
 
-    ::coil::vstring availableProviderTypes
-        = SdoServiceProviderFactory::instance().getIdentifiers();
+    coil::vstring availableProviderTypes{
+      SdoServiceProviderFactory::instance().getIdentifiers()};
     coil::Properties tmp;
     tmp["sdo.service.provider.available_services"]
       = coil::flatten(availableProviderTypes);
-    m_rtobj.setProperties(tmp);
     RTC_DEBUG(("sdo.service.provider.available_services: %s",
                tmp["sdo.service.provider.available_services"].c_str()));
+    m_rtobj.setProperties(std::move(tmp));
 
     // If types include '[Aa][Ll][Ll]', all types enabled in this RTC
-    ::coil::vstring activeProviderTypes;
+    coil::vstring activeProviderTypes;
     for (auto & enabledProviderType : enabledProviderTypes)
       {
         if (coil::toLower(enabledProviderType) == "all")
           {
-            activeProviderTypes = availableProviderTypes;
+            activeProviderTypes = std::move(availableProviderTypes);
             RTC_DEBUG(("sdo.service.provider.enabled_services: ALL"));
             break;
           }
@@ -130,7 +130,7 @@ namespace RTC
           {
             if (availableProviderType == enabledProviderType)
               {
-                activeProviderTypes.push_back(availableProviderType);
+                activeProviderTypes.emplace_back(std::move(availableProviderType));
               }
           }
       }
@@ -156,7 +156,7 @@ namespace RTC
             delete svc;
             continue;
           }
-        m_providers.push_back(svc);
+        m_providers.emplace_back(svc);
       }
   }
 
@@ -167,7 +167,7 @@ namespace RTC
     // getting consumer types from RTC's properties
 
     ::std::string constypes = prop["sdo.service.consumer.enabled_services"];
-    m_consumerTypes = ::coil::split(constypes, ",", true);
+    m_consumerTypes = coil::split(constypes, ",", true);
     RTC_DEBUG(("sdo.service.consumer.enabled_services: %s", constypes.c_str()));
 
     coil::Properties tmp;
@@ -272,7 +272,7 @@ namespace RTC
             return false;
           }
       }
-    m_providers.push_back(provider);
+    m_providers.emplace_back(provider);
     return true;
   }
 
@@ -382,7 +382,7 @@ namespace RTC
                NVUtil::toString(sProfile.properties).c_str()));
 
     // store consumer
-    m_consumers.push_back(consumer);
+    m_consumers.emplace_back(consumer);
 
     return true;
   }

--- a/src/lib/rtm/StateMachine.h
+++ b/src/lib/rtm/StateMachine.h
@@ -873,7 +873,7 @@ namespace RTC_Utils
       s.clear();
       for (size_t i(0); i < m_num; ++i)
         {
-          s.push_back(nullfunc);
+          s.emplace_back(nullfunc);
         }
     }
 

--- a/utils/rtcprof/rtcprof.cpp
+++ b/utils/rtcprof/rtcprof.cpp
@@ -49,15 +49,15 @@ int main(int argc, char* argv[])
   // making command line option
   //   dummy -o manager.modules.load_path
   coil::vstring opts;
-  opts.push_back("dummy");
-  opts.push_back("-o");
+  opts.emplace_back("dummy");
+  opts.emplace_back("-o");
   std::string load_path("manager.modules.load_path:");
   load_path += dirname;
-  opts.push_back(load_path);
-  opts.push_back("-o");
-  opts.push_back("logger.enable:NO");
-  opts.push_back("-o");
-  opts.push_back("manager.corba_servant:NO");
+  opts.emplace_back(load_path);
+  opts.emplace_back("-o");
+  opts.emplace_back("logger.enable:NO");
+  opts.emplace_back("-o");
+  opts.emplace_back("manager.corba_servant:NO");
 
   // Manager initialization
   RTC::Manager::init(static_cast<int>(opts.size()), coil::Argv(opts).get());
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])
               exists = true;
             }
         }
-      if (!exists) { profs.push_back(propnew); }
+      if (!exists) { profs.emplace_back(std::move(propnew)); }
     }
 
   // loaded component profile have to be one


### PR DESCRIPTION
## Description of the Change

コンテナ間のコピーでコピー元を破壊して良い（ローカル変数）の場合に move iterator を使用する。
コンテナの要素追加に push_back よりも emplace_back を使う。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?   ConsoleOutComp の起動のみ確認
