### PR TITLE
データポートの通信が遅い問題の解決

### DIFF
--- a/src/ext/transport/FastRTPS/FastRTPSInPort.h
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.h
@@ -263,7 +263,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -278,7 +278,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -293,7 +293,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -308,7 +308,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -323,7 +323,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -338,7 +338,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -351,7 +351,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -364,7 +364,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyIn(m_profile, data);
     }
 
   private:

--- a/src/ext/transport/OpenSplice/OpenSpliceInPort.h
+++ b/src/ext/transport/OpenSplice/OpenSpliceInPort.h
@@ -248,7 +248,7 @@ namespace RTC
         inline void onBufferWrite(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+                connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
         }
 
         /*!
@@ -263,7 +263,7 @@ namespace RTC
         inline void onBufferFull(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+                connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
         }
 
         /*!
@@ -278,7 +278,7 @@ namespace RTC
         inline void onBufferWriteTimeout(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
+                connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyIn(m_profile, data);
         }
 
         /*!
@@ -293,7 +293,7 @@ namespace RTC
         inline void onBufferWriteOverwrite(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
+                connectorData_[ON_BUFFER_OVERWRITE]->notifyIn(m_profile, data);
         }
 
         /*!
@@ -308,7 +308,7 @@ namespace RTC
         inline void onReceived(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+                connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
         }
 
         /*!
@@ -323,7 +323,7 @@ namespace RTC
         inline void onReceiverFull(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+                connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
         }
 
         /*!
@@ -336,7 +336,7 @@ namespace RTC
         inline void onReceiverTimeout(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
+                connectorData_[ON_RECEIVER_TIMEOUT]->notifyIn(m_profile, data);
         }
 
         /*!
@@ -349,7 +349,7 @@ namespace RTC
         inline void onReceiverError(ByteData& data)
         {
             m_listeners->
-                connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
+                connectorData_[ON_RECEIVER_ERROR]->notifyIn(m_profile, data);
         }
 
     private:

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -356,7 +356,7 @@ namespace RTC
       header["md5sum"] = info->md5sum();
       header["callerid"] = m_callerid;
       header["type"] = info->type();
-      header["tcp_nodelay"] = "0";
+      header["tcp_nodelay"] = "1";
 
       RTC_VERBOSE(("writeHeader()"));
       RTC_VERBOSE(("Message Type:%s", info->type().c_str()));

--- a/src/ext/transport/ROSTransport/ROSInPort.h
+++ b/src/ext/transport/ROSTransport/ROSInPort.h
@@ -521,7 +521,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -536,7 +536,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -551,7 +551,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -566,7 +566,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -581,7 +581,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -596,7 +596,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -609,7 +609,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -622,7 +622,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyIn(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/CORBA_CdrMemoryStream.cpp
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.cpp
@@ -47,10 +47,12 @@ namespace RTC
     {
         m_endian = little_endian;
 #ifdef ORB_IS_ORBEXPRESS
+        _cdr.rewind();
         m_cdr.is_little_endian(little_endian);
 #elif defined(ORB_IS_TAO)
-
+        m_cdr.reset();
 #else
+        m_cdr.rewindPtrs();
         m_cdr.setByteSwapFlag(little_endian);
 #endif
     }

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -125,6 +125,21 @@ namespace RTC
     return ret;
   }
 
+  ConnectorListenerHolder::ReturnCode ConnectorDataListenerHolder::notifyIn(ConnectorInfo& info, ByteData& data)
+  {
+      std::string type = info.properties.getProperty("marshaling_type", "corba");
+      std::string marshaling_type{ coil::eraseBothEndsBlank(
+        info.properties.getProperty("in.marshaling_type", type)) };
+      return notify(info, data, marshaling_type);
+  }
+
+  ConnectorListenerHolder::ReturnCode ConnectorDataListenerHolder::notifyOut(ConnectorInfo& info, ByteData& data)
+  {
+      std::string type = info.properties.getProperty("marshaling_type", "corba");
+      std::string marshaling_type{ coil::eraseBothEndsBlank(
+        info.properties.getProperty("out.marshaling_type", type)) };
+      return notify(info, data, marshaling_type);
+  }
 
   /*!
    * @if jp

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -59,7 +59,10 @@ namespace RTC
    * @class ConnectorDataListener holder class
    * @endif
    */
-  ConnectorDataListenerHolder::ConnectorDataListenerHolder() = default;
+  ConnectorDataListenerHolder::ConnectorDataListenerHolder()
+  {
+      delete m_cdr;
+  }
 
 
   ConnectorDataListenerHolder::~ConnectorDataListenerHolder()
@@ -207,7 +210,13 @@ namespace RTC
    * @brief Constructor
    * @endif
    */
-  ConnectorListeners::ConnectorListeners() = default;
+  ConnectorListeners::ConnectorListeners()
+  {
+      for (unsigned int i = 0; i < CONNECTOR_DATA_LISTENER_NUM; i++)
+      {
+          connectorData_[i] = new ConnectorDataListenerHolder();
+      }
+  }
   /*!
    * @if jp
    * @brief デストラクタ

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1078,6 +1078,12 @@ namespace RTC
     virtual ReturnCode notify(ConnectorInfo& info,
                 ByteData& cdrdata, const std::string& marshalingtype);
 
+
+    virtual ReturnCode notifyIn(ConnectorInfo& info, ByteData& data);
+
+    virtual ReturnCode notifyOut(ConnectorInfo& info, ByteData& data);
+
+
     /*!
      * @if jp
      *
@@ -1522,6 +1528,24 @@ namespace RTC
               }
           }
           return ret;
+      }
+
+
+
+      ReturnCode notifyIn(ConnectorInfo& info, ByteData& data) override
+      {
+          std::string type = info.properties.getProperty("marshaling_type", "corba");
+          std::string marshaling_type{ coil::eraseBothEndsBlank(
+            info.properties.getProperty("in.marshaling_type", type)) };
+          return notify(info, data, marshaling_type);
+      }
+
+      ReturnCode notifyOut(ConnectorInfo& info, ByteData& data) override
+      {
+          std::string type = info.properties.getProperty("marshaling_type", "corba");
+          std::string marshaling_type{ coil::eraseBothEndsBlank(
+            info.properties.getProperty("out.marshaling_type", type)) };
+          return notify(info, data, marshaling_type);
       }
 
   };

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1527,6 +1527,23 @@ namespace RTC
                   ret = ret | listener.first->operator()(info, cdrdata, marshalingtype);
               }
           }
+
+          if (ret == DATA_CHANGED || ret == BOTH_CHANGED)
+          {
+              if (endian[0] == "little")
+              {
+                  cdr->isLittleEndian(true);
+              }
+              else if (endian[0] == "big")
+              {
+                  cdr->isLittleEndian(false);
+              }
+
+              cdr->serialize(data);
+              cdrdata.setDataLength(cdr->getDataLength());
+              cdr->readData(cdrdata.getBuffer(), cdrdata.getDataLength());
+          }
+
           return ret;
       }
 

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -516,12 +516,23 @@ namespace RTC
   public:
     /*!
      * @if jp
+     * @brief コンストラクタ
+     * @else
+     * @brief Constructor
+     * @endif
+     */
+    ConnectorDataListenerT() = default;
+    /*!
+     * @if jp
      * @brief デストラクタ
      * @else
      * @brief Destructor
      * @endif
      */
-    ~ConnectorDataListenerT() override = default;
+    ~ConnectorDataListenerT() override
+    {
+        delete m_cdr;
+    }
 
     /*!
      * @if jp
@@ -553,14 +564,20 @@ namespace RTC
     {
       DataType data;
 
-      ByteDataStream<DataType> *cdr = coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().createObject(marshalingtype);
+      if(m_cdr == nullptr || m_marshalingtype != marshalingtype)
+      {
+        m_cdr = coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().createObject(marshalingtype);
+        m_marshalingtype = marshalingtype;
+      }
+      ::RTC::ByteDataStream<DataType> *cdr = dynamic_cast<::RTC::ByteDataStream<DataType>*>(m_cdr);
+      
 
       if (!cdr)
       {
           return NO_CHANGE;
       }
 
-      cdr->writeData(cdrdata.getBuffer(), cdrdata.getDataLength());
+      
       // endian type check
       std::string endian_type{coil::normalize(
         info.properties.getProperty("serializer.cdr.endian", "little"))};
@@ -574,6 +591,9 @@ namespace RTC
       {
           cdr->isLittleEndian(false);
       }
+
+
+      cdr->writeData(cdrdata.getBuffer(), cdrdata.getDataLength());
 
       cdr->deserialize(data);
 
@@ -594,10 +614,6 @@ namespace RTC
           cdr->readData(cdrdata.getBuffer(), cdrdata.getDataLength());
       }
 
-      
-
-      coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().deleteObject(cdr);
-  
       return ret;
     }
 
@@ -620,6 +636,9 @@ namespace RTC
      */
     virtual ReturnCode operator()(ConnectorInfo& info,
                                  DataType& data) = 0;
+  private:
+      ByteDataStreamBase* m_cdr{nullptr};
+      std::string m_marshalingtype;
   };
 
   /*!
@@ -1056,7 +1075,7 @@ namespace RTC
      * @param cdrdata Data
      * @endif
      */
