### PR TITLE
Invalid overwrite read-only strings

### DIFF
--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -627,7 +627,7 @@ namespace RTC
      * prop["interface_type"]: インターフェースタイプ
      * などがアクセス可能になる。
      */
-    std::string& dflow_type(prop["dataflow_type"]);
+    std::string dflow_type(prop["dataflow_type"]);
     dflow_type = coil::normalize(std::move(dflow_type));
 
     if (dflow_type == "push")


### PR DESCRIPTION
Invalid overwrite read-only strings in the Properties objects.
coil::normalize modifies given string. It have to be given as copied string.
```
    std::string dflow_type(prop["dataflow_type"]);
    dflow_type = coil::normalize(std::move(dflow_type));
```

## Identify the Bug

coild::normalize() function modifies almost readonly Properties variables.

## Verification 
- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
