### PR TITLE
Update Microwave.cpp

### DIFF
--- a/examples/StaticFsm/Display.cpp
+++ b/examples/StaticFsm/Display.cpp
@@ -11,11 +11,11 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* const consoleout_spec[] =
+static const char* const display_spec[] =
   {
     "implementation_id", "Display",
     "type_name",         "Display",
-    "description",       "Console output component",
+    "description",       "Display component for Microwave example",
     "version",           "1.0",
     "vendor",            "Noriaki Ando, AIST",
     "category",          "example",
@@ -113,7 +113,7 @@ extern "C"
 {
   void DisplayInit(RTC::Manager* manager)
   {
-    coil::Properties profile(consoleout_spec);
+    coil::Properties profile(display_spec);
     manager->registerFactory(profile,
                              RTC::Create<Display>,
                              RTC::Delete<Display>);

--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -12,7 +12,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* const inputbuttom_spec[] =
+static const char* const inputbutton_spec[] =
   {
     "implementation_id", "Inputbutton",
     "type_name",         "Inputbutton",

--- a/examples/StaticFsm/Inputbutton.cpp
+++ b/examples/StaticFsm/Inputbutton.cpp
@@ -12,11 +12,11 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* const consolein_spec[] =
+static const char* const inputbuttom_spec[] =
   {
     "implementation_id", "Inputbutton",
     "type_name",         "Inputbutton",
-    "description",       "Console input component",
+    "description",       "InputButton component for Microwave example",
     "version",           "1.0",
     "vendor",            "Noriaki Ando, AIST",
     "category",          "example",
@@ -124,7 +124,7 @@ extern "C"
  
   void InputbuttonInit(RTC::Manager* manager)
   {
-    RTC::Properties profile(consolein_spec);
+    RTC::Properties profile(inputbutton_spec);
     manager->registerFactory(profile,
                              RTC::Create<Inputbutton>,
                              RTC::Delete<Inputbutton>);

--- a/examples/StaticFsm/Microwave.cpp
+++ b/examples/StaticFsm/Microwave.cpp
@@ -11,11 +11,11 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* const consoleout_spec[] =
+static const char* const microwave_spec[] =
   {
     "implementation_id", "Microwave",
     "type_name",         "Microwave",
-    "description",       "Console output component",
+    "description",       "Microwave Static FSM component",
     "version",           "1.0",
     "vendor",            "Noriaki Ando, AIST",
     "category",          "example",
@@ -81,7 +81,7 @@ extern "C"
 {
   void MicrowaveInit(RTC::Manager* manager)
   {
-    coil::Properties profile(consoleout_spec);
+    coil::Properties profile(microwave_spec);
     manager->registerFactory(profile,
                              RTC::Create<Microwave>,
                              RTC::Delete<Microwave>);

--- a/examples/Throughput/Throughput.cpp
+++ b/examples/Throughput/Throughput.cpp
@@ -17,7 +17,7 @@
 
 // Module specification
 // <rtc-template block="module_spec">
-static const char* const analyzer_spec[] =
+static const char* const throughput_spec[] =
   {
     "implementation_id", "Throughput",
     "type_name",         "Throughput",
@@ -538,7 +538,7 @@ extern "C"
  
   void ThroughputInit(RTC::Manager* manager)
   {
-    coil::Properties profile(analyzer_spec);
+    coil::Properties profile(throughput_spec);
     manager->registerFactory(profile,
                              RTC::Create<Throughput>,
                              RTC::Delete<Throughput>);


### PR DESCRIPTION
# Identify the Bug

#494

StaticFSMのサンプルMicrowaveを使用を定義した***_specが以下のようにconsoleout_specとなっており、descriptionがConsoleInの説明になっている。

## Description of the Change

- specの変数名および、ファクトリへの引数を変更
- spec 内のdescriptionを変更

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