-    ReturnCode notify(ConnectorInfo& info,
+    virtual ReturnCode notify(ConnectorInfo& info,
                 ByteData& cdrdata, const std::string& marshalingtype);
 
     /*!
@@ -1145,6 +1164,11 @@ namespace RTC
       std::lock_guard<std::mutex> guard(m_mutex);
       ReturnCode ret(NO_CHANGE);
 
+      if(m_listeners.empty())
+      {
+        return ret;
+      }
+
       std::string endian_type{coil::normalize(
         info.properties.getProperty("serializer.cdr.endian", "little"))};
       std::vector<std::string> endian(coil::split(endian_type, ","));
@@ -1160,7 +1184,17 @@ namespace RTC
             }
           else
             {
-              ByteDataStream<DataType> *cdr = coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().createObject(marshalingtype);
+              if (m_cdr == nullptr || m_marshalingtype != marshalingtype)
+              {
+                  m_cdr = coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().createObject(marshalingtype);
+                  m_marshalingtype = marshalingtype;
+              }
+              ::RTC::ByteDataStream<DataType> *cdr = dynamic_cast<::RTC::ByteDataStream<DataType>*>(m_cdr);
+
+              if (!cdr)
+              {
+                  return NO_CHANGE;
+              }
 
               if (endian[0] == "little")
               {
@@ -1173,17 +1207,18 @@ namespace RTC
               cdr->serialize(typeddata);
               ByteData tmp = *cdr;
               ret = ret | listener.first->operator()(info, tmp, marshalingtype);
-              coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().deleteObject(cdr);
+
             }
         }
       return ret;
     }
 
-  private:
+  protected:
     std::vector<Entry> m_listeners;
     std::mutex m_mutex;
+    ByteDataStreamBase* m_cdr{ nullptr };
+    std::string m_marshalingtype;
   };
-
 
   /*!
    * @if jp
@@ -1350,7 +1385,7 @@ namespace RTC
      * The ConnectorDataListenerType listener is stored.
      * @endif
      */
-    ConnectorDataListenerHolder connectorData_[CONNECTOR_DATA_LISTENER_NUM];
+    ConnectorDataListenerHolder *connectorData_[CONNECTOR_DATA_LISTENER_NUM];
     /*!
      * @if jp
      * @brief ConnectorListenerTypeリスナ配列
@@ -1361,6 +1396,178 @@ namespace RTC
      * @endif
      */
     ConnectorListenerHolder connector_[CONNECTOR_LISTENER_NUM];
+  };
+
+
+  /*!
+   * @if jp
+   * @class ConnectorDataListenerHolderT
+   * @brief データ型指定のConnectorListener ホルダクラス
+   *
+   * 複数の ConnectorListener を保持し管理するクラス。
+   *
+   * @else
+   * @class ConnectorDataListenerHolderT
+   * @brief ConnectorListener holder class
+   *
+   * This class manages one ore more instances of ConnectorListener class.
+   *
+   * @endif
+   */
+  template <class DataType>
+  class ConnectorDataListenerHolderT
+      : public ConnectorDataListenerHolder
+  {
+  public:
+      /*!
+       * @if jp
+       * @brief コンストラクタ
+       * @else
+       * @brief Constructor
+       * @endif
+       */
+      ConnectorDataListenerHolderT() = default;
+      /*!
+       * @if jp
+       * @brief デストラクタ
+       * @else
+       * @brief Destructor
+       * @endif
+       */
+      ~ConnectorDataListenerHolderT() override
+      {
+
+      }
+
+
+
+      /*!
+       * @if jp
+       *
+       * @brief リスナーへ通知する
+       *
+       * 登録されているリスナのコールバックメソッドを呼び出す。
+       *
+       * @param info ConnectorInfo
+       * @param cdrdata データ
+       * @else
+       *
+       * @brief Notify listeners.
+       *
+       * This calls the Callback method of the registered listener.
+       *
+       * @param info ConnectorInfo
+       * @param cdrdata Data
+       * @endif
+       */
+      ReturnCode notify(ConnectorInfo& info,
+          ByteData& cdrdata, const std::string& marshalingtype) override
+      {
+          std::lock_guard<std::mutex> guard(m_mutex);
+          ConnectorListenerHolder::ReturnCode ret(NO_CHANGE);
+
+          if(m_listeners.empty())
+          {
+            return ret;
+          }
+
+          DataType data;
+
+          if (m_cdr == nullptr || m_marshalingtype != marshalingtype)
+          {
+              m_cdr = coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().createObject(marshalingtype);
+              m_marshalingtype = marshalingtype;
+          }
+          ::RTC::ByteDataStream<DataType> *cdr = dynamic_cast<::RTC::ByteDataStream<DataType>*>(m_cdr);
+
+
+          if (!cdr)
+          {
+              return NO_CHANGE;
+          }
+
+
+          // endian type check
+          std::string endian_type{ coil::normalize(
+            info.properties.getProperty("serializer.cdr.endian", "little")) };
+          std::vector<std::string> endian(coil::split(endian_type, ","));
+
+          if (endian[0] == "little")
+          {
+              cdr->isLittleEndian(true);
+          }
+          else if (endian[0] == "big")
+          {
+              cdr->isLittleEndian(false);
+          }
+
+
+          cdr->writeData(cdrdata.getBuffer(), cdrdata.getDataLength());
+
+          cdr->deserialize(data);
+
+
+          for (auto & listener : m_listeners)
+          {
+              ConnectorDataListenerT<DataType>* datalistener(nullptr);
+              datalistener =
+                  dynamic_cast<ConnectorDataListenerT<DataType>*>(listener.first);
+              if (datalistener != nullptr)
+              {
+                  ret = ret | datalistener->operator()(info, data);
+              }
+              else
+              {
+                  ret = ret | listener.first->operator()(info, cdrdata, marshalingtype);
+              }
+          }
+          return ret;
+      }
+
+  };
+
+  /*!
+   * @if jp
+   * @class ConnectorListenersT
+   * @brief ConnectorListenersT クラス
+   *
+   *
+   * @else
+   * @class ConnectorListenersT
+   * @brief ConnectorListenersT class
+   *
+   *
+   * @endif
+   */
+  template <class DataType>
+  class ConnectorListenersT
+      : public ConnectorListeners
+  {
+  public:
+      /*!
+       * @if jp
+       * @brief コンストラクタ
+       * @else
+       * @brief Constructor
+       * @endif
+       */
+      ConnectorListenersT()
+      {
+          for (unsigned int i = 0; i < CONNECTOR_DATA_LISTENER_NUM; i++)
+          {
+              delete connectorData_[i];
+              connectorData_[i] = new ConnectorDataListenerHolderT<DataType>();
+          }
+      };
+      /*!
+       * @if jp
+       * @brief デストラクタ
+       * @else
+       * @brief Destructor
+       * @endif
+       */
+      ~ConnectorListenersT() {};
+
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -118,6 +118,9 @@ namespace RTC
         m_OnRead(nullptr),  m_OnReadConvert(nullptr),
         m_status(1), m_directNewData(false)
     {
+
+      this->initConnectorListeners();
+
       this->addConnectorDataListener(ON_RECEIVED,
                                      new Timestamp<DataType>("on_received"));
       this->addConnectorDataListener(ON_BUFFER_READ,
@@ -781,7 +784,26 @@ namespace RTC
     {
       m_OnReadConvert = on_rconvert;
     }
-
+  protected:
+    /*!
+     * @if jp
+     *
+     * @brief コネクタリスナの初期化 
+     *
+     * 
+     *
+     * @else
+     *
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    void initConnectorListeners() override
+    {
+      delete m_listeners;
+      m_listeners = new ConnectorListenersT<DataType>();
+    }
   private:
     std::string m_typename;
     /*!

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -41,7 +41,7 @@ namespace RTC
    * @endif
    */
   InPortBase::InPortBase(const char* name, const char* data_type)
-    : PortBase(name), m_singlebuffer(true), m_thebuffer(nullptr), m_littleEndian(true)
+    : PortBase(name), m_singlebuffer(true), m_thebuffer(nullptr), m_littleEndian(true), m_listeners(nullptr)
   {
     RTC_DEBUG(("Port name: %s", name));
 
@@ -55,6 +55,8 @@ namespace RTC
     m_properties["data_type"] = data_type;
 
     addProperty("dataport.subscription_type", "Any");
+
+    initConnectorListeners();
   }
 
   /*!
@@ -88,7 +90,7 @@ namespace RTC
             RTC_ERROR(("Although singlebuffer flag is true, the buffer != 0"));
           }
       }
-
+    delete m_listeners;
   }
 
   /*!
@@ -369,7 +371,7 @@ namespace RTC
       {
         RTC_TRACE(("addConnectorDataListener(%s)",
                    ConnectorDataListener::toString(type)));
-        m_listeners.connectorData_[type].addListener(listener, autoclean);
+        m_listeners->connectorData_[type]->addListener(listener, autoclean);
         return;
       }
     RTC_ERROR(("addConnectorDataListener(): Invalid listener type."));
@@ -384,7 +386,7 @@ namespace RTC
       {
         RTC_TRACE(("removeConnectorDataListener(%s)",
                    ConnectorDataListener::toString(type)));
-        m_listeners.connectorData_[type].removeListener(listener);
+        m_listeners->connectorData_[type]->removeListener(listener);
         return;
       }
     RTC_ERROR(("removeConnectorDataListener(): Invalid listener type."));
@@ -408,7 +410,7 @@ namespace RTC
       {
         RTC_TRACE(("addConnectorListener(%s)",
                    ConnectorListener::toString(type)));
-        m_listeners.connector_[type].addListener(listener, autoclean);
+        m_listeners->connector_[type].addListener(listener, autoclean);
         return;
       }
     RTC_ERROR(("addConnectorListener(): Invalid listener type."));
@@ -422,7 +424,7 @@ namespace RTC
       {
         RTC_TRACE(("removeConnectorListener(%s)",
                    ConnectorListener::toString(type)));
-        m_listeners.connector_[type].removeListener(listener);
+        m_listeners->connector_[type].removeListener(listener);
         return;
       }
     RTC_ERROR(("removeConnectorListener(): Invalid listener type."));
@@ -1046,7 +1048,7 @@ namespace RTC
       }
   }
 
-  ConnectorListeners& InPortBase::getListeners()
+  ConnectorListeners* InPortBase::getListeners()
   {
     return m_listeners;
   }
@@ -1111,5 +1113,24 @@ namespace RTC
       }
 
       return PortBase::notify_connect(connector_profile);
+  }
+  /*!
+   * @if jp
+   *
+   * @brief コネクタリスナの初期化
+   *
+   *
+   *
+   * @else
+   *
+   * @brief
+   *
+   *
+   * @endif
+   */
+  void InPortBase::initConnectorListeners()
+  {
+      delete m_listeners;
+      m_listeners = new ConnectorListeners();
   }
 } // namespace RTC

--- a/src/lib/rtm/InPortBase.h
+++ b/src/lib/rtm/InPortBase.h
@@ -614,9 +614,8 @@ namespace RTC
      *
      * @endif
      */
-    virtual ConnectorListeners& getListeners();
+    virtual ConnectorListeners* getListeners();
     ReturnCode_t notify_connect(ConnectorProfile& connector_profile) override;
-
   protected:
     /*!
      * @if jp
@@ -734,7 +733,7 @@ namespace RTC
      * @param prop チェックするプロパティ
      * @param littleEndian エンディアン情報（true:little,false:big）
      * @return true:"serializer"キーが存在しない または 存在していて内容がある。
-,false:"serializer"キーが存在しているが内容が空 または 存在しているが内容が"little","big" 以外。
+     * ,false:"serializer"キーが存在しているが内容が空 または 存在しているが内容が"little","big" 以外。
      *
      * @else
      *
@@ -811,15 +810,30 @@ namespace RTC
     InPortConnector*
     createConnector(const ConnectorProfile& cprof, coil::Properties& prop,
                     OutPortConsumer* consumer);
-  protected:
-	  /*!
+	 /*!
 	  * @if jp
 	  * @brief ローカルのピアOutPortを取得
 	  * @else
 	  * @brief Getting local peer OutPort if available
 	  * @endif
 	  */
-	  OutPortBase* getLocalOutPort(const ConnectorInfo& profile);
+	OutPortBase* getLocalOutPort(const ConnectorInfo& profile);
+
+    /*!
+     * @if jp
+     *
+     * @brief コネクタリスナの初期化 
+     *
+     * 
+     *
+     * @else
+     *
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    virtual void initConnectorListeners();
     /*!
      * @if jp
      * @brief バッファモード
@@ -884,7 +898,7 @@ namespace RTC
      * @brief ConnectorDataListener listener
      * @endif
      */
-    ConnectorListeners m_listeners;
+    ConnectorListeners *m_listeners;
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPortConnector.cpp
+++ b/src/lib/rtm/InPortConnector.cpp
@@ -30,10 +30,10 @@ namespace RTC
    * @endif
    */
   InPortConnector::InPortConnector(ConnectorInfo& info,
-                                   ConnectorListeners& listeners,
+                                   ConnectorListeners* listeners,
                                    CdrBufferBase* buffer)
     : rtclog("InPortConnector"), m_profile(info),
-	m_listeners(listeners), m_buffer(buffer), m_littleEndian(true), m_outPortListeners(nullptr), m_directOutPort(nullptr), m_marshaling_type("corba")
+	m_listeners(listeners), m_buffer(buffer), m_littleEndian(true), m_outPortListeners(nullptr), m_directOutPort(nullptr), m_marshaling_type("corba"), m_cdr(nullptr)
   {
   }
 
@@ -44,7 +44,10 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  InPortConnector::~InPortConnector() = default;
+  InPortConnector::~InPortConnector()
+  {
+      delete m_cdr;
+  }
 
   /*!
    * @if jp
@@ -161,7 +164,7 @@ namespace RTC
 		  }
 		  m_directOutPort = directOutPort;
 		  
-		  m_outPortListeners = &(directOutPort->getListeners());
+		  m_outPortListeners = directOutPort->getListeners();
 		  return true;
 	  }
   }

--- a/src/lib/rtm/InPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.cpp
@@ -72,10 +72,9 @@ namespace RTC
     RTC_PARANOID(("put()"));
 
 #ifndef ORB_IS_RTORB
-    ::OpenRTM::CdrData tmp;
     CORBA::ULong len = static_cast<CORBA::ULong>(data.getDataLength());
-    tmp.length(len);
-    data.readData(static_cast<unsigned char*>(tmp.get_buffer()), len);
+    m_data.length(len);
+    data.readData(static_cast<unsigned char*>(m_data.get_buffer()), len);
 #else // ORB_IS_RTORB
     OpenRTM_CdrData *cdrdata_tmp = new OpenRTM_CdrData();
     cdrdata_tmp->_buffer =
@@ -88,7 +87,7 @@ namespace RTC
       {
         // return code conversion
         // (IDL)OpenRTM::DataPort::ReturnCode_t -> DataPortStatus
-        return convertReturnCode(_ptr()->put(tmp));
+        return convertReturnCode(_ptr()->put(m_data));
       }
     catch (...)
       {

--- a/src/lib/rtm/InPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.cpp
@@ -1,6 +1,6 @@
 ﻿// -*- C++ -*-
 /*!
- * @file  InPortCorbaCdrConsumer.h
+ * @file  InPortCorbaCdrConsumer.cpp
  * @brief InPortCorbaCdrConsumer class
  * @date  $Date: 2007-12-31 03:08:03 $
  * @author Noriaki Ando <n-ando@aist.go.jp>
@@ -93,7 +93,6 @@ namespace RTC
       {
         return DataPortStatus::CONNECTION_LOST;
       }
-    return DataPortStatus::UNKNOWN_ERROR;
   }
 
   /*!

--- a/src/lib/rtm/InPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.h
@@ -296,6 +296,7 @@ namespace RTC
 
     mutable Logger rtclog;
     coil::Properties m_properties;
+    ::OpenRTM::CdrData m_data;
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrProvider.cpp
@@ -151,27 +151,26 @@ namespace RTC
 
     if (m_connector == nullptr)
       {
-        ByteData cdr;
-        cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
+        m_cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
 
-        onReceiverError(cdr);
+        onReceiverError(m_cdr);
         return ::OpenRTM::PORT_ERROR;
       }
 
     RTC_PARANOID(("received data size: %d", data.length()));
-    ByteData cdr;
+    
     // set endian type
     bool endian_type = m_connector->isLittleEndian();
     RTC_TRACE(("connector endian: %s", endian_type ? "little":"big"));
 
-    cdr.isLittleEndian(endian_type);
-    cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
-    RTC_PARANOID(("converted CDR data size: %d", cdr.getDataLength()));
+    m_cdr.isLittleEndian(endian_type);
+    m_cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
+    RTC_PARANOID(("converted CDR data size: %d", m_cdr.getDataLength()));
 
-    onReceived(cdr);
-    BufferStatus ret = m_connector->write(cdr);
+    onReceived(m_cdr);
+    BufferStatus ret = m_connector->write(m_cdr);
 
-    return convertReturn(ret, cdr);
+    return convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/InPortCorbaCdrProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrProvider.h
@@ -267,7 +267,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -282,7 +282,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -297,7 +297,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -312,7 +312,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -327,7 +327,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -342,7 +342,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -355,7 +355,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -368,7 +368,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyIn(m_profile, data);
     }
 
   private:
@@ -377,6 +377,7 @@ namespace RTC
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     InPortConnector* m_connector{nullptr};
+    ByteData m_cdr;
 
   };  // class InPortCorbaCdrProvider
 } // namespace RTC

--- a/src/lib/rtm/InPortCorbaCdrUDPConsumer.cpp
+++ b/src/lib/rtm/InPortCorbaCdrUDPConsumer.cpp
@@ -100,7 +100,6 @@ namespace RTC
       {
         return DataPortStatus::CONNECTION_LOST;
       }
-    return DataPortStatus::UNKNOWN_ERROR;
   }
   
   /*!

--- a/src/lib/rtm/InPortCorbaCdrUDPConsumer.cpp
+++ b/src/lib/rtm/InPortCorbaCdrUDPConsumer.cpp
@@ -78,10 +78,9 @@ namespace RTC
     RTC_PARANOID(("put()"));
 
 #ifndef ORB_IS_RTORB
-    ::OpenRTM::CdrData tmp;
     CORBA::ULong len = (CORBA::ULong)data.getDataLength();
-    tmp.length(len);
-    data.readData((unsigned char*)tmp.get_buffer(), len);
+    m_data.length(len);
+    data.readData((unsigned char*)m_data.get_buffer(), len);
 #else // ORB_IS_RTORB
     OpenRTM_CdrData *cdrdata_tmp = new OpenRTM_CdrData();
     cdrdata_tmp->_buffer =
@@ -94,7 +93,7 @@ namespace RTC
       {
         // return code conversion
         // (IDL)OpenRTM::DataPort::ReturnCode_t -> DataPortStatus
-		_ptr()->put(tmp);
+        _ptr()->put(m_data);
         return DataPortStatus::PORT_OK;
       }
     catch (...)
@@ -194,25 +193,25 @@ namespace RTC
 	
 
 #ifdef ORB_IS_TAO
-	TAO_Stub *stub = obj->_stubobj();
+    TAO_Stub *stub = obj->_stubobj();
 
 
-	TAO_MProfile profiles = stub->base_profiles();
-	
-	while (profiles.profile_count() > 1)
-	{
-		if (profiles.get_profile(0)->tag() != TAO_TAG_DIOP_PROFILE)
-		{
-			profiles.remove_profile(profiles.get_profile(0));
-		}
-		else
-		{
-			break;
-		}
-	}
-	
-	TAO_Profile* profile = stub->profile_in_use();
-	stub->base_profiles(profiles);
+    TAO_MProfile profiles = stub->base_profiles();
+    
+    while (profiles.profile_count() > 1)
+      {
+        if (profiles.get_profile(0)->tag() != TAO_TAG_DIOP_PROFILE)
+          {
+            profiles.remove_profile(profiles.get_profile(0));
+          }
+        else
+          {
+            break;
+          }
+    }
+    
+    TAO_Profile* profile = stub->profile_in_use();
+    stub->base_profiles(profiles);
 #endif
     
     if (CORBA::is_nil(obj))

--- a/src/lib/rtm/InPortCorbaCdrUDPConsumer.h
+++ b/src/lib/rtm/InPortCorbaCdrUDPConsumer.h
@@ -288,6 +288,7 @@ namespace RTC
 
     mutable Logger rtclog;
     coil::Properties m_properties;
+    ::OpenRTM::CdrData m_data;
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPortCorbaCdrUDPProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrUDPProvider.cpp
@@ -153,29 +153,27 @@ namespace RTC
 
     if (m_buffer == 0)
       {
-        ByteData cdr;
 
-        cdr.writeData((unsigned char*)data.get_buffer(), data.length());
+        m_cdr.writeData((unsigned char*)data.get_buffer(), data.length());
 
-        onReceiverError(cdr);
+        onReceiverError(m_cdr);
         return;
       }
 
     RTC_PARANOID(("received data size: %d", data.length()))
-    ByteData cdr;
     // set endian type
     bool endian_type = m_connector->isLittleEndian();
     RTC_TRACE(("connector endian: %s", endian_type ? "little":"big"));
 
-    cdr.isLittleEndian(endian_type);
-    cdr.writeData((unsigned char*)&(data[0]), data.length());
-    RTC_PARANOID(("converted CDR data size: %d", cdr.getDataLength()));
+    m_cdr.isLittleEndian(endian_type);
+    m_cdr.writeData((unsigned char*)&(data[0]), data.length());
+    RTC_PARANOID(("converted CDR data size: %d", m_cdr.getDataLength()));
 
 
-    onReceived(cdr);
-	BufferStatus ret = m_buffer->write(cdr);
+    onReceived(m_cdr);
+    BufferStatus ret = m_buffer->write(m_cdr);
 
-	convertReturn(ret, cdr);
+    convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/InPortCorbaCdrUDPProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrUDPProvider.h
@@ -258,7 +258,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notify(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notify(m_profile, data);
     }
 
     /*!
@@ -273,7 +273,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notify(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notify(m_profile, data);
     }
 
     /*!
@@ -288,7 +288,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notify(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notify(m_profile, data);
     }
 
     /*!
@@ -303,7 +303,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notify(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notify(m_profile, data);
     }
 
     /*!
@@ -318,7 +318,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notify(m_profile, data);
+        connectorData_[ON_RECEIVED]->notify(m_profile, data);
     }
 
     /*!
@@ -333,7 +333,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notify(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notify(m_profile, data);
     }
 
     /*!
@@ -346,7 +346,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notify(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notify(m_profile, data);
     }
 
     /*!
@@ -359,7 +359,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notify(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notify(m_profile, data);
     }
 
   private:
@@ -377,6 +377,7 @@ namespace RTC
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     InPortConnector* m_connector;
+    ByteData m_cdr;
 
   };  // class InPortCorCdrbaProvider
 } // namespace RTC

--- a/src/lib/rtm/InPortDSConsumer.cpp
+++ b/src/lib/rtm/InPortDSConsumer.cpp
@@ -1,6 +1,6 @@
 ﻿// -*- C++ -*-
 /*!
- * @file  InPortDSConsumer.h
+ * @file  InPortDSConsumer.cpp
  * @brief InPortDSConsumer class
  * @date  $Date: 2018-09-20 07:49:59 $
  * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
@@ -91,7 +91,6 @@ namespace RTC
       {
         return DataPortStatus::CONNECTION_LOST;
       }
-    return DataPortStatus::UNKNOWN_ERROR;
   }
 
   /*!

--- a/src/lib/rtm/InPortDSConsumer.cpp
+++ b/src/lib/rtm/InPortDSConsumer.cpp
@@ -70,10 +70,9 @@ namespace RTC
     RTC_PARANOID(("put()"));
 
 #ifndef ORB_IS_RTORB
-    ::RTC::OctetSeq tmp;
     CORBA::ULong len = static_cast<CORBA::ULong>(data.getDataLength());
-    tmp.length(len);
-    data.readData(static_cast<unsigned char*>(tmp.get_buffer()), len);
+    m_data.length(len);
+    data.readData(static_cast<unsigned char*>(m_data.get_buffer()), len);
 #else // ORB_IS_RTORB
     OpenRTM_CdrData *cdrdata_tmp = new OpenRTM_CdrData();
     cdrdata_tmp->_buffer =
@@ -86,7 +85,7 @@ namespace RTC
       {
         // return code conversion
         // (IDL)OpenRTM::DataPort::ReturnCode_t -> DataPortStatus
-        return convertReturnCode(_ptr()->push(tmp));
+        return convertReturnCode(_ptr()->push(m_data));
       }
     catch (...)
       {

--- a/src/lib/rtm/InPortDSConsumer.h
+++ b/src/lib/rtm/InPortDSConsumer.h
@@ -37,7 +37,7 @@ namespace RTC
    * データ転送に CORBA の RTC::DataPushService インターフェースを利用し
    * た、push 型データフロー型を実現する InPort コンシューマクラス。
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @else
    * @class InPortDSConsumer
@@ -47,7 +47,7 @@ namespace RTC
    * interface in CORBA for data transfer and realizes a push-type
    * dataflow.
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @endif
    */
@@ -294,6 +294,7 @@ namespace RTC
 
     mutable Logger rtclog;
     coil::Properties m_properties;
+    ::RTC::OctetSeq m_data;
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPortDSProvider.cpp
+++ b/src/lib/rtm/InPortDSProvider.cpp
@@ -149,29 +149,26 @@ namespace RTC
 
     if (m_connector == nullptr)
       {
-        ByteData cdr;
+        m_cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
 
-        cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
-
-        onReceiverError(cdr);
+        onReceiverError(m_cdr);
         return ::RTC::PORT_ERROR;
       }
 
     RTC_PARANOID(("received data size: %d", data.length()));
-    ByteData cdr;
     // set endian type
     bool endian_type = m_connector->isLittleEndian();
     RTC_TRACE(("connector endian: %s", endian_type ? "little":"big"));
 
-    cdr.isLittleEndian(endian_type);
-    cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
-    RTC_PARANOID(("converted CDR data size: %d", cdr.getDataLength()));
+    m_cdr.isLittleEndian(endian_type);
+    m_cdr.writeData(const_cast<unsigned char*>(data.get_buffer()), static_cast<CORBA::ULong>(data.length()));
+    RTC_PARANOID(("converted CDR data size: %d", m_cdr.getDataLength()));
 
 
-    onReceived(cdr);
-    BufferStatus ret = m_connector->write(cdr);
+    onReceived(m_cdr);
+    BufferStatus ret = m_connector->write(m_cdr);
 
-    return convertReturn(ret, cdr);
+    return convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/InPortDSProvider.h
+++ b/src/lib/rtm/InPortDSProvider.h
@@ -38,7 +38,7 @@ namespace RTC
    * データ転送に CORBA の RTC::DataPushService インターフェースを利用し
    * た、push 型データフロー型を実現する InPort プロバイダクラス。
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @else
    * @class InPortDSProvider
@@ -48,7 +48,7 @@ namespace RTC
    * interface in CORBA for data transfer and realizes a push-type
    * dataflow.
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @endif
    */
@@ -265,7 +265,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -280,7 +280,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -295,7 +295,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -310,7 +310,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -325,7 +325,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -340,7 +340,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -353,7 +353,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -366,7 +366,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyIn(m_profile, data);
     }
 
   private:
@@ -375,6 +375,7 @@ namespace RTC
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     InPortConnector* m_connector{nullptr};
+    ByteData m_cdr;
 
   };  // class InPortDSProvider
 } // namespace RTC

