### PR TITLE
_var型変数の使い方見直し

### DIFF
--- a/examples/ExtTrigger/ConsoleInComp.cpp
+++ b/examples/ExtTrigger/ConsoleInComp.cpp
@@ -56,21 +56,22 @@ void MyModuleInit(RTC::Manager* manager)
   NVUtil::dump(prof->properties);
   std::cout << "=================================================" << std::endl;
 
-  PortServiceList* portlist;
+  PortServiceList_var portlist;
   portlist = comp->get_ports();
 
   for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
     {
-      PortService_ptr port;
-      port = (*portlist)[i];
+      PortService_var port;
+      port = PortService::_duplicate(portlist[i]);
+      RTC::PortProfile_var portprof = port->get_port_profile();
       std::cout << "================================================="
 		<< std::endl;
       std::cout << "Port" << i << " (name): ";
-      std::cout << port->get_port_profile()->name << std::endl;
+      std::cout << portprof->name << std::endl;
       std::cout << "-------------------------------------------------"
 		<< std::endl;    
       RTC::PortInterfaceProfileList iflist;
-      iflist = port->get_port_profile()->interfaces;
+      iflist = portprof->interfaces;
 
       for (CORBA::ULong j(0), m(iflist.length()); j < m; ++j)
 	    {
@@ -83,7 +84,7 @@ void MyModuleInit(RTC::Manager* manager)
 	      std::cout << "Polarity: " << pol << std::endl;
 	    }
       std::cout << "- properties -" << std::endl;
-      NVUtil::dump(port->get_port_profile()->properties);
+      NVUtil::dump(portprof->properties);
       std::cout << "-------------------------------------------------" << std::endl;
     }
   return;

--- a/examples/ExtTrigger/ConsoleOutComp.cpp
+++ b/examples/ExtTrigger/ConsoleOutComp.cpp
@@ -53,23 +53,24 @@ void MyModuleInit(RTC::Manager* manager)
   NVUtil::dump(prof->properties);
   std::cout << "=================================================" << std::endl;
 
-  PortServiceList* portlist;
+  PortServiceList_var portlist;
   portlist = comp->get_ports();
 
   for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
     {
-      PortService_ptr port;
-      port = (*portlist)[i];
+      PortService_var port;
+      port = PortService::_duplicate(portlist[i]);
+      RTC::PortProfile_var portprof = port->get_port_profile();
       std::cout << "================================================="
 		<< std::endl;
       std::cout << "Port" << i << " (name): ";
-      std::cout << port->get_port_profile()->name << std::endl;
+      std::cout << portprof->name << std::endl;
       std::cout << "-------------------------------------------------"
 		<< std::endl;
 
     
       RTC::PortInterfaceProfileList iflist;
-      iflist = port->get_port_profile()->interfaces;
+      iflist = portprof->interfaces;
 
       for (CORBA::ULong j(0), m(iflist.length()); j < m; ++j)
 	    {
@@ -82,7 +83,7 @@ void MyModuleInit(RTC::Manager* manager)
 	      std::cout << "Polarity: " << pol << std::endl;
 	    }
       std::cout << "- properties -" << std::endl;
-      NVUtil::dump(port->get_port_profile()->properties);
+      NVUtil::dump(portprof->properties);
       std::cout << "-------------------------------------------------"
 		<< std::endl;
     }

--- a/examples/Serializer/ConsoleInShortComp.cpp
+++ b/examples/Serializer/ConsoleInShortComp.cpp
@@ -58,21 +58,22 @@ void MyModuleInit(RTC::Manager* manager)
   NVUtil::dump(prof->properties);
   std::cout << "=================================================" << std::endl;
 
-  PortServiceList* portlist;
+  PortServiceList_var portlist;
   portlist = comp->get_ports();
 
   for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
     {
-      PortService_ptr port;
-      port = (*portlist)[i];
+      PortService_var port;
+      port = PortService::_duplicate(portlist[i]);
+      RTC::PortProfile_var portprof = port->get_port_profile();
       std::cout << "================================================="
 		<< std::endl;
       std::cout << "Port" << i << " (name): ";
-      std::cout << port->get_port_profile()->name << std::endl;
+      std::cout << portprof->name << std::endl;
       std::cout << "-------------------------------------------------"
 		<< std::endl;    
       RTC::PortInterfaceProfileList iflist;
-      iflist = port->get_port_profile()->interfaces;
+      iflist = portprof->interfaces;
 
       for (CORBA::ULong j(0), m(iflist.length()); j < m; ++j)
 	    {
@@ -85,7 +86,7 @@ void MyModuleInit(RTC::Manager* manager)
 	      std::cout << "Polarity: " << pol << std::endl;
 	    }
       std::cout << "- properties -" << std::endl;
-      NVUtil::dump(port->get_port_profile()->properties);
+      NVUtil::dump(portprof->properties);
       std::cout << "-------------------------------------------------" << std::endl;
     }
   return;

--- a/examples/Serializer/ConsoleOutDoubleComp.cpp
+++ b/examples/Serializer/ConsoleOutDoubleComp.cpp
@@ -56,24 +56,25 @@ void MyModuleInit(RTC::Manager* manager)
   NVUtil::dump(prof->properties);
   std::cout << "=================================================" << std::endl;
 
