### PR TITLE
[compat, bugfix] Fix split() spec: return empty if input is empty.

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -325,6 +325,7 @@ namespace coil
                 const std::string& delimiter,
                 bool ignore_empty)
   {
+    if (input.empty()) { return {}; }
     if (delimiter.empty()) { return {eraseBothEndsBlank(input)}; }
 
     vstring results;

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -399,19 +399,25 @@ namespace coil
    * @brief 文字列を分割文字で分割する
    *
    * 設定された文字列を与えられたデリミタで分割する。
+   * 注意: input が空文字列の場合、ignore_empty の指定に関わらず、
+   * 常に空リストを返す。
    *
    * @param input 分割対象文字列
    * @param delimiter 分割文字列(デリミタ)
+   * @param ignore_empty 空文字列を登録可否
    *
    * @return 文字列分割結果リスト
    *
    * @else
    * @brief Split string by delimiter
    *
-   * Split the set string by the given delimiter
+   * Split the set string by the given delimiter.
+   * Note: If this function is called with 'input' == "", it ignore
+   * 'ignore_empty' and return an empty list.
    *
    * @param input The target characters of string for split
    * @param delimiter Split string (delimiter)
+   * @param ignore_empty ignore empty strings or not
    *
    * @return Split string result list
    *


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

メモリリーク (realloc) 箇所が100倍くらい増加している。
#617 のバグ修正 「input = "", ignore_empty = false の時に空文字列を無視していない点を修正」 により、
このバグに依存しているどこかで発生しているように見える。具体的にどこかはわからない。

## Description of the Change

ignore_empty の値にかかわらず、入力が空文字列なら空リストをとりあえず返すという旧実装を仕様とする。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  大量発生していたリーク数は正常にもどった