--- a/src/lib/rtm/InPortDirectProvider.h
+++ b/src/lib/rtm/InPortDirectProvider.h
@@ -232,7 +232,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -247,7 +247,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -262,7 +262,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -277,7 +277,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -292,7 +292,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -307,7 +307,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -320,7 +320,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -333,7 +333,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyIn(m_profile, data);
     }
 
   private:

--- a/src/lib/rtm/InPortPullConnector.cpp
+++ b/src/lib/rtm/InPortPullConnector.cpp
@@ -34,7 +34,7 @@ namespace RTC
    */
   InPortPullConnector::InPortPullConnector(ConnectorInfo info,
                                            OutPortConsumer* consumer,
-                                           ConnectorListeners& listeners,
+                                           ConnectorListeners* listeners,
                                            CdrBufferBase* buffer)
     : InPortConnector(info, listeners, buffer), m_consumer(consumer),
       m_listeners(listeners)
@@ -49,7 +49,7 @@ namespace RTC
       }
     m_buffer->init(info.properties.getNode("buffer"));
     m_consumer->setBuffer(m_buffer);
-    m_consumer->setListener(info, &m_listeners);
+    m_consumer->setListener(info, m_listeners);
 
     std::string type{info.properties.getProperty("marshaling_type", "corba")};
     m_marshaling_type = coil::eraseBothEndsBlank(
@@ -86,9 +86,9 @@ namespace RTC
       {
         return DataPortStatus::PORT_ERROR;
       }
-    ByteData tmp;
-    DataPortStatus ret = m_consumer->get(tmp);
-    data->writeData(tmp.getBuffer(), tmp.getDataLength());
+    
+    DataPortStatus ret = m_consumer->get(m_data);
+    data->writeData(m_data.getBuffer(), m_data.getDataLength());
     return ret;
   }
 
