### PR TITLE
スレッドのCPUアフィニティを指定しない場合にログにエラーメッセージを出力しないようにする(1.2)

### DIFF
--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -124,31 +124,37 @@ namespace RTC_exp
     RTC_TRACE(("svc()"));
     int count(0);
 
-    bool result = coil::setThreadCpuAffinity(m_cpu);
-
-    if (!result)
+    if (!m_cpu.empty())
       {
-        RTC_ERROR(("setThreadCpuAffinity():"
-                   "CPU affinity mask setting failed"));
-      };
-	
-	coil::CpuMask ret_cpu;
-	result = coil::getThreadCpuAffinity(ret_cpu);
-	
+        bool result = coil::setThreadCpuAffinity(m_cpu);
+        if (!result)
+          {
+            RTC_ERROR(("setThreadCpuAffinity():"
+                       "CPU affinity mask setting failed"));
+          };
+        
+        coil::CpuMask ret_cpu;
+        result = coil::getThreadCpuAffinity(ret_cpu);
+        
 
 #ifdef RTM_OS_LINUX
-	std::sort(ret_cpu.begin(), ret_cpu.end());
-	std::sort(m_cpu.begin(), m_cpu.end());
-	if (result && ret_cpu.size() > 0 && m_cpu.size() > 0 && ret_cpu.size() == m_cpu.size()
+        std::sort(ret_cpu.begin(), ret_cpu.end());
+        std::sort(m_cpu.begin(), m_cpu.end());
+        if (result && ret_cpu.size() > 0 && m_cpu.size() > 0 && ret_cpu.size() == m_cpu.size()
         && std::equal(ret_cpu.begin(), ret_cpu.end(), m_cpu.begin()))
-	{
+          {
 
-	}
-	else
-	{
-		RTC_ERROR(("pthread_getaffinity_np(): returned error."));
-	}
+          }
+        else
+          {
+            RTC_ERROR(("pthread_getaffinity_np(): returned error."));
+          }
 #endif
+    }
+    else
+    {
+        RTC_DEBUG(("cpu affinity is not set"));
+    }
 
     do
       {


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

rtc.confで`cpu_affinity`が空白の場合にログにエラーメッセージを出力する。


## Description of the Change

エラーメッセージを出力しないようにした。
master branchは修正済み。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
