### PR TITLE
_var型変数、_duplicate関数の使い方のミスによりオブジェクトが意図しないタイミングで削除されるバグの修正

### DIFF
--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -113,7 +113,7 @@ namespace CORBA_RTCUtil
           { return RTC::ExecutionContext::_nil(); }
         if (CORBA::is_nil(eclist[ec_id]))
           { return RTC::ExecutionContext::_nil(); }
-        return eclist[ec_id];
+        return RTC::ExecutionContext::_duplicate(eclist[ec_id]);
       }
     if (ec_id >= 1000)
       {
@@ -124,7 +124,7 @@ namespace CORBA_RTCUtil
           { return RTC::ExecutionContext::_nil(); }
         if (CORBA::is_nil(eclist[pec_id]))
           { return RTC::ExecutionContext::_nil(); }
-        return eclist[pec_id];
+        return RTC::ExecutionContext::_duplicate(eclist[pec_id]);
       }
     return RTC::ExecutionContext::_nil();
   }
@@ -1186,7 +1186,7 @@ namespace CORBA_RTCUtil
       {
         RTC::PortProfile_var pp = ports[p]->get_port_profile();
         std::string s(CORBA::string_dup(pp->name));
-        if (name == s) { return ports[p]; }
+        if (name == s) { return RTC::PortService::_duplicate(ports[p]); }
       }
     return RTC::PortService::_nil();
   }

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2614,7 +2614,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 		  
 		  std::string port0_name = port0_str;
 		  RTObject_impl* comp0 = NULL;
-		  RTC::RTObject_ptr comp0_ref = NULL;
+		  RTC::RTObject_var comp0_ref;
 
 		  if (comp0_name.find("://") == std::string::npos)
 		  {
@@ -2624,7 +2624,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 				  RTC_ERROR(("%s not found.", comp0_name.c_str()));
 				  continue;
 			  }
-			  comp0_ref = comp0->getObjRef();
+			  comp0_ref = RTObject::_duplicate(comp0->getObjRef());
 		  }
 		  else
 		  {
@@ -2634,7 +2634,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 				  RTC_ERROR(("%s not found.", comp0_name.c_str()));
 				  continue;
 			  }
-			  comp0_ref = rtcs[0];
+			  comp0_ref = RTObject::_duplicate(rtcs[0]);
 			  coil::vstring tmp_port0_name = coil::split(port0_str, "/");
 			  port0_name = tmp_port0_name.back();
 
@@ -2678,7 +2678,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 			  std::string comp_name = coil::flatten(tmp, ".");
 			  std::string port_name = port_str;
 			  RTObject_impl* comp = NULL;
-			  RTC::RTObject_ptr comp_ref = NULL;
+			  RTC::RTObject_var comp_ref;
 
 
 			  if (comp_name.find("://") == std::string::npos)
@@ -2689,7 +2689,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 					  RTC_ERROR(("%s not found.", comp_name.c_str()));
 					  continue;
 				  }
-				  comp_ref = comp->getObjRef();
+				  comp_ref = RTObject::_duplicate(comp->getObjRef());
 			  }
 			  else
 			  {
@@ -2699,7 +2699,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 					  RTC_ERROR(("%s not found.", comp_name.c_str()));
 					  continue;
 				  }
-				  comp_ref = rtcs[0];
+				  comp_ref = RTObject::_duplicate(rtcs[0]);
 				  coil::vstring tmp_port_name = coil::split(port_str, "/");
 				  port_name = tmp_port_name.back();
 
@@ -2761,7 +2761,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 		  coil::eraseBothEndsBlank(comps[i]);
 		  if (!comps[i].empty())
 		  {
-			  RTC::RTObject_ptr comp_ref;
+			  RTC::RTObject_var comp_ref;
 			  if (comps[i].find("://") == std::string::npos)
 			  {
 				  RTObject_impl* comp = getComponent(comps[i].c_str());
@@ -2769,7 +2769,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 				  {
 					  RTC_ERROR(("%s not found.", comps[i].c_str())); continue;
 				  }
-				  comp_ref = comp->getObjRef();
+				  comp_ref = RTObject::_duplicate(comp->getObjRef());
 			  }
 			  else
 			  {
@@ -2779,7 +2779,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 					  RTC_ERROR(("%s not found.", comps[i].c_str()));
 					  continue;
 				  }
-				  comp_ref = rtcs[0];
+				  comp_ref = RTObject::_duplicate(rtcs[0]);
 				  
 			  }
 			  

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -388,7 +388,7 @@ namespace RTC
 
     for (CORBA::ULong i(0), len(prof.ports.length()); i < len; ++i)
       {
-        RTC::PortService_var p(prof.ports[i]);
+        RTC::PortService_var p(RTC::PortService::_duplicate(prof.ports[i]));
         try
           {
             return p->notify_disconnect(connector_id);
@@ -693,7 +693,7 @@ namespace RTC
     for (CORBA::ULong i(index); i < len; ++i)
       {
         RTC::PortService_var p;
-        p = cprof.ports[i];
+        p = RTC::PortService::_duplicate(cprof.ports[i]);
         try
           {
             return p->notify_disconnect(cprof.connector_id);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
以下の条件でRTCが異常終了する可能性がある。

1. コネクタを切断する(TAOを使用する場合は100％問題が発生する。omniORBで問題が発生しない理由は不明)
2. rtc.confで`manager.components.preconnect:`オプションを指定してポートを接続する。
3. rtc.confで`manager.components.preactivation:`オプションを指定してRTCをアクティベートする。
4. CORBA_RTCUtilのget_actual_ec関数を使用する(問題未確認)
5. CORBA_RTCUtilのget_port_by_name関数を使用する



## Description of the Change

#665 の修正内容のうち、動作中に異常終了する可能性のある致命的なバグについて修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