@@ -137,7 +137,7 @@ namespace RTC
    */
   void InPortPullConnector::onConnect()
   {
-    m_listeners.connector_[ON_CONNECT].notify(m_profile);
+    m_listeners->connector_[ON_CONNECT].notify(m_profile);
   }
 
   /*!
@@ -149,7 +149,7 @@ namespace RTC
    */
   void InPortPullConnector::onDisconnect()
   {
-    m_listeners.connector_[ON_DISCONNECT].notify(m_profile);
+    m_listeners->connector_[ON_DISCONNECT].notify(m_profile);
   }
 
   void InPortPullConnector::unsubscribeInterface(const coil::Properties& prop)

--- a/src/lib/rtm/InPortPullConnector.h
+++ b/src/lib/rtm/InPortPullConnector.h
@@ -131,7 +131,7 @@ namespace RTC
      */
     InPortPullConnector(ConnectorInfo info,
                         OutPortConsumer* consumer,
-                        ConnectorListeners& listeners,
+                        ConnectorListeners* listeners,
                         CdrBufferBase* buffer = nullptr);
 
     /*!
@@ -302,7 +302,8 @@ namespace RTC
      * @brief A reference to a ConnectorListener
      * @endif
      */
-    ConnectorListeners& m_listeners;
+    ConnectorListeners* m_listeners;
+    ByteData m_data;
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPortPushConnector.h
+++ b/src/lib/rtm/InPortPushConnector.h
@@ -124,7 +124,7 @@ namespace RTC
      */
     InPortPushConnector(ConnectorInfo info,
                         InPortProvider* provider,
-                        ConnectorListeners& listeners,
+                        ConnectorListeners* listeners,
                         CdrBufferBase* buffer = nullptr);
 
     /*!
@@ -275,19 +275,19 @@ namespace RTC
     
     inline void onBufferRead(ByteData& data)
     {
-      m_listeners.
-        connectorData_[ON_BUFFER_READ].notifyIn(m_profile, data);
+      m_listeners->
+        connectorData_[ON_BUFFER_READ]->notifyIn(m_profile, data);
 
     }
     void onBufferEmpty(ByteData&  /*data*/)
     {
-      m_listeners.
+      m_listeners->
         connector_[ON_BUFFER_EMPTY].notify(m_profile);
 
     }
     void onBufferReadTimeout(ByteData&  /*data*/)
     {
-      m_listeners.
+      m_listeners->
         connector_[ON_BUFFER_READ_TIMEOUT].notify(m_profile);
     }
 
