### PR TITLE
Improvement coil::Properties: typo, singed types, using macro.

### DIFF
--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -432,9 +432,9 @@ namespace coil
    * @brief Get the number of properties
    * @endif
    */
-  int Properties::size() const
+  size_t Properties::size() const
   {
-    return static_cast<int>(propertyNames().size());
+    return propertyNames().size();
   }
 
   /*!
@@ -753,7 +753,7 @@ namespace coil
    * @endif
    */
   std::ostream&
-  Properties::_dump(std::ostream& out, const Properties& curr, int index)
+  Properties::_dump(std::ostream& out, const Properties& curr, size_t index)
   {
     if (index != 0) out << indent(index) << "- " << curr.name;
     if (curr.leaf.empty())
@@ -783,10 +783,10 @@ namespace coil
    * @brief Create indents
    * @endif
    */
-  std::string Properties::indent(int index)
+  std::string Properties::indent(size_t index)
   {
     std::string space = std::string();
-    for (int i(0); i < index - 1; ++i)
+    for (size_t i(0); i < index - 1; ++i)
       {
         space += "  ";
       }
@@ -800,10 +800,10 @@ namespace coil
    * @brief Create indents
    * @endif
    */
-  std::string indent(int index)
+  std::string indent(size_t index)
   {
     std::string space;
-    for (int i(0); i < index - 1; ++i)
+    for (size_t i(0); i < index - 1; ++i)
       {
         space += "  ";
       }
@@ -832,7 +832,7 @@ namespace coil
       return out;
   }
 
-  void Properties::_dump(std::string& out, const Properties& curr, int index) const
+  void Properties::_dump(std::string& out, const Properties& curr, size_t index) const
   {
       if (index != 0) out += indent(index) + "- " + curr.name;
       if (curr.leaf.empty())
@@ -854,7 +854,7 @@ namespace coil
       }
   }
 
-  void Properties::_dump(std::vector<std::string>& out, const Properties& curr, int index) const
+  void Properties::_dump(std::vector<std::string>& out, const Properties& curr, size_t index) const
   {
       if (index != 0) out.push_back(indent(index) + "- " + curr.name);
       if (curr.leaf.empty())

--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -71,7 +71,7 @@ namespace coil
    * @brief Constructor(Give the default value with char*[])
    * @endif
    */
-  Properties::Properties(const char* const defaults[], long num)
+  Properties::Properties(const char* const defaults[], size_t num)
   {
     leaf.clear();
     setDefaults(defaults, num);
@@ -306,9 +306,9 @@ namespace coil
    * @brief Set a default value together in the property list
    * @endif
    */
-  void Properties::setDefaults(const char* const defaults[], long num)
+  void Properties::setDefaults(const char* const defaults[], size_t num)
   {
-    for (long i = 0; i < num && defaults[i][0] != '\0' ; i += 2)
+    for (size_t i = 0; i < num && defaults[i][0] != '\0' ; i += 2)
       {
         setDefault(eraseBothEndsBlank(defaults[i]),
                    eraseBothEndsBlank(defaults[i + 1]));

--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -420,7 +420,7 @@ namespace coil
     std::vector<std::string> names;
     for (auto prop : leaf)
       {
-        _propertiyNames(names, prop->name, prop);
+        _propertyNames(names, prop->name, prop);
       }
     return names;
   }
@@ -687,9 +687,9 @@ namespace coil
    * @endif
    */
   void
-  Properties::_propertiyNames(std::vector<std::string>& names,
-                              const std::string& curr_name,
-                              const Properties* curr)
+  Properties::_propertyNames(std::vector<std::string>& names,
+                             const std::string& curr_name,
+                             const Properties* curr)
   {
     if (!curr->leaf.empty())
       {
@@ -697,7 +697,7 @@ namespace coil
           {
             std::string next_name;
             next_name = curr_name + "." + prop->name;
-            _propertiyNames(names, next_name, prop);
+            _propertyNames(names, next_name, prop);
           }
       }
     else

--- a/src/lib/coil/common/coil/Properties.h
+++ b/src/lib/coil/common/coil/Properties.h
@@ -909,7 +909,7 @@ namespace coil
      *
      * @endif
      */
-    int size() const;
+    size_t size() const;
 
     /*!
      * @if jp
@@ -1099,7 +1099,7 @@ namespace coil
      *
      * @endif
      */
-    void _dump(std::string& out, const Properties& curr, int index) const;
+    void _dump(std::string& out, const Properties& curr, size_t index) const;
 
     /*!
      * @if jp
@@ -1118,7 +1118,7 @@ namespace coil
      *
      * @endif
      */
-    void _dump(std::vector<std::string>& out, const Properties& curr, int index) const;
+    void _dump(std::vector<std::string>& out, const Properties& curr, size_t index) const;
 
   protected:
     /*!
@@ -1307,7 +1307,7 @@ namespace coil
      * @endif
      */
     static std::ostream& _dump(std::ostream& out, const Properties& curr,
-                               int index);
+                               size_t index);
 
     /*!
      * @if jp
@@ -1332,7 +1332,7 @@ namespace coil
      *
      * @endif
      */
-    static std::string indent(int index);
+    static std::string indent(size_t index);
 
   private:
     std::string name = "";
@@ -1371,4 +1371,3 @@ namespace coil
   };  // class Properties
 } // namespace coil
 #endif  // COIL_PROPERTIES_H
-

--- a/src/lib/coil/common/coil/Properties.h
+++ b/src/lib/coil/common/coil/Properties.h
@@ -20,12 +20,10 @@
 #ifndef COIL_PROPERTIES_H
 #define COIL_PROPERTIES_H
 
-
+#include <limits>
 #include <string>
 #include <vector>
 #include <map>
-#include <climits>
-
 
 /*!
  * @if jp
@@ -175,7 +173,7 @@ namespace coil
      * </pre>
      *
      * @param defaults デフォルト値を指定する配列
-     * @param num デフォルト値を設定する要素数(デフォルト値:LONG_MAX)
+     * @param num デフォルト値を設定する要素数(デフォルト値:max of size_t)
      *
      * @else
      *
@@ -203,11 +201,12 @@ namespace coil
      *
      * @param defaults Array that specifies the default values
      * @param num Number of elements that specifies the default value
-     *            (The default value:LONG_MAX)
+     *            (The default value:max of size_t)
      *
      * @endif
      */
-    explicit Properties(const char* const defaults[], long num = LONG_MAX);
+    explicit Properties(const char* const defaults[],
+                        size_t num = std::numeric_limits<size_t>::max());
 
     /*!
      * @if jp
@@ -578,7 +577,7 @@ namespace coil
      * なければならない。
      *
      * @param defaults デフォルト値を指定する配列
-     * @param num デフォルト値を設定する要素数(デフォルト値:LONG_MAX)
+     * @param num デフォルト値を設定する要素数(デフォルト値:max of size_t)
      *
      * @else
      * @brief Set a default value together in the property list
@@ -591,11 +590,12 @@ namespace coil
      *
      * @param defaults Array that specifies the default values
      * @param num Number of elements that specifies the default value
-     *            (Default value:LONG_MAX)
+     *            (Default value:max of size_t)
      *
      * @endif
      */
-    void setDefaults(const char* const defaults[], long num = LONG_MAX);
+    void setDefaults(const char* const defaults[],
+                     size_t num = std::numeric_limits<size_t>::max());
 
     //============================================================
     // load and save functions

--- a/src/lib/coil/common/coil/Properties.h
+++ b/src/lib/coil/common/coil/Properties.h
@@ -1251,9 +1251,9 @@ namespace coil
      *
      * @endif
      */
-    static void _propertiyNames(std::vector<std::string>& names,
-                                const std::string& curr_name,
-                                const Properties* curr);
+    static void _propertyNames(std::vector<std::string>& names,
+                               const std::string& curr_name,
+                               const Properties* curr);
 
     /*!
      * @if jp

--- a/src/lib/hrtm/properties.h
+++ b/src/lib/hrtm/properties.h
@@ -29,10 +29,10 @@ namespace utils
   {
   public:
     explicit Properties();
-    explicit Properties(const char* const defaults[], long num = LONG_MAX);
+    explicit Properties(const char* const defaults[],
+                        long num = std::numeric_limits<size_t>::max());
     ~Properties() override;
   };
 } // namespace utils
 } // namespace hrtm
 #endif // HRTM_PROPERTIES_H
-


### PR DESCRIPTION
## Description of the Change

Properties の小さな改善を行う。
* LONG_MAX を limits に変更
* 警告が多いので singed 型をやめて unsigned 型を使用
* 誤字修正 _propertiyNames

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
