### PR TITLE
RTCが状態遷移しない問題の修正

### DIFF
--- a/src/lib/rtm/ExecutionContextWorker.cpp
+++ b/src/lib/rtm/ExecutionContextWorker.cpp
@@ -173,14 +173,12 @@ namespace RTC_impl
         return RTC::BAD_PARAMETER;
       }
     RTC_DEBUG(("Component found in the EC."));
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
-    if (!(obj->isCurrentState(RTC::INACTIVE_STATE)))
+    if (!(obj->activate()))
       {
         RTC_ERROR(("State of the RTC is not INACTIVE_STATE."));
         return RTC::PRECONDITION_NOT_MET;
       }
     RTC_DEBUG(("Component is in INACTIVE state. Going to ACTIVE state."));
-    obj->goTo(RTC::ACTIVE_STATE);
     rtobj = obj;
     RTC_DEBUG(("activateComponent() done."));
     return RTC::RTC_OK;
@@ -205,13 +203,11 @@ namespace RTC_impl
         RTC_ERROR(("Given RTC is not participant of this EC."));
         return RTC::BAD_PARAMETER;
       }
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
-    if (!(rtobj->isCurrentState(RTC::ACTIVE_STATE)))
+    if (!(rtobj->deactivate()))
       {
         RTC_ERROR(("State of the RTC is not ACTIVE_STATE."));
         return RTC::PRECONDITION_NOT_MET;
       }
-    rtobj->goTo(RTC::INACTIVE_STATE);
     return RTC::RTC_OK;
   }
 
@@ -234,13 +230,11 @@ namespace RTC_impl
         RTC_ERROR(("Given RTC is not participant of this EC."));
         return RTC::BAD_PARAMETER;
       }
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
-    if (!(rtobj->isCurrentState(RTC::ERROR_STATE)))
+    if (!(rtobj->reset()))
       {
         RTC_ERROR(("State of the RTC is not ERROR_STATE."));
         return RTC::PRECONDITION_NOT_MET;
       }
-    rtobj->goTo(RTC::INACTIVE_STATE);
     return RTC::RTC_OK;
   }
 
@@ -427,7 +421,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (!comp->isCurrentState(state)) { return false; }
       }
     return true;
@@ -439,7 +432,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (!comp->isNextState(state)) { return false; }
       }
     return true;
@@ -451,7 +443,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (comp->isCurrentState(state)) { return true; }
       }
     return false;
@@ -463,7 +454,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (comp->isNextState(state)) { return true; }
       }
     return false;
@@ -474,15 +464,12 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorker()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex); 
         comp->workerPreDo();  
     }
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         comp->workerDo();     
     }
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         comp->workerPostDo(); 
     }
     std::lock_guard<std::mutex> guard(m_mutex);
@@ -494,7 +481,6 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorkerPreDo()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         comp->workerPreDo();  
     }
   }
@@ -504,7 +490,6 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorkerDo()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex); 
         comp->workerDo();     
     }
   }
@@ -514,7 +499,6 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorkerPostDo()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex); 
         comp->workerPostDo(); 
     }
     // m_comps might be changed here

--- a/src/lib/rtm/ExecutionContextWorker.h
+++ b/src/lib/rtm/ExecutionContextWorker.h
@@ -593,7 +593,6 @@ namespace RTC_impl
     std::vector<RTC_impl::RTObjectStateMachine*> m_removedComps;
     mutable std::mutex m_removedMutex;
     using CompItr = std::vector<RTC_impl::RTObjectStateMachine*>::iterator;
-    mutable std::mutex m_statemutex;
 
   };  // class PeriodicExecutionContext
 } // namespace RTC_impl

--- a/src/lib/rtm/RTObjectStateMachine.cpp
+++ b/src/lib/rtm/RTObjectStateMachine.cpp
@@ -425,4 +425,17 @@ namespace RTC_impl
   {
     return m_sm.worker_post();
   }
+
+  bool RTObjectStateMachine::activate()
+  {
+      return m_sm.goTo(RTC::INACTIVE_STATE, RTC::ACTIVE_STATE);
+  }
+  bool RTObjectStateMachine::deactivate()
+  {
+      return m_sm.goTo(RTC::ACTIVE_STATE, RTC::INACTIVE_STATE);
+  }
+  bool RTObjectStateMachine::reset()
+  {
+      return m_sm.goTo(RTC::ERROR_STATE, RTC::INACTIVE_STATE);
+  }
 } // namespace RTC_impl