@@ -308,7 +308,7 @@ namespace RTC
      * @brief A reference to a ConnectorListener
      * @endif
      */
-    ConnectorListeners& m_listeners;
+    ConnectorListeners* m_listeners;
 
     bool m_deleteBuffer;
 
@@ -324,6 +324,8 @@ namespace RTC
     WorkerThreadCtrl m_writecompleted_worker;
     WorkerThreadCtrl m_readcompleted_worker;
     WorkerThreadCtrl m_readready_worker;
+
+    ByteData m_data;
 
   };
 } // namespace RTC

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -118,15 +118,14 @@ namespace RTC
 		return ::OpenRTM::PORT_ERROR;
 	}
 	
-    ByteData cdr;
 	bool endian_type = m_connector->isLittleEndian();
 
 	try
 	{
 		setEndian(endian_type);
-		read(cdr);
+		read(m_cdr);
 		
-		RTC_PARANOID(("received data size: %d", cdr.getDataLength()));
+		RTC_PARANOID(("received data size: %d", m_cdr.getDataLength()));
 
 		
 	}
@@ -135,11 +134,11 @@ namespace RTC
 
 	}
 	
-	onReceived(cdr);
+	onReceived(m_cdr);
 	
-    BufferStatus ret = m_connector->write(cdr);
+    BufferStatus ret = m_connector->write(m_cdr);
 	
-	return convertReturn(ret, cdr);
+	return convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -189,49 +189,49 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notifyIn(m_profile, data);
     }
 
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyIn(m_profile, data);
     }
 
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyIn(m_profile, data);
     }
 
   private:
@@ -240,6 +240,7 @@ namespace RTC
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     InPortConnector* m_connector{nullptr};
+    ByteData m_cdr;
 
   };  // class InPortCorCdrbaProvider
 } // namespace RTC

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -106,7 +106,7 @@ namespace RTC
 	  m_value(value), m_onWrite(nullptr), m_onWriteConvert(nullptr),
 	  m_directNewData(false), m_directValue(value)
     {
-
+      this->initConnectorListeners();
       this->addConnectorDataListener(ON_BUFFER_WRITE,
                                      new Timestamp<DataType>("on_write"));
       this->addConnectorDataListener(ON_SEND,
@@ -491,7 +491,27 @@ namespace RTC
 	{
 		return m_directNewData;
 	}
-    
+
+  protected:
+    /*!
+     * @if jp
+     *
+     * @brief コネクタリスナの初期化 
+     *
+     * 
+     *
+     * @else
+     *
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    void initConnectorListeners() override
+    {
+        delete m_listeners;
+        m_listeners = new ConnectorListenersT<DataType>();
+    }
   private:
     std::string m_typename;
     /*!

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -78,7 +78,7 @@ namespace RTC
    * @endif
    */
   OutPortBase::OutPortBase(const char* name, const char* data_type)
-    : PortBase(name), m_littleEndian(true)
+    : PortBase(name), m_littleEndian(true), m_listeners(nullptr)
   {
     RTC_DEBUG(("Port name: %s", name));
 
@@ -100,6 +100,8 @@ namespace RTC
 
     m_properties["data_type"] = data_type;
 
+    initConnectorListeners();
+
   }
 
   /*!
@@ -116,6 +118,7 @@ namespace RTC
     std::for_each(m_connectors.begin(),
                   m_connectors.end(),
                   connector_cleanup());
+    delete m_listeners;
   }
 
   /*!
@@ -375,7 +378,7 @@ namespace RTC
       {
         RTC_TRACE(("addConnectorDataListener(%s)",
                    ConnectorDataListener::toString(type)));
-        m_listeners.connectorData_[type].addListener(listener, autoclean);
+        m_listeners->connectorData_[type]->addListener(listener, autoclean);
         return;
       }
     RTC_ERROR(("addConnectorDataListener(): Unknown Listener Type"));
@@ -399,7 +402,7 @@ namespace RTC
       {
         RTC_TRACE(("removeConnectorDataListener(%s)",
                    ConnectorDataListener::toString(type)));
-        m_listeners.connectorData_[type].removeListener(listener);
+        m_listeners->connectorData_[type]->removeListener(listener);
         return;
       }
     RTC_ERROR(("removeConnectorDataListener(): Unknown Listener Type"));
@@ -423,7 +426,7 @@ namespace RTC
       {
         RTC_TRACE(("addConnectorListener(%s)",
                    ConnectorListener::toString(type)));
-        m_listeners.connector_[type].addListener(listener, autoclean);
+        m_listeners->connector_[type].addListener(listener, autoclean);
         return;
       }
     RTC_ERROR(("addConnectorListener(): Unknown Listener Type"));
@@ -446,7 +449,7 @@ namespace RTC
       {
         RTC_TRACE(("removeConnectorListener(%s)",
                    ConnectorListener::toString(type)));
-        m_listeners.connector_[type].removeListener(listener);
+        m_listeners->connector_[type].removeListener(listener);
         return;
       }
     RTC_ERROR(("removeConnectorListener(): Unknown Listener Type"));
@@ -1128,17 +1131,45 @@ namespace RTC
 	  {
 		  return RTC::PRECONDITION_NOT_MET;
 	  }
-	  
-	  
-
-
 
 	  return PortBase::notify_connect(connector_profile);
   }
-
-  ConnectorListeners& OutPortBase::getListeners()
+  /*!
+   * @if jp
+   *
+   * @brief コネクタリスナの取得
+   *
+   *
+   *
+   * @else
+   *
+   * @brief
+   *
+   *
+   * @endif
+   */
+  ConnectorListeners* OutPortBase::getListeners()
   {
 	  return m_listeners;
+  }
+  /*!
+   * @if jp
+   *
+   * @brief コネクタリスナの初期化
+   *
+   *
+   *
+   * @else
+   *
+   * @brief
+   *
+   *
+   * @endif
+   */
+  void OutPortBase::initConnectorListeners()
+  {
+      delete m_listeners;
+      m_listeners = new ConnectorListeners();
   }
 
 } // namespace RTC

--- a/src/lib/rtm/OutPortBase.h
+++ b/src/lib/rtm/OutPortBase.h
@@ -788,7 +788,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	virtual ConnectorListeners& getListeners();
+	virtual ConnectorListeners* getListeners();
 
 
   protected:
@@ -1029,7 +1029,6 @@ namespace RTC
 
     ReturnCode_t notify_connect(ConnectorProfile& connector_profile) override;
 
-
   protected:
     /*!
      * @if jp
@@ -1039,7 +1038,21 @@ namespace RTC
      * @endif
      */
     InPortBase* getLocalInPort(const ConnectorInfo& profile);
-
+    /*!
+     * @if jp
+     *
+     * @brief コネクタリスナの初期化
+     *
+     *
+     *
+     * @else
+     *
+     * @brief
+     *
+     *
+     * @endif
+     */
+    virtual void initConnectorListeners();
 
     
 
@@ -1082,7 +1095,7 @@ namespace RTC
      * @brief ConnectorDataListener listener
      * @endif
      */
-    ConnectorListeners m_listeners;
+    ConnectorListeners *m_listeners;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortConnector.cpp
+++ b/src/lib/rtm/OutPortConnector.cpp
@@ -30,9 +30,9 @@ namespace RTC
    * @endif
    */
   OutPortConnector::OutPortConnector(ConnectorInfo& info,
-                                     ConnectorListeners& listeners)
+                                     ConnectorListeners* listeners)
     : rtclog("OutPortConnector"), m_profile(info), m_littleEndian(true),