-  PortServiceList* portlist;
+  PortServiceList_var portlist;
   portlist = comp->get_ports();
 
 
   for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
     {
-      PortService_ptr port;
-      port = (*portlist)[i];
+      PortService_var port;
+      port = PortService::_duplicate(portlist[i]);
+      RTC::PortProfile_var portprof = port->get_port_profile();
       std::cout << "================================================="
 		<< std::endl;
       std::cout << "Port" << i << " (name): ";
-      std::cout << port->get_port_profile()->name << std::endl;
+      std::cout << portprof->name << std::endl;
       std::cout << "-------------------------------------------------"
 		<< std::endl;
 
     
       RTC::PortInterfaceProfileList iflist;
-      iflist = port->get_port_profile()->interfaces;
+      iflist = portprof->interfaces;
 
       for (CORBA::ULong j(0), m(iflist.length()); j < m; ++j)
 	    {
@@ -86,7 +87,7 @@ void MyModuleInit(RTC::Manager* manager)
 	      std::cout << "Polarity: " << pol << std::endl;
 	    }
       std::cout << "- properties -" << std::endl;
-      NVUtil::dump(port->get_port_profile()->properties);
+      NVUtil::dump(portprof->properties);
       std::cout << "-------------------------------------------------"
 		<< std::endl;
     }

--- a/examples/SimpleIO/ConsoleInComp.cpp
+++ b/examples/SimpleIO/ConsoleInComp.cpp
@@ -58,21 +58,22 @@ void MyModuleInit(RTC::Manager* manager)
   NVUtil::dump(prof->properties);
   std::cout << "=================================================" << std::endl;
 
-  PortServiceList* portlist;
+  PortServiceList_var portlist;
   portlist = comp->get_ports();
 
   for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
     {
-      PortService_ptr port;
-      port = (*portlist)[i];
+      PortService_var port;
+      port = PortService::_duplicate(portlist[i]);
+      RTC::PortProfile_var portprof = port->get_port_profile();
       std::cout << "================================================="
 		<< std::endl;
       std::cout << "Port" << i << " (name): ";
-      std::cout << port->get_port_profile()->name << std::endl;
+      std::cout << portprof->name << std::endl;
       std::cout << "-------------------------------------------------"
 		<< std::endl;    
       RTC::PortInterfaceProfileList iflist;
-      iflist = port->get_port_profile()->interfaces;
+      iflist = portprof->interfaces;
 
       for (CORBA::ULong j(0), m(iflist.length()); j < m; ++j)
 	    {
@@ -85,7 +86,7 @@ void MyModuleInit(RTC::Manager* manager)
 	      std::cout << "Polarity: " << pol << std::endl;
 	    }
       std::cout << "- properties -" << std::endl;
-      NVUtil::dump(port->get_port_profile()->properties);
+      NVUtil::dump(portprof->properties);
       std::cout << "-------------------------------------------------" << std::endl;
     }
   return;

--- a/examples/SimpleIO/ConsoleOutComp.cpp
+++ b/examples/SimpleIO/ConsoleOutComp.cpp
@@ -56,24 +56,25 @@ void MyModuleInit(RTC::Manager* manager)
   NVUtil::dump(prof->properties);
   std::cout << "=================================================" << std::endl;
 
-  PortServiceList* portlist;
+  PortServiceList_var portlist;
   portlist = comp->get_ports();
 
 
   for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
     {
-      PortService_ptr port;
-      port = (*portlist)[i];
+      PortService_var port;
+      port = PortService::_duplicate(portlist[i]);
+      RTC::PortProfile_var portprof = port->get_port_profile();
       std::cout << "================================================="
 		<< std::endl;
       std::cout << "Port" << i << " (name): ";
-      std::cout << port->get_port_profile()->name << std::endl;
+      std::cout << portprof->name << std::endl;
       std::cout << "-------------------------------------------------"
 		<< std::endl;
 
     
       RTC::PortInterfaceProfileList iflist;
-      iflist = port->get_port_profile()->interfaces;
+      iflist = portprof->interfaces;
 
       for (CORBA::ULong j(0), m(iflist.length()); j < m; ++j)
 	    {
@@ -86,7 +87,7 @@ void MyModuleInit(RTC::Manager* manager)
 	      std::cout << "Polarity: " << pol << std::endl;
 	    }
       std::cout << "- properties -" << std::endl;
-      NVUtil::dump(port->get_port_profile()->properties);
+      NVUtil::dump(portprof->properties);
       std::cout << "-------------------------------------------------"
 		<< std::endl;
     }

--- a/src/ext/ec/logical_time/example/LTTSampleComp.cpp
+++ b/src/ext/ec/logical_time/example/LTTSampleComp.cpp
@@ -47,21 +47,22 @@ void MyModuleInit(RTC::Manager* manager)
   NVUtil::dump(prof->properties);
   std::cout << "=================================================" << std::endl;
 
-  PortServiceList* portlist;
+  PortServiceList_var portlist;
   portlist = comp->get_ports();
 
   for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
     {
-      PortService_ptr port;
-      port = (*portlist)[i];
+      PortService_var port;
+      port = PortService::_duplicate(portlist[i]);
+      RTC::PortProfile_var portprof = port->get_port_profile();
       std::cout << "================================================="
                 << std::endl;
       std::cout << "Port" << i << " (name): ";
-      std::cout << port->get_port_profile()->name << std::endl;
+      std::cout << portprof->name << std::endl;
       std::cout << "-------------------------------------------------"
                 << std::endl;
       RTC::PortInterfaceProfileList iflist;
-      iflist = port->get_port_profile()->interfaces;
+      iflist = portprof->interfaces;
       for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
         {
           std::cout << "I/F name: ";
@@ -73,7 +74,7 @@ void MyModuleInit(RTC::Manager* manager)
           std::cout << "Polarity: " << pol << std::endl;
         }
       std::cout << "- properties -" << std::endl;
-      NVUtil::dump(port->get_port_profile()->properties);
+      NVUtil::dump(portprof->properties);
       std::cout << "-------------------------------------------------"
                 << std::endl;
     }

