### PR TITLE
Replace macro with numelic_limites.

### DIFF
--- a/src/lib/coil/common/coil/TimeMeasure.cpp
+++ b/src/lib/coil/common/coil/TimeMeasure.cpp
@@ -19,11 +19,7 @@
 
 #include <coil/TimeMeasure.h>
 #include <cmath>
-
-
-#ifndef ULLONG_MAX
-#define ULLONG_MAX 0xffffffffffffffffULL
-#endif
+#include <limits>
 
 namespace coil
 {
@@ -127,8 +123,8 @@ namespace coil
                                   double &mean_interval,
                                   double &stddev)
   {
-    max_interval = static_cast<double>(0);
-    min_interval = static_cast<double>(ULLONG_MAX);
+    max_interval = .0;
+    min_interval = static_cast<double>(std::numeric_limits<uint64_t>::max());
 
     double sum = 0;
     double sq_sum = 0;


### PR DESCRIPTION

## Description of the Change

C++11 では climits で定義されているマクロを自作しているので置き換える。
climits を使っても良かったが、C++ なので limits を使用した。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
