### PR TITLE
A bug in notExisting() func #616

### DIFF
--- a/src/lib/rtm/LocalServiceAdmin.cpp
+++ b/src/lib/rtm/LocalServiceAdmin.cpp
@@ -272,7 +272,7 @@ namespace RTM
    */
   bool LocalServiceAdmin::notExisting(const std::string& id)
   {
-    std::lock_guard<std::mutex> guard(m_mutex);
+    std::lock_guard<std::mutex> guard(m_services_mutex);
     for (auto & service : m_services)
       {
         if (service->getProfile().name == id)


### PR DESCRIPTION
m_mutex must be m_services_mutex in notExisting() func #616

## Identify the Bug
LocalServiceAdmin::notExisting() locks m_mutex on the head of the function, but it have to be m_services_mutex.

## Description of the Change

m_mutex replaced into m_services_mutex 

## Verification 

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