--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -1390,7 +1390,7 @@ namespace CORBA_RTCUtil
     SDOPackage::Configuration_var conf = rtc->get_configuration();
     SDOPackage::ConfigurationSet_var confset = conf->get_configuration_set(confset_name.c_str());
 
-    set_configuration_parameter(conf, confset, value_name, value);
+    set_configuration_parameter(conf, confset.out(), value_name, value);
 
     conf->activate_configuration_set(confset_name.c_str());
 
@@ -1416,7 +1416,7 @@ namespace CORBA_RTCUtil
     SDOPackage::Configuration_var conf = rtc->get_configuration();
     SDOPackage::ConfigurationSet_var confset = conf->get_active_configuration_set();
 
-    set_configuration_parameter(conf, confset, value_name, value);
+    set_configuration_parameter(conf, confset.out(), value_name, value);
 
     conf->activate_configuration_set(confset->id);
 

--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -99,7 +99,7 @@ namespace CORBA_RTCUtil
    * @return 
    * @endif
    */
-  RTC::ExecutionContext_var get_actual_ec(const RTC::RTObject_ptr rtc,
+  RTC::ExecutionContext_ptr get_actual_ec(const RTC::RTObject_ptr rtc,
                                           RTC::UniqueId ec_id)
   {
     if (CORBA::is_nil(rtc)) { return RTC::ExecutionContext::_nil(); }
@@ -112,9 +112,9 @@ namespace CORBA_RTCUtil
         if (CORBA::is_nil(eclist[static_cast<CORBA::ULong>(ec_id)]))
           { return RTC::ExecutionContext::_nil(); }
 #ifdef ORB_IS_TAO
-        return eclist[(CORBA::ULong)ec_id].in();
+        return RTC::ExecutionContext::_duplicate(eclist[(CORBA::ULong)ec_id].in());
 #else
-        return eclist[static_cast<CORBA::ULong>(ec_id)];
+        return RTC::ExecutionContext::_duplicate(eclist[static_cast<CORBA::ULong>(ec_id)]);
 #endif
       }
     if (ec_id >= 1000)
@@ -127,9 +127,9 @@ namespace CORBA_RTCUtil
 		if (CORBA::is_nil(eclist[static_cast<CORBA::ULong>(pec_id)]))
           { return RTC::ExecutionContext::_nil(); }
 #ifdef ORB_IS_TAO
-        return eclist[(CORBA::ULong)pec_id].in();
+        return RTC::ExecutionContext::_duplicate(eclist[(CORBA::ULong)pec_id].in());
 #else
-        return eclist[static_cast<CORBA::ULong>(pec_id)];
+        return RTC::ExecutionContext::_duplicate(eclist[static_cast<CORBA::ULong>(pec_id)]);
 #endif
       }
     return RTC::ExecutionContext::_nil();
@@ -205,7 +205,7 @@ namespace CORBA_RTCUtil
   {
     if (CORBA::is_nil(rtc)) { return RTC::BAD_PARAMETER; }
     RTC::ExecutionContext_var ec = get_actual_ec(rtc, ec_id);
-    if (CORBA::is_nil(ec)) { return RTC::BAD_PARAMETER; }
+    if (CORBA::is_nil(ec.in())) { return RTC::BAD_PARAMETER; }
     return ec->activate_component(rtc);
   }
   /*!
@@ -266,7 +266,7 @@ namespace CORBA_RTCUtil
    * @return 
    * @endif
    */
