### PR TITLE
RTCがエラー状態から遷移しない問題の修正

### DIFF
--- a/src/lib/rtm/ExecutionContextWorker.cpp
+++ b/src/lib/rtm/ExecutionContextWorker.cpp
@@ -472,11 +472,19 @@ namespace RTC_impl
   void ExecutionContextWorker::invokeWorker()
   {
     RTC_PARANOID(("invokeWorker()"));
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
-    for (auto & comp : m_comps) { comp->workerPreDo();  }
-    for (auto & comp : m_comps) { comp->workerDo();     }
-    for (auto & comp : m_comps) { comp->workerPostDo(); }
+    for (auto & comp : m_comps) { 
+        std::lock_guard<std::mutex> stateguard(m_statemutex); 
+        comp->workerPreDo();  
+    }
+    for (auto & comp : m_comps) { 
+        std::lock_guard<std::mutex> stateguard(m_statemutex);
+        comp->workerDo();     
+    }
+    for (auto & comp : m_comps) { 
+        std::lock_guard<std::mutex> stateguard(m_statemutex);
+        comp->workerPostDo(); 
+    }
     std::lock_guard<std::mutex> guard(m_mutex);
     updateComponentList();
   }
@@ -484,25 +492,31 @@ namespace RTC_impl
   void ExecutionContextWorker::invokeWorkerPreDo()
   {
     RTC_PARANOID(("invokeWorkerPreDo()"));
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
-    for (auto & comp : m_comps) { comp->workerPreDo();  }
+    for (auto & comp : m_comps) { 
+        std::lock_guard<std::mutex> stateguard(m_statemutex);
+        comp->workerPreDo();  
+    }
   }
 
   void ExecutionContextWorker::invokeWorkerDo()
   {
     RTC_PARANOID(("invokeWorkerDo()"));
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
-    for (auto & comp : m_comps) { comp->workerDo();     }
+    for (auto & comp : m_comps) { 
+        std::lock_guard<std::mutex> stateguard(m_statemutex); 
+        comp->workerDo();     
+    }
   }
 
   void ExecutionContextWorker::invokeWorkerPostDo()
   {
     RTC_PARANOID(("invokeWorkerPostDo()"));
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
-    for (auto & comp : m_comps) { comp->workerPostDo(); }
+    for (auto & comp : m_comps) { 
+        std::lock_guard<std::mutex> stateguard(m_statemutex); 
+        comp->workerPostDo(); 
+    }
     // m_comps might be changed here
     std::lock_guard<std::mutex> guard(m_mutex);
     updateComponentList();

--- a/src/lib/rtm/ExecutionContextWorker.cpp
+++ b/src/lib/rtm/ExecutionContextWorker.cpp
@@ -173,6 +173,7 @@ namespace RTC_impl
         return RTC::BAD_PARAMETER;
       }
     RTC_DEBUG(("Component found in the EC."));
+    std::lock_guard<std::mutex> stateguard(m_statemutex);
     if (!(obj->isCurrentState(RTC::INACTIVE_STATE)))
       {
         RTC_ERROR(("State of the RTC is not INACTIVE_STATE."));
@@ -204,6 +205,7 @@ namespace RTC_impl
         RTC_ERROR(("Given RTC is not participant of this EC."));
         return RTC::BAD_PARAMETER;
       }
+    std::lock_guard<std::mutex> stateguard(m_statemutex);
     if (!(rtobj->isCurrentState(RTC::ACTIVE_STATE)))
       {
         RTC_ERROR(("State of the RTC is not ACTIVE_STATE."));
@@ -232,6 +234,7 @@ namespace RTC_impl
         RTC_ERROR(("Given RTC is not participant of this EC."));
         return RTC::BAD_PARAMETER;
       }
+    std::lock_guard<std::mutex> stateguard(m_statemutex);
     if (!(rtobj->isCurrentState(RTC::ERROR_STATE)))
       {
         RTC_ERROR(("State of the RTC is not ERROR_STATE."));
@@ -424,6 +427,7 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
+        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (!comp->isCurrentState(state)) { return false; }
       }
     return true;
@@ -435,6 +439,7 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
+        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (!comp->isNextState(state)) { return false; }
       }
     return true;
@@ -446,6 +451,7 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
+        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (comp->isCurrentState(state)) { return true; }
       }
     return false;
@@ -457,6 +463,7 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
+        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (comp->isNextState(state)) { return true; }
       }
     return false;
@@ -465,6 +472,7 @@ namespace RTC_impl
   void ExecutionContextWorker::invokeWorker()
   {
     RTC_PARANOID(("invokeWorker()"));
+    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
     for (auto & comp : m_comps) { comp->workerPreDo();  }
     for (auto & comp : m_comps) { comp->workerDo();     }
@@ -476,6 +484,7 @@ namespace RTC_impl
   void ExecutionContextWorker::invokeWorkerPreDo()
   {
     RTC_PARANOID(("invokeWorkerPreDo()"));
+    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
     for (auto & comp : m_comps) { comp->workerPreDo();  }
   }
@@ -483,6 +492,7 @@ namespace RTC_impl
   void ExecutionContextWorker::invokeWorkerDo()
   {
     RTC_PARANOID(("invokeWorkerDo()"));
+    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
     for (auto & comp : m_comps) { comp->workerDo();     }
   }
@@ -490,6 +500,7 @@ namespace RTC_impl
   void ExecutionContextWorker::invokeWorkerPostDo()
   {
     RTC_PARANOID(("invokeWorkerPostDo()"));
+    std::lock_guard<std::mutex> stateguard(m_statemutex);
     // m_comps never changes its size here
     for (auto & comp : m_comps) { comp->workerPostDo(); }
     // m_comps might be changed here

--- a/src/lib/rtm/ExecutionContextWorker.h
+++ b/src/lib/rtm/ExecutionContextWorker.h
@@ -593,6 +593,7 @@ namespace RTC_impl
     std::vector<RTC_impl::RTObjectStateMachine*> m_removedComps;
     mutable std::mutex m_removedMutex;
     using CompItr = std::vector<RTC_impl::RTObjectStateMachine*>::iterator;
+    mutable std::mutex m_statemutex;
 
   };  // class PeriodicExecutionContext
 } // namespace RTC_impl


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#652 

ExecutionContextWorker.cppの`deactivateComponent`関数の以下の部分に問題がある。

```
    if (!(rtobj->isCurrentState(RTC::ACTIVE_STATE)))
      {
        RTC_ERROR(("State of the RTC is not ACTIVE_STATE."));
        return RTC::PRECONDITION_NOT_MET;
      }
    rtobj->goTo(RTC::INACTIVE_STATE);
```

`isCurrentState`関数で状態を確認してから`goTo`関数で状態遷移を指令するまでの間はロックしていない。
つまりこの間にエラー状態に遷移した場合、アクティブ状態ではないのに非アクティブ状態を次の状態に設定する。
ただし、`deactivateComponent`関数実行後に実行コンテキストは全てのRTCの次の状態が`INACTIVE_STATE`の場合に停止するため、永久に非アクティブ状態に遷移することもリセットすることもできない。

## Description of the Change

`goto`関数で状態遷移、もしくは`isCurrentState`関数、`isNextState`関数で状態の確認をする箇所はmutexでロックするようにした。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
