### PR TITLE
ByteDataクラスのメモリリークの修正

### DIFF
--- a/src/lib/rtm/ByteData.cpp
+++ b/src/lib/rtm/ByteData.cpp
@@ -108,8 +108,12 @@ namespace RTC
      */
     ByteData& ByteData::operator= (const ByteData &rhs)
     {
-        m_len = rhs.m_len;
-        m_buf = new unsigned char[m_len];
+        if(m_len != rhs.m_len)
+        {
+            m_len = rhs.m_len;
+            delete[] m_buf;
+            m_buf = new unsigned char[m_len];
+        }
         memcpy(m_buf, rhs.m_buf, m_len);
         return *this;
     }
@@ -133,8 +137,12 @@ namespace RTC
      */
     ByteData& ByteData::operator= (const ByteDataStreamBase &rhs)
     {
-        m_len = rhs.getDataLength();
-        m_buf = new unsigned char[m_len];
+        if(m_len != rhs.getDataLength())
+        {
+            m_len = rhs.getDataLength();
+            delete[] m_buf;
+            m_buf = new unsigned char[m_len];
+        }
         rhs.readData(m_buf, m_len);
         return *this;
     }
@@ -237,11 +245,13 @@ namespace RTC
         {
             return;
         }
-        
-        delete[] m_buf;
-        
-        m_len = length;
-        m_buf = new unsigned char[length];
+
+        if(m_len != length)
+        {
+            delete[] m_buf;
+            m_len = length;
+            m_buf = new unsigned char[length];
+        }
         memcpy(m_buf, data, length);
     }
     /*!
@@ -284,7 +294,7 @@ namespace RTC
      */
     void ByteData::setDataLength(unsigned long length)
     {
-        if (length <= 0)
+        if (length <= 0 || m_len == length)
         {
             return;
         }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

データの送受信を実行するたびにメモリの使用量が増大するバグが発生する。

## Description of the Change

シリアライズ後のバイト列を保持するByteDataクラスの代入演算子の処理で解放漏れがあったため修正した。
またデータのサイズが変化していないときに領域の再確保を行うのは無駄のため修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