-  bool get_state(RTC::LifeCycleState  &state, const RTC::RTObject_ptr rtc, RTC::UniqueId ec_id)
+  bool get_state(RTC::LifeCycleState &state, const RTC::RTObject_ptr rtc, RTC::UniqueId ec_id)
   {
     if (CORBA::is_nil(rtc))
       {
@@ -529,8 +529,8 @@ namespace CORBA_RTCUtil
       }
     try
       {
-        RTC::ExecutionContextService_ptr ecservice = RTC::ExecutionContextService::_narrow(ec);
-        RTC::ExecutionContextProfile* profile = ecservice->get_profile();
+        RTC::ExecutionContextService_var ecservice = RTC::ExecutionContextService::_narrow(ec);
+        RTC::ExecutionContextProfile_var profile = ecservice->get_profile();
         return profile->participants;
       }
     catch (...)
@@ -556,11 +556,11 @@ namespace CORBA_RTCUtil
       {
         return names;
       }
-    RTC::PortServiceList ports = (*rtc->get_ports());
+    RTC::PortServiceList_var ports = rtc->get_ports();
 
-    for (unsigned int i = 0; i < ports.length(); i++)
+    for (unsigned int i = 0; i < ports->length(); i++)
       {
-        RTC::PortProfile* pp = ports[i]->get_port_profile();
+        RTC::PortProfile_var pp = ports[i]->get_port_profile();
 #ifdef ORB_IS_TAO
         std::string s(pp->name);
 #else
@@ -588,11 +588,11 @@ namespace CORBA_RTCUtil
       {
         return names;
       }
-    RTC::PortServiceList ports = (*rtc->get_ports());
+    RTC::PortServiceList_var ports = rtc->get_ports();
 
-    for (unsigned int i = 0; i < ports.length(); i++)
+    for (unsigned int i = 0; i < ports->length(); i++)
       {
-        RTC::PortProfile* pp = ports[i]->get_port_profile();
+        RTC::PortProfile_var pp = ports[i]->get_port_profile();
         coil::Properties prop;
         NVUtil::copyToProperties(prop, pp->properties);
 
@@ -626,11 +626,11 @@ namespace CORBA_RTCUtil
       {
         return names;
       }
-    RTC::PortServiceList ports = (*rtc->get_ports());
+    RTC::PortServiceList_var ports = rtc->get_ports();
 
-    for (unsigned int i = 0; i < ports.length(); i++)
+    for (unsigned int i = 0; i < ports->length(); i++)
       {
-        RTC::PortProfile* pp = ports[i]->get_port_profile();
+        RTC::PortProfile_var pp = ports[i]->get_port_profile();
         coil::Properties prop;
         NVUtil::copyToProperties(prop, pp->properties);
 
@@ -666,11 +666,11 @@ namespace CORBA_RTCUtil
       {
         return names;
       }
-    RTC::PortServiceList ports = (*rtc->get_ports());
+    RTC::PortServiceList_var ports = rtc->get_ports();
 
-    for (unsigned int i = 0; i < ports.length(); i++)
+    for (unsigned int i = 0; i < ports->length(); i++)
       {
-        RTC::PortProfile* pp = ports[i]->get_port_profile();
+        RTC::PortProfile_var pp = ports[i]->get_port_profile();
         coil::Properties prop;
         NVUtil::copyToProperties(prop, pp->properties);
 
@@ -704,8 +704,8 @@ namespace CORBA_RTCUtil
       {
         return names;
       }
-    RTC::ConnectorProfileList conprof = (*port->get_connector_profiles());
-    for (unsigned int i = 0; i < conprof.length(); i++)
+    RTC::ConnectorProfileList_var conprof = port->get_connector_profiles();
+    for (unsigned int i = 0; i < conprof->length(); i++)
       {
         names.emplace_back(conprof[i].name);
       }
@@ -732,8 +732,8 @@ namespace CORBA_RTCUtil
       {
         return names;
       }
-    RTC::ConnectorProfileList conprof = (*port->get_connector_profiles());
-    for (unsigned int i = 0; i < conprof.length(); i++)
+    RTC::ConnectorProfileList_var conprof = port->get_connector_profiles();
+    for (unsigned int i = 0; i < conprof->length(); i++)
       {
         names.emplace_back(conprof[i].name);
       }
@@ -809,7 +809,7 @@ namespace CORBA_RTCUtil
    * @return 
    * @endif
    */
-  RTC::ConnectorProfile_var create_connector(const std::string& name,
+  RTC::ConnectorProfile* create_connector(const std::string& name,
                                              const coil::Properties& prop_arg,
                                              const RTC::PortService_ptr port0,
                                              const RTC::PortService_ptr port1)
@@ -946,8 +946,8 @@ namespace CORBA_RTCUtil
       {
         return RTC::BAD_PARAMETER;
       }
-    RTC::ConnectorProfileList conprof = (*port_ref->get_connector_profiles());
-    for (unsigned int i = 0; i < conprof.length(); i++)
+    RTC::ConnectorProfileList_var conprof = port_ref->get_connector_profiles();
+    for (unsigned int i = 0; i < conprof->length(); i++)
       {
         if (std::string(conprof[i].name) == conn_name)
           {
@@ -978,8 +978,8 @@ namespace CORBA_RTCUtil
         return RTC::BAD_PARAMETER;
       }
 
-    RTC::ConnectorProfileList conprof = (*port_ref->get_connector_profiles());
-    for (unsigned int i = 0; i < conprof.length(); i++)
+    RTC::ConnectorProfileList_var conprof = port_ref->get_connector_profiles();
+    for (unsigned int i = 0; i < conprof->length(); i++)
       {
         if (std::string(conprof[i].name) == conn_name)
           {
@@ -1086,7 +1086,7 @@ namespace CORBA_RTCUtil
    * @return
    * @endif
    */
-  RTC::PortService_var get_port_by_url(const std::string& port_name)
+  RTC::PortService_ptr get_port_by_url(const std::string& port_name)
   {
     RTC::Manager& mgr = RTC::Manager::instance();
     RTC::NamingManager* nm = mgr.getNaming();
@@ -1172,10 +1172,10 @@ namespace CORBA_RTCUtil
   RTC::ReturnCode_t connect_multi(const std::string& name,
                                   const coil::Properties& prop,
                                   const RTC::PortService_ptr port,
-                                  RTC::PortServiceList_var& target_ports)
+                                  RTC::PortServiceList& target_ports)
   {
     RTC::ReturnCode_t ret(RTC::RTC_OK);
-    for (CORBA::ULong i(0); i < target_ports->length(); ++i)
+    for (CORBA::ULong i(0); i < target_ports.length(); ++i)
       {
         if (target_ports[i]->_is_equivalent(port)) { continue; }
         if (CORBA_RTCUtil::already_connected(port, target_ports[i]))
@@ -1199,7 +1199,7 @@ namespace CORBA_RTCUtil
    * @return
    * @endif
    */
-  bool find_port::operator()(const RTC::PortService_var& p)
+  bool find_port::operator()(const RTC::PortService_ptr p)
   {
     RTC::PortProfile_var prof = p->get_port_profile();
     std::string c(CORBA::string_dup(prof->name));
@@ -1218,19 +1218,18 @@ namespace CORBA_RTCUtil
    * @return
    * @endif
    */
-  RTC::PortService_var get_port_by_name(const RTC::RTObject_ptr rtc,
+  RTC::PortService_ptr get_port_by_name(const RTC::RTObject_ptr rtc,
                                         const std::string& name)
   {
     RTC::PortServiceList_var ports = rtc->get_ports();
-    RTC::PortService_var port_var;
     for (CORBA::ULong p(0); p < ports->length(); ++p)
       {
         RTC::PortProfile_var pp = ports[p]->get_port_profile();
         std::string s(CORBA::string_dup(pp->name));
 #ifdef ORB_IS_TAO
-        if (name == s) { return ports[p].in(); }
+        if (name == s) { return RTC::PortService::_duplicate(ports[p].in()); }
 #else
-        if (name == s) { return ports[p]; }
+        if (name == s) { return RTC::PortService::_duplicate(ports[p]); }
 #endif
       }
     return RTC::PortService::_nil();
@@ -1293,8 +1292,8 @@ namespace CORBA_RTCUtil
    */
   coil::Properties get_configuration(const RTC::RTObject_ptr rtc, const std::string& conf_name)
   {
-    SDOPackage::Configuration_ptr conf = rtc->get_configuration();
-    SDOPackage::ConfigurationSet* confset = conf->get_configuration_set(conf_name.c_str());
+    SDOPackage::Configuration_var conf = rtc->get_configuration();
+    SDOPackage::ConfigurationSet_var confset = conf->get_configuration_set(conf_name.c_str());
     SDOPackage::NVList confData = confset->configuration_data;
 
     coil::Properties prop;
@@ -1318,8 +1317,8 @@ namespace CORBA_RTCUtil
    */
   std::string get_parameter_by_key(const RTC::RTObject_ptr rtc, const std::string& confset_name, const std::string& value_name)
   {
-    SDOPackage::Configuration_ptr conf = rtc->get_configuration();
-    SDOPackage::ConfigurationSet* confset = conf->get_configuration_set(confset_name.c_str());
+    SDOPackage::Configuration_var conf = rtc->get_configuration();
+    SDOPackage::ConfigurationSet_var confset = conf->get_configuration_set(confset_name.c_str());
     SDOPackage::NVList confData = confset->configuration_data;
 
     coil::Properties prop;
@@ -1340,8 +1339,8 @@ namespace CORBA_RTCUtil
    */
   std::string get_active_configuration_name(const RTC::RTObject_ptr rtc)
   {
-    SDOPackage::Configuration_ptr conf = rtc->get_configuration();
-    SDOPackage::ConfigurationSet* confset = conf->get_active_configuration_set();
+    SDOPackage::Configuration_var conf = rtc->get_configuration();
+    SDOPackage::ConfigurationSet_var confset = conf->get_active_configuration_set();
 #ifdef ORB_IS_TAO
 	return std::string(confset->id);
 #else
@@ -1361,8 +1360,8 @@ namespace CORBA_RTCUtil
    */
   coil::Properties get_active_configuration(const RTC::RTObject_ptr rtc)
   {
-    SDOPackage::Configuration_ptr conf = rtc->get_configuration();
-    SDOPackage::ConfigurationSet* confset = conf->get_active_configuration_set();
+    SDOPackage::Configuration_var conf = rtc->get_configuration();
+    SDOPackage::ConfigurationSet_var confset = conf->get_active_configuration_set();
     SDOPackage::NVList confData = confset->configuration_data;
 
     coil::Properties prop;
@@ -1388,8 +1387,8 @@ namespace CORBA_RTCUtil
    */
   bool set_configuration(const RTC::RTObject_ptr rtc, const std::string& confset_name, const std::string& value_name, const std::string& value)
   {
-    SDOPackage::Configuration_ptr conf = rtc->get_configuration();
-    SDOPackage::ConfigurationSet* confset = conf->get_configuration_set(confset_name.c_str());
+    SDOPackage::Configuration_var conf = rtc->get_configuration();
+    SDOPackage::ConfigurationSet_var confset = conf->get_configuration_set(confset_name.c_str());
 
     set_configuration_parameter(conf, confset, value_name, value);
 
@@ -1414,8 +1413,8 @@ namespace CORBA_RTCUtil
    */
   bool set_active_configuration(const RTC::RTObject_ptr rtc, const std::string& value_name, const std::string& value)
   {
-    SDOPackage::Configuration_ptr conf = rtc->get_configuration();
-    SDOPackage::ConfigurationSet* confset = conf->get_active_configuration_set();
+    SDOPackage::Configuration_var conf = rtc->get_configuration();
+    SDOPackage::ConfigurationSet_var confset = conf->get_active_configuration_set();
 
     set_configuration_parameter(conf, confset, value_name, value);
 

--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -1390,7 +1390,7 @@ namespace CORBA_RTCUtil
     SDOPackage::Configuration_var conf = rtc->get_configuration();
     SDOPackage::ConfigurationSet_var confset = conf->get_configuration_set(confset_name.c_str());
 
-    set_configuration_parameter(conf, confset.out(), value_name, value);
+    set_configuration_parameter(conf, confset.inout(), value_name, value);
 
     conf->activate_configuration_set(confset_name.c_str());
 
@@ -1416,7 +1416,7 @@ namespace CORBA_RTCUtil
     SDOPackage::Configuration_var conf = rtc->get_configuration();
     SDOPackage::ConfigurationSet_var confset = conf->get_active_configuration_set();
 
-    set_configuration_parameter(conf, confset.out(), value_name, value);
+    set_configuration_parameter(conf, confset.inout(), value_name, value);
 
     conf->activate_configuration_set(confset->id);
 
@@ -1440,18 +1440,18 @@ namespace CORBA_RTCUtil
    * @return 
    * @endif
    */
-  bool set_configuration_parameter(SDOPackage::Configuration_ptr conf, SDOPackage::ConfigurationSet* confset, const std::string& value_name, const std::string& value)
+  bool set_configuration_parameter(SDOPackage::Configuration_ptr conf, SDOPackage::ConfigurationSet& confset, const std::string& value_name, const std::string& value)
   {
-    SDOPackage::NVList confData = confset->configuration_data;
+    SDOPackage::NVList confData = confset.configuration_data;
     coil::Properties prop;
     NVUtil::copyToProperties(prop, confData);
     prop[value_name] = value;
 
     NVUtil::copyFromProperties(confData, prop);
 
-    confset->configuration_data = confData;
+    confset.configuration_data = confData;
 
-    conf->set_configuration_set_values((*confset));
+    conf->set_configuration_set_values(confset);
 
     return true;
   }

--- a/src/lib/rtm/CORBA_RTCUtil.h
+++ b/src/lib/rtm/CORBA_RTCUtil.h
@@ -202,7 +202,7 @@ namespace CORBA_RTCUtil
    * @return 
    * @endif
    */
-  RTC::ExecutionContext_var get_actual_ec(RTC::RTObject_ptr rtc,
+  RTC::ExecutionContext_ptr get_actual_ec(RTC::RTObject_ptr rtc,
                                           RTC::UniqueId ec_id = 0);
 
   /*!
@@ -603,7 +603,7 @@ namespace CORBA_RTCUtil
    * @return 
    * @endif
    */
-  RTC::ConnectorProfile_var create_connector(const std::string& name,
+  RTC::ConnectorProfile* create_connector(const std::string& name,
                                              const coil::Properties& prop_arg,
                                              RTC::PortService_ptr port0,
                                              RTC::PortService_ptr port1);
@@ -777,7 +777,7 @@ namespace CORBA_RTCUtil
   * @return
   * @endif
   */
-  RTC::PortService_var get_port_by_url(const std::string& port_name);
+  RTC::PortService_ptr get_port_by_url(const std::string& port_name);
 
   /*!
    * @if jp
@@ -818,7 +818,7 @@ namespace CORBA_RTCUtil
   RTC::ReturnCode_t connect_multi(const std::string& name,
     const coil::Properties& prop,
     RTC::PortService_ptr port,
-    RTC::PortServiceList_var& target_ports);
+    RTC::PortServiceList* target_ports);
   /*!
    * @if jp
    * @brief ポートを名前から検索
@@ -850,7 +850,7 @@ namespace CORBA_RTCUtil
      * @return 
      * @endif
      */
-  bool operator()(const RTC::PortService_var& p);
+  bool operator()(const RTC::PortService_ptr p);
   };
 
   /*!
@@ -866,7 +866,7 @@ namespace CORBA_RTCUtil
    * @return
    * @endif
    */
-  RTC::PortService_var get_port_by_name(RTC::RTObject_ptr rtc,
+  RTC::PortService_ptr get_port_by_name(RTC::RTObject_ptr rtc,
                                         const std::string& name);
 
   /*!

--- a/src/lib/rtm/CORBA_RTCUtil.h
+++ b/src/lib/rtm/CORBA_RTCUtil.h
@@ -1021,7 +1021,7 @@ namespace CORBA_RTCUtil
    * @endif
    */
   bool set_configuration_parameter(SDOPackage::Configuration_ptr conf,
-                                   SDOPackage::ConfigurationSet* confset,
+                                   SDOPackage::ConfigurationSet& confset,
                                    const std::string& value_name,
                                    const std::string& value);
 

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2591,7 +2591,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 
         std::string port0_name = port0_str;
         RTObject_impl* comp0 = nullptr;
-        RTC::RTObject_ptr comp0_ref = nullptr;
+        RTC::RTObject_var comp0_ref;
 
         if (comp0_name.find("://") == std::string::npos)
           {
@@ -2601,7 +2601,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
               RTC_ERROR(("%s not found.", comp0_name.c_str()));
               continue;
             }
-            comp0_ref = comp0->getObjRef();
+            comp0_ref = RTObject::_duplicate(comp0->getObjRef());
           }
         else
           {
@@ -2611,12 +2611,12 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                 RTC_ERROR(("%s not found.", comp0_name.c_str()));
                 continue;
               }
-            comp0_ref = rtcs[0];
+            comp0_ref = RTObject::_duplicate(rtcs[0]);
             coil::vstring tmp_port0_name = coil::split(port0_str, "/");
             port0_name = tmp_port0_name.back();
           }
 
-        RTC::PortService_var port0_var = CORBA_RTCUtil::get_port_by_name(comp0_ref, port0_name);
+        RTC::PortService_var port0_var = CORBA_RTCUtil::get_port_by_name(comp0_ref.in(), port0_name);
         if (CORBA::is_nil(port0_var))
           {
             RTC_DEBUG(("port %s found: ", port0_str.c_str()));
@@ -2636,7 +2636,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                 prop["dataport." + key] = value;
               }
 
-            if (RTC::RTC_OK != CORBA_RTCUtil::connect(connector, prop, port0_var, RTC::PortService::_nil()))
+            if (RTC::RTC_OK != CORBA_RTCUtil::connect(connector, prop, port0_var.in(), RTC::PortService::_nil()))
               {
                 RTC_ERROR(("Connection error: %s", connector.c_str()));
               }
@@ -2649,7 +2649,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
             std::string comp_name = coil::flatten(tmp, ".");
             std::string port_name = port;
             RTObject_impl* comp = nullptr;
-            RTC::RTObject_ptr comp_ref = nullptr;
+            RTC::RTObject_var comp_ref;
 
             if (comp_name.find("://") == std::string::npos)
               {
@@ -2659,7 +2659,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                       RTC_ERROR(("%s not found.", comp_name.c_str()));
                       continue;
                   }
-                comp_ref = comp->getObjRef();
+                comp_ref = RTObject::_duplicate(comp->getObjRef());
               }
             else
               {
@@ -2669,12 +2669,12 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                     RTC_ERROR(("%s not found.", comp_name.c_str()));
                     continue;
                   }
-                comp_ref = rtcs[0];
+                comp_ref = RTObject::_duplicate(rtcs[0]);
                 coil::vstring tmp_port_name = coil::split(port, "/");
                 port_name = tmp_port_name.back();
               }
 
-            RTC::PortService_var port_var = CORBA_RTCUtil::get_port_by_name(comp_ref, port_name);
+            RTC::PortService_var port_var = CORBA_RTCUtil::get_port_by_name(comp_ref.in(), port_name);
 
             if (CORBA::is_nil(port_var))
               {
@@ -2690,7 +2690,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                 prop["dataport." + key] = std::move(value);
               }
 
-            if (RTC::RTC_OK != CORBA_RTCUtil::connect(connector, prop, port0_var, port_var))
+            if (RTC::RTC_OK != CORBA_RTCUtil::connect(connector, prop, port0_var.in(), port_var.in()))
               {
                 RTC_ERROR(("Connection error: %s", connector.c_str()));
               }
@@ -2722,7 +2722,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
         c = coil::eraseBothEndsBlank(std::move(c));
         if (!c.empty())
           {
-            RTC::RTObject_ptr comp_ref;
+            RTC::RTObject_var comp_ref;
             if (c.find("://") == std::string::npos)
               {
                 RTObject_impl* comp = getComponent(c.c_str());
@@ -2730,7 +2730,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                   {
                     RTC_ERROR(("%s not found.", c.c_str())); continue;
                   }
-                comp_ref = comp->getObjRef();
+                comp_ref = RTObject::_duplicate(comp->getObjRef());
               }
             else
               {
@@ -2740,10 +2740,9 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                     RTC_ERROR(("%s not found.", c.c_str()));
                     continue;
                   }
-                comp_ref = rtcs[0];
+                comp_ref = RTObject::_duplicate(rtcs[0]);
               }
-
-            RTC::ReturnCode_t ret = CORBA_RTCUtil::activate(comp_ref);
+            RTC::ReturnCode_t ret = CORBA_RTCUtil::activate(comp_ref.in());
             if (ret != RTC::RTC_OK)
               {
                 RTC_ERROR(("%s activation filed.", c.c_str()));
@@ -2893,7 +2892,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
       }
   }
 
-  PortServiceList_var Manager::getPortsOnNameServers(const std::string& nsname,
+  PortServiceList* Manager::getPortsOnNameServers(const std::string& nsname,
                                                      const std::string& kind)
   {
     PortServiceList_var ports = new PortServiceList();

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -1817,7 +1817,7 @@ namespace RTC
 	*
 	* @endif
 	*/
-	PortServiceList_var getPortsOnNameServers(const std::string& nsname, const std::string& kind);
+	PortServiceList* getPortsOnNameServers(const std::string& nsname, const std::string& kind);
 	/*!
 	* @if jp
 	* @brief

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -727,21 +727,21 @@ namespace RTC
     for (::CORBA::ULong i(0), len(sdos->length()); i < len; ++i)
       {
         ::RTC::RTObject_var rtc(::RTC::RTObject::_narrow(sdos[i]));
-        activateChildComp(rtc);
+        activateChildComp(rtc.in());
       }
     RTC_DEBUG(("%d member RTC%s activated.", sdos->length(),
                sdos->length() == 1 ? " was" : "s were"));
     return ::RTC::RTC_OK;
   }
 
-  void PeriodicECSharedComposite::activateChildComp(const RTC::RTObject_var& rtobj)
+  void PeriodicECSharedComposite::activateChildComp(const RTC::RTObject_ptr rtobj)
   {
       ::RTC::ExecutionContextList_var ecs(get_owned_contexts());
       SDOPackage::OrganizationList_var orglist = rtobj->get_owned_organizations();
 
       if (orglist->length() == 0)
       {
-          ecs[CORBA::ULong(0)]->activate_component(rtobj.in());
+          ecs[CORBA::ULong(0)]->activate_component(rtobj);
       }
 
       for (CORBA::ULong i(0); i < orglist->length(); ++i)
@@ -750,7 +750,7 @@ namespace RTC
           for (CORBA::ULong j(0); j < child_sdos->length(); ++j)
           {
               ::RTC::RTObject_var child(::RTC::RTObject::_narrow(child_sdos[j]));
-              activateChildComp(child);
+              activateChildComp(child.in());
           }
       }
   }
@@ -772,19 +772,19 @@ namespace RTC
     for (::CORBA::ULong i(0), len(sdos->length()); i < len; ++i)
       {
         ::RTC::RTObject_var rtc(::RTC::RTObject::_narrow(sdos[i]));
-        deactivateChildComp(rtc);
+        deactivateChildComp(rtc.in());
       }
     return ::RTC::RTC_OK;
   }
 
-  void PeriodicECSharedComposite::deactivateChildComp(const RTC::RTObject_var& rtobj)
+  void PeriodicECSharedComposite::deactivateChildComp(const RTC::RTObject_ptr rtobj)
   {
       ::RTC::ExecutionContextList_var ecs(get_owned_contexts());
       SDOPackage::OrganizationList_var orglist = rtobj->get_owned_organizations();
 
       if (orglist->length() == 0)
       {
-          ecs[CORBA::ULong(0)]->deactivate_component(rtobj.in());
+          ecs[CORBA::ULong(0)]->deactivate_component(rtobj);
       }
 
       for (CORBA::ULong i(0); i < orglist->length(); ++i)
@@ -793,7 +793,7 @@ namespace RTC
           for (CORBA::ULong j(0); j < child_sdos->length(); ++j)
           {
               ::RTC::RTObject_var child(::RTC::RTObject::_narrow(child_sdos[j]));
-              deactivateChildComp(child);
+              deactivateChildComp(child.in());
           }
       }
   }
@@ -814,19 +814,19 @@ namespace RTC
     for (::CORBA::ULong i(0), len(sdos->length()); i < len; ++i)
       {
         ::RTC::RTObject_var rtc(::RTC::RTObject::_narrow(sdos[i]));
-        resetChildComp(rtc);
+        resetChildComp(rtc.in());
       }
     return ::RTC::RTC_OK;
   }
 
-  void PeriodicECSharedComposite::resetChildComp(const RTC::RTObject_var& rtobj)
+  void PeriodicECSharedComposite::resetChildComp(const RTC::RTObject_ptr rtobj)
   {
       ::RTC::ExecutionContextList_var ecs(get_owned_contexts());
       SDOPackage::OrganizationList_var orglist = rtobj->get_owned_organizations();
 
       if (orglist->length() == 0)
       {
-          ecs[CORBA::ULong(0)]->reset_component(rtobj.in());
+          ecs[CORBA::ULong(0)]->reset_component(rtobj);
       }
 
       for (CORBA::ULong i(0); i < orglist->length(); ++i)
@@ -835,7 +835,7 @@ namespace RTC
           for (CORBA::ULong j(0); j < child_sdos->length(); ++j)
           {
               ::RTC::RTObject_var child(::RTC::RTObject::_narrow(child_sdos[j]));
-              resetChildComp(child);
+              resetChildComp(child.in());
           }
       }
   }

--- a/src/lib/rtm/PeriodicECSharedComposite.h
+++ b/src/lib/rtm/PeriodicECSharedComposite.h
@@ -543,7 +543,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t onActivated(RTC::UniqueId exec_handle) override;
-    void activateChildComp(const RTC::RTObject_var& rtobj);
+    void activateChildComp(const RTC::RTObject_ptr rtobj);
     /*!
      * @if jp
      *
@@ -576,7 +576,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t onDeactivated(RTC::UniqueId exec_handle) override;
-    void deactivateChildComp(const RTC::RTObject_var& rtobj);
+    void deactivateChildComp(const RTC::RTObject_ptr rtobj);
 
     /*!
      * @if jp
@@ -609,7 +609,7 @@ namespace RTC
      * @endif
      */
     ReturnCode_t onReset(RTC::UniqueId exec_handle) override;
-    void resetChildComp(const RTC::RTObject_var& rtobj);
+    void resetChildComp(const RTC::RTObject_ptr rtobj);
     /*!
      * @if jp
      *

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -377,7 +377,7 @@ namespace RTC
 
     for (CORBA::ULong i(0), len(prof.ports.length()); i < len; ++i)
       {
-        RTC::PortService_var p(prof.ports[i]);
+        RTC::PortService_var p(RTC::PortService::_duplicate(prof.ports[i]));
         try
           {
             return p->notify_disconnect(connector_id);
@@ -688,7 +688,7 @@ namespace RTC
     for (CORBA::ULong i(static_cast<CORBA::ULong>(index)); i < len; ++i)
       {
         RTC::PortService_var p;
-        p = cprof.ports[i];
+        p = RTC::PortService::_duplicate(cprof.ports[i]);
         try
           {
             return p->notify_disconnect(cprof.connector_id);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

CORBAオブジェクトを扱う関数で参照カウントが本来よりも増える、もしくは減るバグが発生すると考えられる箇所が多数存在する。

## Description of the Change

1. CORBAオブジェクトを返す関数は_ptr型で返して_var型で受け取るようにする。増加した参照カウントは関数の外側で削除する。

_var型で受け取るのか、_ptr型で受け取るのかで混乱するため、必ず関数内部で参照カウントを増やして_var型変数で受け取ってカウントを削除することを徹底する。

```CPP
RTC::ExecutionContext_ptr get_actual_ec(const RTC::RTObject_ptr rtc,
                                          RTC::UniqueId ec_id)
  {
        return RTC::ExecutionContext::_duplicate(eclist[(CORBA::ULong)ec_id].in());
```

```CPP
RTC::ExecutionContext_var ec = get_actual_ec(rtc, ec_id);
```

2. 引数には_ptr型で入力する。
内部で別の_var型変数に格納するときなどに混乱するため_ptr型で渡すことを徹底する。


上記の修正を行ったが、以下の点については怪しいがバグかどうかは不明のため未修正

1. PeriodicECSharedComposite.cppの以下の部分で_var型で受け取っているが参照カウントの辻妻は合っているのか？constを付ければ問題ない？

```CPP
const SDO_var sdo(sdo_list[i]);
```

```CPP
const SDO_var sdo  = sdo_list[i].object();
```

2. InPortCorbaCdrConsumer.cpp等で_this関数の戻り値を_var型に格納しているが、_this関数内部で参照カウントが増えているのか？

```CPP
m_objref = this->_this();
```

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