-	m_directInPort(nullptr), m_listeners(listeners), m_directMode(false), m_marshaling_type("corba")
+	m_directInPort(nullptr), m_listeners(listeners), m_directMode(false), m_marshaling_type("corba"), m_cdr(nullptr)
   {
   }
 
@@ -43,7 +43,10 @@ namespace RTC
    * @brief Destructor
    * @endif
    */
-  OutPortConnector::~OutPortConnector() = default;
+  OutPortConnector::~OutPortConnector()
+  {
+    delete m_cdr;
+  }
   /*!
    * @if jp
    * @brief ConnectorInfo 取得
@@ -172,7 +175,7 @@ namespace RTC
 		  return false;
 	  }
 	  m_directInPort = directInPort;
-	  m_inPortListeners = &(directInPort->getListeners());
+	  m_inPortListeners = directInPort->getListeners();
 	  return true;
   }
 

--- a/src/lib/rtm/OutPortConnector.h
+++ b/src/lib/rtm/OutPortConnector.h
@@ -65,7 +65,7 @@ namespace RTC
      * @brief Constructor
      * @endif
      */
-    OutPortConnector(ConnectorInfo& info, ConnectorListeners& listeners);
+    OutPortConnector(ConnectorInfo& info, ConnectorListeners* listeners);
 
     /*!
      * @if jp
@@ -224,31 +224,31 @@ namespace RTC
               if (inport->isNew())
                 {
                   // ON_BUFFER_OVERWRITE(In,Out), ON_RECEIVER_FULL(In,Out) callback
-                  m_listeners.
-                    connectorData_[ON_BUFFER_OVERWRITE].notifyOut(m_profile, data);
+                  m_listeners->
+                    connectorData_[ON_BUFFER_OVERWRITE]->notifyOut(m_profile, data);
                   m_inPortListeners->
-                    connectorData_[ON_BUFFER_OVERWRITE].notifyOut(m_profile, data);
-                  m_listeners.
-                    connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
+                    connectorData_[ON_BUFFER_OVERWRITE]->notifyOut(m_profile, data);
+                  m_listeners->
+                    connectorData_[ON_RECEIVER_FULL]->notifyOut(m_profile, data);
                   m_inPortListeners->
-                    connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
+                    connectorData_[ON_RECEIVER_FULL]->notifyOut(m_profile, data);
                   RTC_PARANOID(("ON_BUFFER_OVERWRITE(InPort,OutPort), "
                                 "ON_RECEIVER_FULL(InPort,OutPort) "
                                 "callback called in direct mode."));
                 }
               // ON_BUFFER_WRITE(In,Out) callback
-              m_listeners.
-                connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
+              m_listeners->
+                connectorData_[ON_BUFFER_WRITE]->notifyOut(m_profile, data);
               m_inPortListeners->
-                connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
+                connectorData_[ON_BUFFER_WRITE]->notifyOut(m_profile, data);
               RTC_PARANOID(("ON_BUFFER_WRITE(InPort,OutPort), "
                                 "callback called in direct mode."));
               inport->write(data);  // write to InPort variable!!
               // ON_RECEIVED(In,Out) callback
-              m_listeners.
-                connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
+              m_listeners->
+                connectorData_[ON_RECEIVED]->notifyOut(m_profile, data);
               m_inPortListeners->
-                connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
+                connectorData_[ON_RECEIVED]->notifyOut(m_profile, data);
               RTC_PARANOID(("ON_RECEIVED(InPort,OutPort), "
                             "callback called in direct mode."));
               
@@ -256,7 +256,11 @@ namespace RTC
             }
         }
       // normal case
-      ::RTC::ByteDataStream<DataType> *cdr = coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().createObject(m_marshaling_type);
+      if(m_cdr == nullptr)
+      {
+        m_cdr = coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().createObject(m_marshaling_type);
+      }
+      ::RTC::ByteDataStream<DataType> *cdr = dynamic_cast<::RTC::ByteDataStream<DataType>*>(m_cdr);
       if (!cdr)
       {
           RTC_ERROR(("Can not find Marshalizer: %s", m_marshaling_type.c_str()));
@@ -267,7 +271,7 @@ namespace RTC
       RTC_TRACE(("connector endian: %s", isLittleEndian() ? "little":"big"));
       
       DataPortStatus ret = write((ByteDataStreamBase*)cdr);
-      coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().deleteObject(cdr);
+      //coil::GlobalFactory < ::RTC::ByteDataStream<DataType> >::instance().deleteObject(cdr);
       return ret;
     }
 
@@ -357,7 +361,7 @@ namespace RTC
      * @brief A reference to a ConnectorListener
      * @endif
      */
-    ConnectorListeners& m_listeners;
+    ConnectorListeners* m_listeners;
 
     /*!
      * @if jp
@@ -386,6 +390,7 @@ namespace RTC
      * @endif
      */
     std::string m_marshaling_type;
+    ByteDataStreamBase* m_cdr;
 
   };
 } // namespace RTC

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.cpp
@@ -1,6 +1,6 @@
 ﻿// -*- C++ -*-
 /*!
- * @file  OutPortCorbaCdrConsumer.h
+ * @file  OutPortCorbaCdrConsumer.cpp
  * @brief OutPortCorbaCdrConsumer class
  * @date  $Date: 2008-01-13 10:28:27 $
  * @author Noriaki Ando <n-ando@aist.go.jp>

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.h
@@ -280,7 +280,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -295,7 +295,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -310,7 +310,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -325,7 +325,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortCorbaCdrProvider.cpp
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.cpp
@@ -169,12 +169,11 @@ namespace RTC
         return ::OpenRTM::UNKNOWN_ERROR;
       }
 
-    ByteData cdr;
-    BufferStatus ret(m_connector->read(cdr));
+    BufferStatus ret(m_connector->read(m_cdr));
 
     if (ret == BufferStatus::OK)
       {
-        CORBA::ULong len(static_cast<CORBA::ULong>(cdr.getDataLength()));
+        CORBA::ULong len(static_cast<CORBA::ULong>(m_cdr.getDataLength()));
         RTC_PARANOID(("converted CDR data size: %d", len));
 
         if (len == static_cast<CORBA::ULong>(0)) {
@@ -183,15 +182,15 @@ namespace RTC
         }
 #ifndef ORB_IS_RTORB
         data->length(len);
-        cdr.readData(static_cast<unsigned char*>(data->get_buffer()), len);
+        m_cdr.readData(static_cast<unsigned char*>(data->get_buffer()), len);
 #else
         data->length(len);
-        cdr.readData(reinterpret_cast<char *>(&((*data)[0]),
+        m_cdr.readData(reinterpret_cast<char *>(&((*data)[0]),
                                         static_cast<int>(len)));
 #endif  // ORB_IS_RTORB
       }
 
-    return convertReturn(ret, cdr);
+    return convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/OutPortCorbaCdrProvider.h
+++ b/src/lib/rtm/OutPortCorbaCdrProvider.h
@@ -263,7 +263,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_READ]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -278,7 +278,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notifyOut(m_profile, data);
+        connectorData_[ON_SEND]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -352,6 +352,7 @@ namespace RTC
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     OutPortConnector* m_connector{nullptr};
+    ByteData m_cdr;
   };  // class OutPortCorbaCdrProvider
 } // namespace RTC
 

--- a/src/lib/rtm/OutPortDSConsumer.cpp
+++ b/src/lib/rtm/OutPortDSConsumer.cpp
@@ -1,6 +1,6 @@
 ﻿// -*- C++ -*-
 /*!
- * @file  OutPortDSConsumer.h
+ * @file  OutPortDSConsumer.cpp
  * @brief OutPortDSConsumer class
  * @date  $Date: 2018-09-20 07:49:59 $
  * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>

--- a/src/lib/rtm/OutPortDSConsumer.h
+++ b/src/lib/rtm/OutPortDSConsumer.h
@@ -36,7 +36,7 @@ namespace RTC
    * データ転送に CORBA の RTC::DataPullService インターフェースを利用し
    * た、pull 型データフロー型を実現する OutPort コンシューマクラス。
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @else
    * @class OutPortDSConsumer
@@ -46,7 +46,7 @@ namespace RTC
    * interface in CORBA for data transfer and realizes a pull-type
    * dataflow.
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @endif
    */
