### PR TITLE
ExecutionContextWorkerでオーナーのRTCが削除されない問題の修正

### DIFF
--- a/src/lib/rtm/ExecutionContextBase.cpp
+++ b/src/lib/rtm/ExecutionContextBase.cpp
@@ -38,7 +38,14 @@ namespace RTC
    * @brief Virtual Destructor
    * @endif
    */
-  ExecutionContextBase::~ExecutionContextBase() = default;
+  ExecutionContextBase::~ExecutionContextBase()
+  {
+      RTC::ReturnCode_t ret = m_worker.removeComponent(m_profile.getOwner());
+      if (ret != RTC::RTC_OK)
+      {
+          RTC_ERROR(("Error: ECWorker removeComponent() faild."));
+      }
+  }
 
   /*!
    * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#609 でExecutionContextWorkerでRTObjectStateMachineが削除されない問題。


## Description of the Change

オーナーのRTCはExecutionContextBaseのremoveComponent関数で削除しないためdeleteされることもない。
このためExecutionContextWorkerのデストラクタで削除するようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
