### PR TITLE
Fix memory leaks and Windows path.

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -821,7 +821,7 @@ namespace coil
     while (std::regex_search(str, m, e))
     {
       std::string env;
-      if (!coil::getenv(m.str(1).c_str(), env)){ break; }
+      coil::getenv(m.str(1).c_str(), env); // env="" if getenv() fail.
       str.replace(m.position(), m.length(), env);
     }
     return str;

--- a/src/lib/coil/win32/coil/OS.cpp
+++ b/src/lib/coil/win32/coil/OS.cpp
@@ -18,8 +18,9 @@
 
 
 #include <coil/OS.h>
+#include <map>
 #include <string>
-
+#include <vector>
 
 namespace coil
 {
@@ -384,9 +385,9 @@ namespace coil
     {
         return false;
     }
-    char *buff = new char[return_size * sizeof(char)];
-    ::getenv_s(&return_size, buff, return_size, name);
-    env = buff;
+    std::vector<char> buff(return_size);
+    ::getenv_s(&return_size, buff.data(), return_size, name);
+    env = buff.data();
     return true;
   }
 

--- a/src/lib/coil/win32/coil/OS.h
+++ b/src/lib/coil/win32/coil/OS.h
@@ -19,16 +19,10 @@
 #ifndef COIL_OS_H
 #define COIL_OS_H
 
-
 #include <Windows.h>
-#include <string.h>
-#include <stdio.h>
 #include <process.h>
-#include <stdlib.h>
 #include <WinBase.h>
-#include <iostream>
-#include <map>
-
+#include <string>
 
 extern "C"
 {

--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -38,8 +38,8 @@ namespace RTC
 #ifdef RTM_OS_WIN32
   const char* const ManagerConfig::config_file_path[] = 
     {
-      "./rtc.conf",
-      "${PROGRAMDATA}/OpenRTM-aist/rtc.conf",
+      ".\\rtc.conf",
+      "${PROGRAMDATA}\\OpenRTM-aist\\rtc.conf",
       nullptr
     };
 #else


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- [Windows] getenv() でメモリリークしている
- [Windows] rtc.conf のサーチパスのセパレータに "/" が使われているが、環境変数側は"\"を使用している。結果的に文字列置換すると両者が混ざる。
- replaceEnv() で環境変数が見つからなかったときに文字列置換を停止する

## Description of the Change

上記の問題を修正する。
また、未使用ヘッダのインクルードを整理する。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests? 
