### PR TITLE
getObjRef関数内部でduplicateするための仕様変更

### DIFF
--- a/src/ext/ec/logical_time/example/LTTSampleComp.cpp
+++ b/src/ext/ec/logical_time/example/LTTSampleComp.cpp
@@ -26,11 +26,12 @@ void MyModuleInit(RTC::Manager* manager)
   std::cout << "succeed." << std::endl;
   RTC::ExecutionContextList_var eclist = comp->get_owned_contexts();
   if ( eclist->length() > 0) {
-	eclist[0]->start();
-	eclist[0]->activate_component(RTC::RTObject::_duplicate(comp->getObjRef()));
+      eclist[0]->start();
+      RTC::RTObject_var rtobj = comp->getObjRef();
+      eclist[0]->activate_component(rtobj.in());
   }
   else {
-	std::cerr << "No owned EC." << std::endl;
+      std::cerr << "No owned EC." << std::endl;
   }
   RTC::ComponentProfile_var prof;
   prof = comp->get_component_profile();

--- a/src/ext/local_service/nameservice_file/FileNameservice.cpp
+++ b/src/ext/local_service/nameservice_file/FileNameservice.cpp
@@ -381,11 +381,9 @@ namespace RTM
     {
       coil::vstring name = name_;
 #ifndef ORB_IS_RTORB
-      CORBA::Object_var objref =
-        RTC::RTObject::_duplicate(rtobj->getObjRef());
+      CORBA::Object_var objref = rtobj->getObjRef();
 #else
-      RTC::RTObject_var objref =
-        RTC::RTObject::_duplicate(rtobj->getObjRef());
+      RTC::RTObject_var objref = rtobj->getObjRef();
 #endif // ORB_IS_RTORB
       CORBA::String_var ior =
         RTC::Manager::instance().getORB()->object_to_string(objref);

--- a/src/lib/rtm/ExecutionContextBase.cpp
+++ b/src/lib/rtm/ExecutionContextBase.cpp
@@ -117,11 +117,12 @@ namespace RTC
   RTC::ReturnCode_t ExecutionContextBase::
   bindComponent(RTC::RTObject_impl* rtc)
   {
-	if (rtc == nullptr)
-	{
-		  return RTC::BAD_PARAMETER;
-	}
-    setOwner(rtc->getObjRef());
+    if (rtc == nullptr)
+      {
+        return RTC::BAD_PARAMETER;
+      }
+    RTC::RTObject_var rtobj = rtc->getObjRef();
+    setOwner(rtobj.in());
     return m_worker.bindComponent(rtc);
   }
 

--- a/src/lib/rtm/ExecutionContextWorker.cpp
+++ b/src/lib/rtm/ExecutionContextWorker.cpp
@@ -334,8 +334,7 @@ namespace RTC_impl
     RTC_DEBUG(("bindContext returns id = %d", id));
 
     // rtc is owner of this EC
-    RTC::LightweightRTObject_var comp
-      = RTC::LightweightRTObject::_duplicate(rtc->getObjRef());
+    RTC::LightweightRTObject_var comp = rtc->getObjRef();
     m_comps.emplace_back(new RTObjectStateMachine(id, comp));
     RTC_DEBUG(("bindComponent() succeeded."));
 

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -1068,7 +1068,8 @@ namespace RTC
       {
         CORBA::Object_var obj;
         obj = orb->string_to_object(port.c_str());
-        if (getPortRef()->_is_equivalent(obj)) { continue; }
+        PortService_var portref = getPortRef();
+        if (portref->_is_equivalent(obj)) { continue; }
         RTC_DEBUG(("Peer port found: %s.", port.c_str()));
         try
           {

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -39,18 +39,18 @@ namespace RTC
     PortableServer::ObjectId_var oid = ::RTC::Manager::instance().theShortCutPOA()->activate_object(this);
 #endif
 
-	m_objref = this->_this();
+    m_objref = this->_this();
 
     // set InPort's reference
     CORBA::ORB_var orb = ::RTC::Manager::instance().getORB();
-	CORBA::String_var ior = orb->object_to_string(m_objref.in());
+    CORBA::String_var ior = orb->object_to_string(m_objref.in());
     CORBA_SeqUtil::
       push_back(m_properties,
                 NVUtil::newNV("dataport.corba_cdr.inport_ior", ior.in()));
 
     CORBA_SeqUtil::
       push_back(m_properties,
-	  NVUtil::newNV("dataport.corba_cdr.inport_ref", m_objref));
+        NVUtil::newNV("dataport.corba_cdr.inport_ref", m_objref));
 
   }
   

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -39,18 +39,18 @@ namespace RTC
     PortableServer::ObjectId_var oid = ::RTC::Manager::instance().theShortCutPOA()->activate_object(this);
 #endif
 
-    m_objref = this->_this();
+	m_objref = this->_this();
 
     // set InPort's reference
     CORBA::ORB_var orb = ::RTC::Manager::instance().getORB();
-    CORBA::String_var ior = orb->object_to_string(m_objref.in());
+	CORBA::String_var ior = orb->object_to_string(m_objref.in());
     CORBA_SeqUtil::
       push_back(m_properties,
                 NVUtil::newNV("dataport.corba_cdr.inport_ior", ior.in()));
 
     CORBA_SeqUtil::
       push_back(m_properties,
-        NVUtil::newNV("dataport.corba_cdr.inport_ref", m_objref));
+	  NVUtil::newNV("dataport.corba_cdr.inport_ref", m_objref));
 
   }
   

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -770,7 +770,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 
     if (m_config.getProperty("corba.endpoints_ipv4").empty())
       {
-        setEndpointProperty(comp->getObjRef());
+        RTC::RTObject_var rtobj = comp->getObjRef();
+        setEndpointProperty(rtobj.in());
       }
 
     for (int i(0); inherit_prop[i][0] != '\0'; ++i)