@@ -278,7 +278,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -293,7 +293,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -308,7 +308,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -323,7 +323,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortDSProvider.cpp
+++ b/src/lib/rtm/OutPortDSProvider.cpp
@@ -167,12 +167,11 @@ namespace RTC
         return ::RTC::UNKNOWN_ERROR;
       }
 
-    ByteData cdr;
-    BufferStatus ret(m_connector->read(cdr));
+    BufferStatus ret(m_connector->read(m_cdr));
 
     if (ret == BufferStatus::OK)
       {
-        CORBA::ULong len(static_cast<CORBA::ULong>(cdr.getDataLength()));
+        CORBA::ULong len(static_cast<CORBA::ULong>(m_cdr.getDataLength()));
         RTC_PARANOID(("converted CDR data size: %d", len));
 
         if (len == static_cast<CORBA::ULong>(0)) {
@@ -181,15 +180,15 @@ namespace RTC
         }
 #ifndef ORB_IS_RTORB
         data->length(len);
-        cdr.readData(static_cast<unsigned char*>(data->get_buffer()), len);
+        m_cdr.readData(static_cast<unsigned char*>(data->get_buffer()), len);
 #else
         data->length(len);
-        cdr.readData(reinterpret_cast<char *>(&((*data)[0]),
+        m_cdr.readData(reinterpret_cast<char *>(&((*data)[0]),
                                         static_cast<int>(len)));
 #endif  // ORB_IS_RTORB
       }
 
-    return convertReturn(ret, cdr);
+    return convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/OutPortDSProvider.h
+++ b/src/lib/rtm/OutPortDSProvider.h
@@ -38,7 +38,7 @@ namespace RTC
    * データ転送に CORBA の RTC::DataPullService インターフェースを利用し
    * た、pull 型データフロー型を実現する OutPort プロバイダクラス。
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @else
    * @class OutPortDSProvider
@@ -48,7 +48,7 @@ namespace RTC
    * interface in CORBA for data transfer and realizes a pull-type
    * dataflow.
    *
-   * @since 0.4.0
+   * @since 2.0.0
    *
    * @endif
    */
@@ -261,7 +261,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_READ]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -276,7 +276,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notifyOut(m_profile, data);
+        connectorData_[ON_SEND]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -350,6 +350,7 @@ namespace RTC
     ConnectorListeners* m_listeners;
     ConnectorInfo m_profile;
     OutPortConnector* m_connector{nullptr};
+    ByteData m_cdr;
   };  // class OutPortDSProvider
 } // namespace RTC
 

--- a/src/lib/rtm/OutPortDirectProvider.h
+++ b/src/lib/rtm/OutPortDirectProvider.h
@@ -228,7 +228,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_READ]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -243,7 +243,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notifyOut(m_profile, data);
+        connectorData_[ON_SEND]->notifyOut(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortPullConnector.cpp
+++ b/src/lib/rtm/OutPortPullConnector.cpp
@@ -33,7 +33,7 @@ namespace RTC
    */
   OutPortPullConnector::OutPortPullConnector(ConnectorInfo info,
                                              OutPortProvider* provider,
-                                             ConnectorListeners& listeners,
+                                             ConnectorListeners* listeners,
                                              CdrBufferBase* buffer)
     : OutPortConnector(info, listeners),
       m_provider(provider),
@@ -52,7 +52,7 @@ namespace RTC
     m_buffer->init(info.properties.getNode("buffer"));
     m_provider->setBuffer(m_buffer);
     m_provider->setConnector(this);
-    m_provider->setListener(info, &m_listeners);
+    m_provider->setListener(info, m_listeners);
 
     if (coil::toBool(info.properties["sync_readwrite"], "YES", "NO", false))
     {
@@ -254,7 +254,7 @@ namespace RTC
    */
   void OutPortPullConnector::onConnect()
   {
-    m_listeners.connector_[ON_CONNECT].notify(m_profile);
+    m_listeners->connector_[ON_CONNECT].notify(m_profile);
   }
 
   /*!
@@ -266,7 +266,7 @@ namespace RTC
    */
   void OutPortPullConnector::onDisconnect()
   {
-    m_listeners.connector_[ON_DISCONNECT].notify(m_profile);
+    m_listeners->connector_[ON_DISCONNECT].notify(m_profile);
   }
 } // namespace RTC
 

--- a/src/lib/rtm/OutPortPullConnector.h
+++ b/src/lib/rtm/OutPortPullConnector.h
@@ -125,7 +125,7 @@ namespace RTC
      */
     OutPortPullConnector(ConnectorInfo info,
                          OutPortProvider* provider,
-                         ConnectorListeners& listeners,
+                         ConnectorListeners* listeners,
                          CdrBufferBase* buffer = nullptr);
 
     /*!
@@ -273,7 +273,7 @@ namespace RTC
      * @brief A reference to a ConnectorListener
      * @endif
      */
-    ConnectorListeners& m_listeners;
+    ConnectorListeners* m_listeners;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortPushConnector.cpp
+++ b/src/lib/rtm/OutPortPushConnector.cpp
@@ -35,7 +35,7 @@ namespace RTC
    */
   OutPortPushConnector::OutPortPushConnector(ConnectorInfo info,
                                              InPortConsumer* consumer,
-                                             ConnectorListeners& listeners,
+                                             ConnectorListeners* listeners,
                                              CdrBufferBase* buffer)
     : OutPortConnector(info, listeners),
       m_consumer(consumer), m_publisher(nullptr),
@@ -58,7 +58,7 @@ namespace RTC
 
     m_publisher->setConsumer(m_consumer);
     m_publisher->setBuffer(m_buffer);
-    m_publisher->setListener(m_profile, &m_listeners);
+    m_publisher->setListener(m_profile, m_listeners);
 
     std::string type{info.properties.getProperty("marshaling_type", "corba")};
     m_marshaling_type = coil::eraseBothEndsBlank(info.properties.getProperty("out.marshaling_type", type));
@@ -227,7 +227,7 @@ namespace RTC
    */
   void OutPortPushConnector::onConnect()
   {
-    m_listeners.connector_[ON_CONNECT].notify(m_profile);
+    m_listeners->connector_[ON_CONNECT].notify(m_profile);
   }
 
   /*!
@@ -239,7 +239,7 @@ namespace RTC
    */
   void OutPortPushConnector::onDisconnect()
   {
-    m_listeners.connector_[ON_DISCONNECT].notify(m_profile);
+    m_listeners->connector_[ON_DISCONNECT].notify(m_profile);
   }
 
   void OutPortPushConnector::unsubscribeInterface(const coil::Properties& prop)

--- a/src/lib/rtm/OutPortPushConnector.h
+++ b/src/lib/rtm/OutPortPushConnector.h
@@ -129,7 +129,7 @@ namespace RTC
      */
     OutPortPushConnector(ConnectorInfo info,
                          InPortConsumer* consumer,
-                         ConnectorListeners& listeners,
+                         ConnectorListeners* listeners,
                          CdrBufferBase* buffer = nullptr);
 
     /*!
@@ -356,7 +356,7 @@ namespace RTC
      * @brief A reference to a ConnectorListener
      * @endif
      */
-    ConnectorListeners& m_listeners;
+    ConnectorListeners* m_listeners;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortSHMConsumer.h
+++ b/src/lib/rtm/OutPortSHMConsumer.h
@@ -235,7 +235,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -250,7 +250,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -265,7 +265,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyIn(m_profile, data);
     }
 
     /*!
@@ -280,7 +280,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyIn(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyIn(m_profile, data);
     }
 
     /*!

--- a/src/lib/rtm/OutPortSHMProvider.cpp
+++ b/src/lib/rtm/OutPortSHMProvider.cpp
@@ -159,23 +159,22 @@ namespace RTC
         return ::OpenRTM::UNKNOWN_ERROR;
       }
 
-    ByteData cdr;
-    BufferStatus ret(m_connector->read(cdr));
+    BufferStatus ret(m_connector->read(m_cdr));
     if (ret == BufferStatus::OK)
       {
-        CORBA::ULong len(static_cast<CORBA::ULong>(cdr.getDataLength()));
+        CORBA::ULong len(static_cast<CORBA::ULong>(m_cdr.getDataLength()));
         RTC_PARANOID(("converted CDR data size: %d", len));
-	if (len == static_cast<CORBA::ULong>(0)) {
-	  RTC_ERROR(("buffer is empty."));
-	  return ::OpenRTM::BUFFER_EMPTY;
-	}
-	bool endian_type = m_connector->isLittleEndian();
-	setEndian(endian_type);
-	create_memory(m_memory_size, m_shm_address.c_str());
-	write(cdr);
+        if (len == static_cast<CORBA::ULong>(0)) {
+            RTC_ERROR(("buffer is empty."));
+            return ::OpenRTM::BUFFER_EMPTY;
+        }
+        bool endian_type = m_connector->isLittleEndian();
+        setEndian(endian_type);
+        create_memory(m_memory_size, m_shm_address.c_str());
+        write(m_cdr);
       }
 
-    return convertReturn(ret, cdr);
+    return convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/OutPortSHMProvider.h
+++ b/src/lib/rtm/OutPortSHMProvider.h
@@ -207,7 +207,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_READ]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -222,7 +222,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notifyOut(m_profile, data);
+        connectorData_[ON_SEND]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -298,6 +298,7 @@ namespace RTC
     OutPortConnector* m_connector{nullptr};
     std::string m_shm_address;
     int m_memory_size{0};
+    ByteData m_cdr;
   };  // class OutPortCorbaCdrProvider
 } // namespace RTC
 

--- a/src/lib/rtm/PublisherFlush.cpp
+++ b/src/lib/rtm/PublisherFlush.cpp
@@ -143,33 +143,33 @@ namespace RTC
         RTC_DEBUG(("write(): connection lost."));
         return m_retcode;
       }
-    ByteData data_ = *data;
+    m_data = *data;
 
 
-    onSend(data_);
-    DataPortStatus ret(m_consumer->put(data_));
+    onSend(m_data);
+    DataPortStatus ret(m_consumer->put(m_data));
     // consumer::put() returns
     //  {PORT_OK, PORT_ERROR, SEND_FULL, SEND_TIMEOUT, UNKNOWN_ERROR}
 
     switch (ret)
       {
       case DataPortStatus::PORT_OK:
-        onReceived(data_);
+        onReceived(m_data);
         return ret;
       case DataPortStatus::PORT_ERROR:
-        onReceiverError(data_);
+        onReceiverError(m_data);
         return ret;
       case DataPortStatus::SEND_FULL:
-        onReceiverFull(data_);
+        onReceiverFull(m_data);
         return ret;
       case DataPortStatus::SEND_TIMEOUT:
-        onReceiverTimeout(data_);
+        onReceiverTimeout(m_data);
         return ret;
       case DataPortStatus::CONNECTION_LOST:
-        onReceiverTimeout(data_);
+        onReceiverTimeout(m_data);
         return ret;
       case DataPortStatus::UNKNOWN_ERROR:
-        onReceiverError(data_);
+        onReceiverError(m_data);
         return ret;
       case DataPortStatus::BUFFER_ERROR:         /* FALLTHROUGH */
       case DataPortStatus::BUFFER_FULL:          /* FALLTHROUGH */
