### PR TITLE
ManagerServantの終了処理が呼ばれない問題の修正

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -167,6 +167,7 @@ namespace RTC
     m_listeners.manager_.preShutdown();
     shutdownComponents();
     shutdownNaming();
+    shutdownManagerServant();
     shutdownORB();
     // 終了待ち合わせ
     m_threadOrb.join();
@@ -1447,6 +1448,26 @@ std::vector<coil::Properties> Manager::getLoadableModules()
       {
         m_logfiles.clear();
       }
+  }
+
+  /*!
+   * @if jp
+   * @brief Managerサーバント の終了処理
+   *
+   * ManagerサーバントのCORBAオブジェクトの非活性化、
+   * 終了処理を実行する。
+   *
+   * @else
+   * @brief Manager Servant finalization
+   *
+   *
+   * @endif
+   */
+  void Manager::shutdownManagerServant()
+  {
+      PortableServer::ObjectId_var oid = m_pPOA->servant_to_id(m_mgrservant);
+      m_pPOA->deactivate_object(oid);
+      delete m_mgrservant;
   }
 
   //============================================================

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1468,6 +1468,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
       PortableServer::ObjectId_var oid = m_pPOA->servant_to_id(m_mgrservant);
       m_pPOA->deactivate_object(oid);
       delete m_mgrservant;
+      m_mgrservant = nullptr;
   }
 
   //============================================================

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -1335,6 +1335,21 @@ namespace RTC
      */
     void shutdownLogger();
 
+    /*!
+     * @if jp
+     * @brief Managerサーバント の終了処理
+     *
+     * ManagerサーバントのCORBAオブジェクトの非活性化、
+     * 終了処理を実行する。
+     *
+     * @else
+     * @brief Manager Servant finalization
+     *
+     *
+     * @endif
+     */
+    void shutdownManagerServant();
+
     //============================================================
     // ORB initialization and finalization
     //============================================================

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -1875,7 +1875,7 @@ namespace RTC
      * @brief The pointer to the ManagerServant
      * @endif
      */
-    RTM::ManagerServant* m_mgrservant;
+    RTM::ManagerServant* m_mgrservant{nullptr};
 
     /*!
      * @if jp
@@ -2093,7 +2093,7 @@ namespace RTC
      * @brief The pointer to the ModuleManager
      * @endif
      */
-    ModuleManager* m_module;
+    ModuleManager* m_module{nullptr};
 
     /*!
      * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ManagerServantがdeleteされておらず、マスターマネージャからスレーブマネージャの登録を解除するなどの終了処理が呼ばれていない。

## Description of the Change

ManagerにshutdownManagerServant関数を追加し、Mangerの終了時にManagerServantの終了処理が呼ばれるようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
