### PR TITLE
Support clang/ninja build on Windows and fix delete bugs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,12 +79,6 @@ if(MSVC)
 	set(INSTALL_RTM_ETC_DIR ${OPENRTM_VERSION}/ext/)
 	# For setting warning options manually, delete CMake default options.
 	string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-	# Suppress warnings in external headers.
-	# This dosen't work in msbuild (.sln), but work in ninja-build now (CMake 3.14).
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.13)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /experimental:external /external:W0")
-		set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "/external:I ")
-	endif()
 	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 		set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "/imsvc ")
 	endif()

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -92,8 +92,9 @@ namespace coil
    */
   std::string toUpper(std::string str) noexcept
   {
-    std::transform(str.begin(), str.end(), str.begin(),
-                   [](unsigned char x){ return std::toupper(x); });
+    std::transform(str.begin(), str.end(), str.begin(), [](unsigned char x){
+      return static_cast<char>(std::toupper(x));
+    });
     return str;
   }
 
@@ -106,8 +107,9 @@ namespace coil
    */
   std::string toLower(std::string str) noexcept
   {
-    std::transform(str.begin(), str.end(), str.begin(),
-                   [](unsigned char x){ return std::tolower(x); });
+    std::transform(str.begin(), str.end(), str.begin(), [](unsigned char x){
+      return static_cast<char>(std::tolower(x));
+    });
     return str;
   }
 

--- a/src/lib/coil/win32/coil/DynamicLib.cpp
+++ b/src/lib/coil/win32/coil/DynamicLib.cpp
@@ -146,7 +146,7 @@ namespace coil
   void* DynamicLib::symbol(const char* symbol_name)
   {
     if (m_handle == nullptr) return nullptr;
-    return ::GetProcAddress(m_handle, symbol_name);
+    return reinterpret_cast<void*>(::GetProcAddress(m_handle, symbol_name));
   }
 
   /*!

--- a/src/lib/coil/win32/coil/DynamicLib.h
+++ b/src/lib/coil/win32/coil/DynamicLib.h
@@ -262,7 +262,6 @@ namespace coil
     int m_mode;
     int m_closeflag;
     HINSTANCE m_handle;
-    int m_error;
   };  // class DynamicLib
 
 } // namespace coil

--- a/src/lib/coil/win32/coil/OS.cpp
+++ b/src/lib/coil/win32/coil/OS.cpp
@@ -24,6 +24,37 @@
 
 namespace coil
 {
+  static int    opterr = 1,     /* if error message should be printed */
+                optind = 1,     /* index into parent argv vector */
+                optopt,         /* character checked for validity */
+                optreset;       /* reset getopt */
+  static char* optarg;          /* argument associated with option */
+
+  static int const BADCH{static_cast<int>('?')};
+  static int const BADARG{static_cast<int>(':')};
+  static char EMSG[]{""};
+
+  /*!
+   * @if jp
+   *
+   * @brief コマンドライン引数解析関数
+   *
+   * コマンドライン引数を解析する。
+   *
+   * @return 解析結果
+   *
+   * @else
+   *
+   * @brief Function of parses the command line arguments
+   *
+   * Parses the command line arguments.
+   *
+   * @return Result of parses.
+   *
+   * @endif
+   */
+  static int getopt(int nargc, char * const *nargv, const char *ostr);
+
   osversion::osversion() : major(0), minor(0)
     {
 
@@ -187,14 +218,10 @@ namespace coil
                 sprintf_s(name->release, sizeof(name->release), os,
                     static_cast<int>(version_info.dwMajorVersion),
                     static_cast<int>(version_info.dwMinorVersion));
-
                 break;
             }
-
-
         }
     }
-
 
     // name.machine
     SYSTEM_INFO sys_info;
@@ -392,9 +419,9 @@ namespace coil
   }
 
 
-  GetOpt::GetOpt(int argc, char* const argv[], const char* opt, int flag)
+  GetOpt::GetOpt(int argc, char* const argv[], const char* opt, int /*flag*/)
     : optind(1), opterr(1), optopt(0),
-      m_argc(argc), m_argv(argv), m_opt(opt), m_flag(flag)
+      m_argc(argc), m_argv(argv), m_opt(opt)
   {
     this->optarg = coil::optarg;
     coil::optind = 1;

--- a/src/lib/coil/win32/coil/OS.h
+++ b/src/lib/coil/win32/coil/OS.h
@@ -187,37 +187,6 @@ namespace coil
    */
   bool getenv(const char* name, std::string &env);
 
-  static int    opterr = 1,     /* if error message should be printed */
-                optind = 1,     /* index into parent argv vector */
-                optopt,         /* character checked for validity */
-                optreset;       /* reset getopt */
-  static char   *optarg;        /* argument associated with option */
-
-#define  BADCH  (int)'?'
-#define  BADARG  (int)':'
-#define  EMSG  ""
-
-  /*!
-   * @if jp
-   *
-   * @brief コマンドライン引数解析関数
-   *
-   * コマンドライン引数を解析する。
-   *
-   * @return 解析結果
-   *
-   * @else
-   *
-   * @brief Function of parses the command line arguments
-   *
-   * Parses the command line arguments.
-   *
-   * @return Result of parses.
-   *
-   * @endif
-   */
-  static int getopt(int nargc, char * const *nargv, const char *ostr);
-
   /*!
    * @if jp
    *
@@ -298,13 +267,10 @@ namespace coil
     int opterr;       //! エラー表示 0:抑止、1:表示
     int optopt;       //! オプション文字が足りない時、多い時にセットされる
 
-
   private:
     int m_argc;
     char* const * m_argv;
     const char* m_opt;
-    int m_flag;
-
   };
 
 } // namespace coil

--- a/src/lib/coil/win32/coil/Signal.h
+++ b/src/lib/coil/win32/coil/Signal.h
@@ -92,7 +92,7 @@ namespace coil
      *
      * @endif
      */
-    SignalAction(SignalHandler handle, int signum, sigset_t *mask = 0,
+    SignalAction(SignalHandler handle, int signum, sigset_t *mask = nullptr,
                  int flags = 0);
 
     /*!

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1598,7 +1598,7 @@ namespace RTC
               delete connectorData_[i];
               connectorData_[i] = new ConnectorDataListenerHolderT<DataType>();
           }
-      };
+      }
       /*!
        * @if jp
        * @brief デストラクタ
@@ -1606,7 +1606,7 @@ namespace RTC
        * @brief Destructor
        * @endif
        */
-      ~ConnectorListenersT() {};
+      ~ConnectorListenersT() {}
 
   };
 } // namespace RTC


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

new[] で確保しながら delete[] を使っていない箇所がある。 (clang が検出)

## Description of the Change

Windows で clang-8/ninja や cl/ninja の組み合わせでのビルドができるように対応。
 - new [] に対して delete [] を使うように修正
 - static 変数をヘッダで呈してばらまいている点を修正
 - 未使用のメンバー変数を削除
 - 公開する必要のない getopt を cpp の中に隠す
 - 余分なセミコロンの削除

この修正で Visual Studio だけでも CMake指定でビルドできます。
Visual Studio ビルドした場合の時間比率 (括弧内はVS使わない場合の時間): 
  ninja/cl : 48s (38s)
  ninja/clang : 52s (48s)
  .sln -> 2m 57s

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