--- a/src/lib/rtm/RTObjectStateMachine.h
+++ b/src/lib/rtm/RTObjectStateMachine.h
@@ -85,6 +85,10 @@ namespace RTC_impl
     void workerDo();
     void workerPostDo();
 
+    bool activate();
+    bool deactivate();
+    bool reset();
+
   protected:
     void setComponentAction(RTC::LightweightRTObject_ptr comp);
     void setDataFlowComponentAction(RTC::LightweightRTObject_ptr comp);

--- a/src/lib/rtm/StateMachine.h
+++ b/src/lib/rtm/StateMachine.h
@@ -733,6 +733,43 @@ namespace RTC_Utils
         }
     }
 
+    /*!
+     * @if jp
+     * @brief 状態を遷移
+     *
+     * 遷移前の状態と遷移先の状態を指定する。
+     * 現在の状態が指定の状態ではない場合は遷移しない。
+     * 現在の状態が指定の状態の場合のみ状態遷移する。
+     *
+     * @param nowstate 遷移元状態
+     * @param nextstate 遷移先状態
+     * @return 現在の状態が指定の状態の場合はtrueを返す
+     *
+     * @else
+     * @brief Transit State
+     *
+     *
+     * @param nowstate 
+     * @param nextstate 
+     * @return 
+     *
+     * @endif
+     */
+    bool goTo(State nowstate, State nextstate)
+    {
+        if (nowstate == nextstate)
+        {
+            return false;
+        }
+        std::lock_guard<std::mutex> guard(m_mutex);
+        if (m_states.curr == nowstate)
+        {
+            m_states.next = nextstate;
+            return true;
+        }
+        return false;
+    }
+
 
     /*!
      * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#653 の修正がまずかったらしく、RTSE等でdeactivate_componentを実行すると実行中に以下の箇所でブロックされてしまう。

```CPP
  RTC::ReturnCode_t
  ExecutionContextWorker::activateComponent(RTC::LightweightRTObject_ptr comp,
                                            RTObjectStateMachine*& rtobj)
  {
    RTC_TRACE(("activateComponent()"));
    RTObjectStateMachine* obj = findComponent(comp);
    if (obj == nullptr)
      {
        RTC_ERROR(("Given RTC is not participant of this EC."));
        return RTC::BAD_PARAMETER;
      }
    RTC_DEBUG(("Component found in the EC."));
    std::lock_guard<std::mutex> stateguard(m_statemutex); //ここでブロック
    if (!(obj->isCurrentState(RTC::INACTIVE_STATE)))
      {
        RTC_ERROR(("State of the RTC is not INACTIVE_STATE."));
        return RTC::PRECONDITION_NOT_MET;
      }
    RTC_DEBUG(("Component is in INACTIVE state. Going to ACTIVE state."));
    obj->goTo(RTC::ACTIVE_STATE); 
    rtobj = obj;
    RTC_DEBUG(("activateComponent() done."));
    return RTC::RTC_OK;
  }
```

`m_statemutex`のロックとアンロックは`invokeWorkerDo`関数等で実行しているが、deactivate_componentの`m_statemutex`でブロックされている間にもinvokeWorkerDo関数は複数回実行する。つまり`m_statemutex`をアンロックしているにもかかわらずdeactivate_component関数でロックができないということになっている。

```CPP
  void ExecutionContextWorker::invokeWorkerDo()
  {
    RTC_PARANOID(("invokeWorkerDo()"));
    // m_comps never changes its size here
    for (auto & comp : m_comps) { 
        std::lock_guard<std::mutex> stateguard(m_statemutex); 
        comp->workerDo();     
    }
  }

```

Windowsの場合は`A:ロック獲得成功→B:ロック獲得要求→A:1→A:ロック解放→A:2→A:ロック獲得成功`という状況が発生するらしく、deactivate_componentがロック獲得できないままinvokeWorkerDo関数等がロック獲得を行っていると推測する。

- https://yohhoy.hatenadiary.jp/entry/20121002/p1


## Description of the Change

#653 での問題は「状態を確認してから遷移するまでの間に状態が変化する可能性がある」ことのため、StateMachine.hで遷移元の状態と遷移先の状態を指定して現在の状態が指定の状態の場合のみ遷移するgoTo関数を定義してロックする範囲を最小限にした。

ただ、問題が発生する可能性がほぼなくなっただけであり根本的な解決にはなっていない。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
