### PR TITLE
get_organizations関数の戻り値を_var型に入れないため発生するメモリリークの修正

### DIFF
--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -395,12 +395,12 @@ namespace RTC
     if (m_exiting) { return RTC::RTC_OK; }
 
 
-    SDOPackage::OrganizationList* organizations = get_organizations();
+    SDOPackage::OrganizationList_var organizations = get_organizations();
     CORBA::ULong len = organizations->length();
 
     for (CORBA::ULong i = 0; i < len; i++)
       {
-        (*organizations)[i]->remove_member(getInstanceName());
+        organizations[i]->remove_member(getInstanceName());
       }
     // deactivate myself on owned EC
     CORBA_SeqUtil::for_each(m_ecMine,


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#671 

## Description of the Change

get_organizations関数の戻り値をOrganizationList_var型に格納して正常に参照カウントが減るように修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