@@ -180,7 +180,7 @@ namespace RTC
       case DataPortStatus::INVALID_ARGS:         /* FALLTHROUGH */
       case DataPortStatus::PRECONDITION_NOT_MET: /* FALLTHROUGH */
       default:
-        onReceiverError(data_);
+        onReceiverError(m_data);
         return ret;
       }
   }

--- a/src/lib/rtm/PublisherFlush.h
+++ b/src/lib/rtm/PublisherFlush.h
@@ -358,7 +358,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notifyOut(m_profile, data);
+        connectorData_[ON_SEND]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -373,7 +373,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -388,7 +388,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -403,7 +403,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -418,7 +418,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyOut(m_profile, data);
     }
 
   private:
@@ -429,6 +429,7 @@ namespace RTC
     DataPortStatus m_retcode{DataPortStatus::PORT_OK};
     std::mutex m_retmutex;
     bool m_active{false};
+    ByteData m_data;
   };
 
 } // namespace RTC

--- a/src/lib/rtm/PublisherNew.cpp
+++ b/src/lib/rtm/PublisherNew.cpp
@@ -174,25 +174,25 @@ namespace RTC
         return m_retcode;
       }
 
-    ByteData data_ = *data;
+    m_data = *data;
 
     if (m_retcode == DataPortStatus::SEND_FULL)
       {
         RTC_DEBUG(("write(): InPort buffer is full."));
-        m_buffer->write(data_, timeout);
+        m_buffer->write(m_data, timeout);
         m_task->signal();
         return DataPortStatus::BUFFER_FULL;
       }
 
     assert(m_buffer != nullptr);
 
-    onBufferWrite(data_);
-    BufferStatus ret(m_buffer->write(data_, timeout));
+    onBufferWrite(m_data);
+    BufferStatus ret(m_buffer->write(m_data, timeout));
 
     m_task->signal();
     RTC_DEBUG(("%s = write()", toString(ret)));
 
-    return convertReturn(ret, data_);
+    return convertReturn(ret, m_data);
   }
 
   /*!

--- a/src/lib/rtm/PublisherNew.h
+++ b/src/lib/rtm/PublisherNew.h
@@ -556,7 +556,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -571,7 +571,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -586,7 +586,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -601,7 +601,7 @@ namespace RTC
     inline void onBufferWriteOverwrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_OVERWRITE].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_OVERWRITE]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -616,7 +616,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_READ]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -631,7 +631,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notifyOut(m_profile, data);
+        connectorData_[ON_SEND]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -646,7 +646,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -661,7 +661,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -676,7 +676,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -691,7 +691,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -723,6 +723,7 @@ namespace RTC
     int m_skipn{0};
     bool m_active{false};
     int m_leftskip{0};
+    ByteData m_data;
   };
 } // namespace RTC
 

--- a/src/lib/rtm/PublisherPeriodic.cpp
+++ b/src/lib/rtm/PublisherPeriodic.cpp
@@ -175,20 +175,20 @@ namespace RTC
         return m_retcode;
       }
 
-    ByteData data_ = *data;
+    m_data = *data;
 
     if (m_retcode == DataPortStatus::SEND_FULL)
       {
         RTC_DEBUG(("write(): InPort buffer is full."));
-        m_buffer->write(data_, timeout);
+        m_buffer->write(m_data, timeout);
         return DataPortStatus::BUFFER_FULL;
       }
 
-    onBufferWrite(data_);
-    BufferStatus ret(m_buffer->write(data_, timeout));
+    onBufferWrite(m_data);
+    BufferStatus ret(m_buffer->write(m_data, timeout));
     RTC_DEBUG(("%s = write()", toString(ret)));
     m_task->resume();
-    return convertReturn(ret, data_);
+    return convertReturn(ret, m_data);
   }
 
   /*!

--- a/src/lib/rtm/PublisherPeriodic.h
+++ b/src/lib/rtm/PublisherPeriodic.h
@@ -554,7 +554,7 @@ namespace RTC
     inline void onBufferWrite(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -569,7 +569,7 @@ namespace RTC
     inline void onBufferFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_FULL].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_FULL]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -584,7 +584,7 @@ namespace RTC
     inline void onBufferWriteTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_WRITE_TIMEOUT].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_WRITE_TIMEOUT]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -599,7 +599,7 @@ namespace RTC
     inline void onBufferRead(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_BUFFER_READ].notifyOut(m_profile, data);
+        connectorData_[ON_BUFFER_READ]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -614,7 +614,7 @@ namespace RTC
     inline void onSend(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_SEND].notifyOut(m_profile, data);
+        connectorData_[ON_SEND]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -629,7 +629,7 @@ namespace RTC
     inline void onReceived(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVED].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVED]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -644,7 +644,7 @@ namespace RTC
     inline void onReceiverFull(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_FULL].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_FULL]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -659,7 +659,7 @@ namespace RTC
     inline void onReceiverTimeout(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_TIMEOUT].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_TIMEOUT]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -674,7 +674,7 @@ namespace RTC
     inline void onReceiverError(ByteData& data)
     {
       m_listeners->
-        connectorData_[ON_RECEIVER_ERROR].notifyOut(m_profile, data);
+        connectorData_[ON_RECEIVER_ERROR]->notifyOut(m_profile, data);
     }
 
     /*!
@@ -743,6 +743,7 @@ namespace RTC
     bool m_active{false};
     bool m_readback{false};
     int m_leftskip{0};
+    ByteData m_data;
   };
 } // namespace RTC
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#637 


## Description of the Change

以下の修正を行った。

1. コネクタリスナの仕様を変更

コネクタリスナの仕様を変更して複数のリスナが登録されていても1回のみデシリアライズを実行するようにした。

以下のように`ConnectorDataListenerHolder`のサブクラス`ConnectorDataListenerHolderT`、`ConnectorListeners`のサブクラス`ConnectorListenersT`を定義した。

![class](https://user-images.githubusercontent.com/6216077/64851763-079efb80-d653-11e9-8a81-963da85757ef.png)

OutPortBase、InPortBaseでは`ConnectorListeners`のポインタ(`m_listeners`)を持っており、OutPort、InPortには`m_listeners`に`ConnectorListenersT`のオブジェクトの参照を格納する。
`ConnectorListenersT`では`connectorData_`に`ConnectorDataListenerHolderT`のオブジェクトの参照を格納しており、`notify`関数を呼び出すと追加したリスナが1つ以上の場合にデシリアライズを実行する。
その後、デシリアライズ後のデータを使ってコールバック関数を呼び出すため、一度しかデシリアライズを実行しない。

2. シリアライザ、ByteDataオブジェクトを送受信の度に初期化しないようにする

シリアライザとバイト列を保持するByteDataオブジェクトは極力使用するクラスのメンバ変数に持たせるようにして、put関数内等で初期化しないようにした。このためデータのサイズが同じ場合は領域の再確保を実行しなくなるため時間の短縮が見込める。


上記の修正の結果、ROSより少し遅いぐらいの速度にはなったが、Timestampのリスナを登録している関係でデータの転送と関係のないデシリアライズを実行してしまうため、おそらくROSより速い通信は現状の実装では不可能だと思います。

![rtm-ros2](https://user-images.githubusercontent.com/6216077/64853088-9e6cb780-d655-11e9-9b81-2fc356048639.png)

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