@@ -2601,7 +2602,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
               RTC_ERROR(("%s not found.", comp0_name.c_str()));
               continue;
             }
-            comp0_ref = RTObject::_duplicate(comp0->getObjRef());
+            comp0_ref = comp0->getObjRef();
           }
         else
           {
@@ -2659,7 +2660,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                       RTC_ERROR(("%s not found.", comp_name.c_str()));
                       continue;
                   }
-                comp_ref = RTObject::_duplicate(comp->getObjRef());
+                comp_ref = comp->getObjRef();
               }
             else
               {
@@ -2730,7 +2731,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
                   {
                     RTC_ERROR(("%s not found.", c.c_str())); continue;
                   }
-                comp_ref = RTObject::_duplicate(comp->getObjRef());
+                comp_ref = comp->getObjRef();
               }
             else
               {

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -91,7 +91,7 @@ namespace RTM
           {
             if (CORBA::is_nil(m_masters[i])) { continue; }
             m_masters[i]
-              ->remove_slave_manager(RTM::Manager::_duplicate(m_objref));
+              ->remove_slave_manager(m_objref.in());
           }
         catch (...)
           {
@@ -107,7 +107,7 @@ namespace RTM
           {
             if (CORBA::is_nil(m_slaves[i])) { continue; }
             m_slaves[i]
-              ->remove_master_manager(RTM::Manager::_duplicate(m_objref));
+              ->remove_master_manager(m_objref.in());
           }
         catch (...)
           {
@@ -507,7 +507,7 @@ namespace RTM
         RTC::RTObject_impl* rtc = m_mgr.createComponent(create_arg.c_str());
         if (rtc != nullptr)
           {
-            return RTC::RTObject::_duplicate(rtc->getObjRef());
+            return rtc->getObjRef();
           }
       }
 
@@ -563,9 +563,9 @@ namespace RTM
     for (size_t i(0), len(rtcs.size()); i < len; ++i)
       {
 #ifndef ORB_IS_TAO
-        crtcs[static_cast<CORBA::Long>(i)] = RTC::RTObject::_duplicate(rtcs[i]->getObjRef());
+        crtcs[static_cast<CORBA::Long>(i)] = rtcs[i]->getObjRef();
 #else
-        crtcs.inout()[(CORBA::Long)i] = RTC::RTObject::_duplicate(rtcs[i]->getObjRef());
+        crtcs.inout()[(CORBA::Long)i] = rtcs[i]->getObjRef();
 #endif
       }
 
@@ -881,7 +881,7 @@ namespace RTM
               {
                 if (CORBA::is_nil(m_masters[i])) { continue; }
                 m_masters[i]
-                  ->remove_slave_manager(RTM::Manager::_duplicate(m_objref));
+                  ->remove_slave_manager(m_objref.in());
               }
             catch (...)
               {
@@ -899,7 +899,7 @@ namespace RTM
               {
                 if (CORBA::is_nil(m_slaves[i])) { continue; }
                 m_slaves[i]
-                 ->remove_master_manager(RTM::Manager::_duplicate(m_objref));
+                 ->remove_master_manager(m_objref.in());
               }
             catch (...)
               {
@@ -948,8 +948,7 @@ namespace RTM
         if (rtc_name.size() == 1 &&
             rtc_name[0] == rtc->getInstanceName())
           {
-            RTC::RTObject_var rtcref =
-              RTC::RTObject::_duplicate(rtc->getObjRef());
+            RTC::RTObject_var rtcref = rtc->getObjRef();
 #ifndef ORB_IS_RTORB
             CORBA_SeqUtil::push_back(crtcs.inout(), rtcref.in());
 #else // ORB_IS_RTORB
@@ -966,8 +965,7 @@ namespace RTM
             (rtc_name[0] == rtc->getCategory() &&
              rtc_name[1] == rtc->getInstanceName()))
           {
-            RTC::RTObject_var rtcref =
-              RTC::RTObject::_duplicate(rtc->getObjRef());
+            RTC::RTObject_var rtcref = rtc->getObjRef();
 #ifndef ORB_IS_RTORB
             CORBA_SeqUtil::push_back(crtcs.inout(), rtcref.in());
 #else // ORB_IS_RTORB
@@ -1002,9 +1000,9 @@ namespace RTM
   RTM::Manager_ptr ManagerServant::getObjRef() const
   {
 #ifdef ORB_IS_ORBEXPRESS
-    return m_objref.in();
+    return RTM::Manager::_duplicate(m_objref.in());
 #else
-    return m_objref;
+    return RTM::Manager::_duplicate(m_objref);
 #endif
   }
 
@@ -1053,7 +1051,7 @@ namespace RTM
 
         CORBA::String_var ior;
         ior = m_mgr.theORB()->
-          object_to_string(RTM::Manager::_duplicate(m_objref));
+          object_to_string(m_objref);
         std::string iorstr((const char*)ior);
         RTC_DEBUG(("Manager's IOR information:\n %s",
                    CORBA_IORUtil::formatIORinfo(iorstr.c_str()).c_str()));
@@ -1070,11 +1068,12 @@ namespace RTM
 
         // Object activation
         RTC_DEBUG(("Activating manager with id(%s)", config["manager.name"].c_str()));
-        CORBA::String_var ior = m_mgr.theORB()->object_to_string(_this());
-        adapter->bind(config["manager.name"].c_str(), ior.in());
 
         // Set m_objref 
         m_objref = _this();
+
+        CORBA::String_var ior = m_mgr.theORB()->object_to_string(m_objref.in());
+        adapter->bind(config["manager.name"].c_str(), ior.in());
 
 
         std::string iorstr((const char*)ior);
@@ -1126,7 +1125,7 @@ namespace RTM
 #endif  // ORB_IS_RTORB
 
         CORBA::String_var ior;
-        ior = m_mgr.theORB()->object_to_string(RTM::Manager::_duplicate(mgr));
+        ior = m_mgr.theORB()->object_to_string(mgr);
         std::string iorstr((const char*)ior);
         RTC_DEBUG(("Manager's IOR information:\n %s",
                    CORBA_IORUtil::formatIORinfo(iorstr.c_str()).c_str()));
@@ -1164,7 +1163,7 @@ namespace RTM
     coil::Properties prop = m_mgr.getConfig();
     if (mgr_name == prop["manager.instance_name"])
       {
-        return RTM::Manager::_duplicate(getObjRef());
+        return getObjRef();
       }
     if (m_isMaster)
       {

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -173,12 +173,12 @@ namespace RTC_exp
                       RTC_ERROR(("no RTC found: %s", member.c_str()));
                       continue;
                   }
-                  RTC::RTObject_ptr rtobj = comp->getObjRef();
+                  RTC::RTObject_var rtobj = comp->getObjRef();
                   if (CORBA::is_nil(rtobj))
                   {
                       continue;
                   }
-                  rtcs.emplace_back(rtobj);
+                  rtcs.emplace_back(RTC::RTObject::_duplicate(rtobj));
               }
           }
           addTask(rtcs);

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -1085,7 +1085,8 @@ namespace RTC
       {
         CORBA::Object_var obj;
         obj = orb->string_to_object(port.c_str());
-        if (getPortRef()->_is_equivalent(obj)) { continue; }
+        PortService_var portref = getPortRef();
+        if (portref->_is_equivalent(obj)) { continue; }
         RTC_DEBUG(("Peer port found: %s.", port.c_str()));
         try
           {

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -34,8 +34,8 @@ namespace SDOPackage
    * @brief Constructor
    * @endif
    */
-  PeriodicECOrganization::PeriodicECOrganization(::RTC::RTObject_impl* rtobj)
-    : Organization_impl(rtobj->getObjRef()),
+  PeriodicECOrganization::PeriodicECOrganization(::RTC::RTObject_impl* rtobj, SDOSystemElement_ptr sdo)
+    : Organization_impl(sdo),
       rtclog("PeriodicECOrganization"),
       m_rtobj(rtobj),
       m_ec(::RTC::ExecutionContext::_nil())
@@ -622,10 +622,9 @@ namespace RTC
   {
     m_ref = this->_this();
     m_objref = RTC::RTObject::_duplicate(m_ref);
-    m_org = new SDOPackage::PeriodicECOrganization(this);
+    m_org = new SDOPackage::PeriodicECOrganization(this, m_objref.in());
     ::CORBA_SeqUtil::push_back(m_sdoOwnedOrganizations,
-                               ::SDOPackage::Organization::
-                               _duplicate(m_org->getObjRef()));
+                               m_org->getObjRef());
     bindParameter("members", m_members, "", stringToStrVec);
 
     m_configsets.setOnSetConfigurationSet(new setCallback(m_org));
@@ -690,12 +689,12 @@ namespace RTC
 
         ::SDOPackage::SDO_var sdo;
 #ifndef ORB_IS_RTORB
-        sdo = ::SDOPackage::SDO::_duplicate(rtc->getObjRef());
+        sdo = rtc->getObjRef();
         if (::CORBA::is_nil(sdo)) continue;
 
         ::CORBA_SeqUtil::push_back(sdos, sdo);
 #else  // ORB_IS_RTORB
-        sdo = ::SDOPackage::SDO::_duplicate((rtc->getObjRef()).in());
+        sdo = rtc->getObjRef();
         if (::CORBA::is_nil(sdo)) continue;
 
         ::CORBA_SeqUtil::push_back(sdos, ::SDOPackage::SDO_ptr(sdo));

--- a/src/lib/rtm/PeriodicECSharedComposite.h
+++ b/src/lib/rtm/PeriodicECSharedComposite.h
@@ -86,7 +86,7 @@ namespace SDOPackage
      *
      * @endif
      */
-    explicit PeriodicECOrganization(::RTC::RTObject_impl* rtobj);
+    explicit PeriodicECOrganization(::RTC::RTObject_impl* rtobj, SDOSystemElement_ptr sdo);
     /*!
      * @if jp
      * @brief デストラクタ

--- a/src/lib/rtm/PortAdmin.cpp
+++ b/src/lib/rtm/PortAdmin.cpp
@@ -175,9 +175,9 @@ namespace RTC
     if (index >= 0)
       {
 #ifdef ORB_IS_ORBEXPRESS
-	return m_portRefs[index].in();
+	return RTC::PortService::_duplicate(m_portRefs[index].in());
 #else
-	return m_portRefs[index];
+	return RTC::PortService::_duplicate(m_portRefs[index]);
 #endif
       }
     return RTC::PortService::_nil();
@@ -211,8 +211,7 @@ namespace RTC
       }
 
     // Store Port's ref to PortServiceList
-    CORBA_SeqUtil::push_back(m_portRefs,
-                             RTC::PortService::_duplicate(port.getPortRef()));
+    CORBA_SeqUtil::push_back(m_portRefs, port.getPortRef());
 
     // Store Port servant
     return m_portServants.registerObject(&port);

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -225,24 +225,25 @@ namespace RTC
 
 
 
-	Properties prop;
-	NVUtil::copyToProperties(prop, connector_profile.properties);
-	bool default_value = coil::toBool(m_properties["allow_dup_connection"], "YES", "NO", false);
+    Properties prop;
+    NVUtil::copyToProperties(prop, connector_profile.properties);
+    bool default_value = coil::toBool(m_properties["allow_dup_connection"], "YES", "NO", false);
 
-	if (!coil::toBool(prop.getProperty("dataport.allow_dup_connection"), "YES", "NO", default_value))
-	{
-		for (unsigned int i = 0; i < connector_profile.ports.length(); i++)
-		{
-			if (!getPortRef()->_is_equivalent(connector_profile.ports[i]))
-			{
-				bool ret = CORBA_RTCUtil::already_connected(connector_profile.ports[i], m_objref);
-				if(ret)
-				{
-					return RTC::PRECONDITION_NOT_MET;
-				}
-			}
-		}
-	}
+    if (!coil::toBool(prop.getProperty("dataport.allow_dup_connection"), "YES", "NO", default_value))
+      {
+        for (unsigned int i = 0; i < connector_profile.ports.length(); i++)
+          {
+            PortService_var portref = getPortRef();
+            if (!portref->_is_equivalent(connector_profile.ports[i]))
+              {
+                bool ret = CORBA_RTCUtil::already_connected(connector_profile.ports[i], m_objref.in());
+                if(ret)
+                  {
+                    return RTC::PRECONDITION_NOT_MET;
+                  }
+              }
+          }
+      }
 
 
 
@@ -564,9 +565,9 @@ namespace RTC
     RTC_TRACE(("getPortRef()"));
     std::lock_guard<std::mutex> guard(m_profile_mutex);
 #ifdef ORB_IS_ORBEXPRESS
-    return m_profile.port_ref.in();
+    return RTC::PortService::_duplicate(m_profile.port_ref.in());
 #else
-    return m_profile.port_ref;
+    return RTC::PortService::_duplicate(m_profile.port_ref);
 #endif
   }
 

--- a/src/lib/rtm/PortProfileHelper.cpp
+++ b/src/lib/rtm/PortProfileHelper.cpp
@@ -196,7 +196,7 @@ namespace RTC
   {
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    return m_portRef;
+    return RTC::PortService::_duplicate(m_portRef);
   }
 
 

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -77,8 +77,7 @@ namespace RTC
     m_objref = this->_this();
     m_pSdoConfigImpl = new SDOPackage::Configuration_impl(m_configsets,
                                                           m_sdoservice);
-    m_pSdoConfig = SDOPackage::Configuration::
-      _duplicate(m_pSdoConfigImpl->getObjRef());
+    m_pSdoConfig = m_pSdoConfigImpl->getObjRef();
   }
 
   /*!
@@ -103,8 +102,7 @@ namespace RTC
     m_objref = this->_this();
     m_pSdoConfigImpl = new SDOPackage::Configuration_impl(m_configsets,
                                                           m_sdoservice);
-    m_pSdoConfig = SDOPackage::Configuration::
-      _duplicate(m_pSdoConfigImpl->getObjRef());
+    m_pSdoConfig = m_pSdoConfigImpl->getObjRef();
   }
 
   /*!
@@ -1468,9 +1466,9 @@ namespace RTC
   {
     RTC_TRACE(("getObjRef()"));
 #ifdef ORB_IS_ORBEXPRESS
-    return m_objref.in();
+    return RTC::RTObject::_duplicate(m_objref.in());
 #else
-    return m_objref;
+    return RTC::RTObject::_duplicate(m_objref);
 #endif
   }
 
@@ -1551,7 +1549,7 @@ namespace RTC
   bool RTObject_impl::addPort(PortBase& port)
   {
     RTC_TRACE(("addPort(PortBase&)"));
-    port.setOwner(this->getObjRef());
+    port.setOwner(m_objref.in());
     port.setPortConnectListenerHolder(&m_portconnListeners);
     onAddPort(port.getPortProfile());
     return m_portAdmin.addPort(port);
@@ -1868,7 +1866,7 @@ namespace RTC
       {
         return RTC::RTC_ERROR;
       }
-    return ec->deactivate_component(::RTC::RTObject::_duplicate(getObjRef()));
+    return ec->deactivate_component(m_objref.in());
   }
 
   /*!
@@ -1885,7 +1883,7 @@ namespace RTC
       {
         return RTC::RTC_ERROR;
       }
-    return ec->activate_component(::RTC::RTObject::_duplicate(getObjRef()));
+    return ec->activate_component(m_objref.in());
   }
 
   /*!
@@ -1902,7 +1900,7 @@ namespace RTC
       {
         return RTC::RTC_ERROR;
       }
-    return ec->reset_component(::RTC::RTObject::_duplicate(getObjRef()));
+    return ec->reset_component(m_objref.in());
   }
 
   /*!
@@ -2115,7 +2113,8 @@ namespace RTC
     RTC_TRACE(("finalizeContexts()"));
     for (auto & ec : m_eclist)
       {
-        ec->getObjRef()->stop();
+        RTC::ExecutionContextService_var ecref = ec->getObjRef();
+        ecref->stop();
         RTC::RTCList rtcs = ec->getComponentList();
         for (CORBA::ULong i = 0; i < rtcs.length(); i++)
           {

--- a/src/lib/rtm/SdoConfiguration.cpp
+++ b/src/lib/rtm/SdoConfiguration.cpp
@@ -593,7 +593,7 @@ namespace SDOPackage
    */
   Configuration_ptr Configuration_impl::getObjRef()
   {
-    return m_objref;
+    return SDOPackage::Configuration::_duplicate(m_objref);
   }
 
   /*!

--- a/src/lib/rtm/SdoOrganization.cpp
+++ b/src/lib/rtm/SdoOrganization.cpp
@@ -387,4 +387,8 @@ namespace SDOPackage
     m_dependency = dependency;
     return true;
   }
+
+  Organization_ptr Organization_impl::getObjRef() {
+      return SDOPackage::Organization::_duplicate(m_objref);
+  }
 } // namespace SDOPackage

--- a/src/lib/rtm/SdoOrganization.h
+++ b/src/lib/rtm/SdoOrganization.h
@@ -670,7 +670,7 @@ namespace SDOPackage
     // end of CORBA interface definition
     //============================================================
     Organization_ptr getObjRef() {
-      return m_objref;
+      return SDOPackage::Organization::_duplicate(m_objref);
     }
 
   protected:

--- a/src/lib/rtm/SdoOrganization.h
+++ b/src/lib/rtm/SdoOrganization.h
@@ -669,9 +669,7 @@ namespace SDOPackage
 
     // end of CORBA interface definition
     //============================================================
-    Organization_ptr getObjRef() {
-      return SDOPackage::Organization::_duplicate(m_objref);
-    }
+    Organization_ptr getObjRef();
 
   protected:
     ::RTC::Logger rtclog;


### PR DESCRIPTION
…d getPortRef function

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#666 のようにCORBAオブジェクトを取得する関数内部で参照カウントを増やして戻り値を_var型に格納する使用方法を徹底するためにgetObjRef関数の仕様変更が必要。


## Description of the Change

以下の関数内でduplicateするための修正を行い、関数の外でduplicateしている場合は削除した。

- `ManagerServant::getObjRef`
- `PortBase::getPortRef`
- `RTObject_impl::getObjRef`
- `Configuration_impl::getObjRef`
- `Organization_impl::getObjRef`

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
