### PR TITLE
RTCが状態遷移しない問題の修正

### DIFF
--- a/src/lib/rtm/ExecutionContextBase.cpp
+++ b/src/lib/rtm/ExecutionContextBase.cpp
@@ -426,6 +426,11 @@ namespace RTC
         RTC_ERROR(("Unknown error: Invalid state transition."));
         return RTC::RTC_ERROR;
       }
+    else if (rtobj->isCurrentState(RTC::ERROR_STATE))
+      {
+        RTC_ERROR(("State of the RTC transitioned to ERROR_STATE."));
+        return RTC::PRECONDITION_NOT_MET;
+      }
     RTC_DEBUG(("Current state is %s", getStateString(rtobj->getState())));
     ret = onActivated(rtobj, count);  // Template method
     if (ret != RTC::RTC_OK)
@@ -519,6 +524,11 @@ namespace RTC
       {
         RTC_ERROR(("Unknown error: Invalid state transition."));
         return RTC::RTC_ERROR;
+      }
+    else if (rtobj->isCurrentState(RTC::ERROR_STATE))
+      {
+        RTC_ERROR(("State of the RTC transitioned to ERROR_STATE."));
+        return RTC::PRECONDITION_NOT_MET;
       }
     RTC_DEBUG(("Current state is %s", getStateString(rtobj->getState())));
     ret = onDeactivated(rtobj, count);

--- a/src/lib/rtm/ExecutionContextWorker.cpp
+++ b/src/lib/rtm/ExecutionContextWorker.cpp
@@ -173,14 +173,12 @@ namespace RTC_impl
         return RTC::BAD_PARAMETER;
       }
     RTC_DEBUG(("Component found in the EC."));
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
-    if (!(obj->isCurrentState(RTC::INACTIVE_STATE)))
+    if (!(obj->activate()))
       {
         RTC_ERROR(("State of the RTC is not INACTIVE_STATE."));
         return RTC::PRECONDITION_NOT_MET;
       }
     RTC_DEBUG(("Component is in INACTIVE state. Going to ACTIVE state."));
-    obj->goTo(RTC::ACTIVE_STATE);
     rtobj = obj;
     RTC_DEBUG(("activateComponent() done."));
     return RTC::RTC_OK;
@@ -205,13 +203,11 @@ namespace RTC_impl
         RTC_ERROR(("Given RTC is not participant of this EC."));
         return RTC::BAD_PARAMETER;
       }
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
-    if (!(rtobj->isCurrentState(RTC::ACTIVE_STATE)))
+    if (!(rtobj->deactivate()))
       {
         RTC_ERROR(("State of the RTC is not ACTIVE_STATE."));
         return RTC::PRECONDITION_NOT_MET;
       }
-    rtobj->goTo(RTC::INACTIVE_STATE);
     return RTC::RTC_OK;
   }
 
@@ -234,13 +230,11 @@ namespace RTC_impl
         RTC_ERROR(("Given RTC is not participant of this EC."));
         return RTC::BAD_PARAMETER;
       }
-    std::lock_guard<std::mutex> stateguard(m_statemutex);
-    if (!(rtobj->isCurrentState(RTC::ERROR_STATE)))
+    if (!(rtobj->reset()))
       {
         RTC_ERROR(("State of the RTC is not ERROR_STATE."));
         return RTC::PRECONDITION_NOT_MET;
       }
-    rtobj->goTo(RTC::INACTIVE_STATE);
     return RTC::RTC_OK;
   }
 
@@ -427,7 +421,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (!comp->isCurrentState(state)) { return false; }
       }
     return true;
@@ -439,7 +432,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (!comp->isNextState(state)) { return false; }
       }
     return true;
@@ -451,7 +443,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (comp->isCurrentState(state)) { return true; }
       }
     return false;
@@ -463,7 +454,6 @@ namespace RTC_impl
     std::lock_guard<std::mutex> guard(m_mutex);
     for (auto & comp : m_comps)
       {
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         if (comp->isNextState(state)) { return true; }
       }
     return false;
@@ -474,15 +464,12 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorker()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex); 
         comp->workerPreDo();  
     }
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         comp->workerDo();     
     }
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         comp->workerPostDo(); 
     }
     std::lock_guard<std::mutex> guard(m_mutex);
@@ -494,7 +481,6 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorkerPreDo()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex);
         comp->workerPreDo();  
     }
   }
@@ -504,7 +490,6 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorkerDo()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex); 
         comp->workerDo();     
     }
   }
@@ -514,7 +499,6 @@ namespace RTC_impl
     RTC_PARANOID(("invokeWorkerPostDo()"));
     // m_comps never changes its size here
     for (auto & comp : m_comps) { 
-        std::lock_guard<std::mutex> stateguard(m_statemutex); 
         comp->workerPostDo(); 
     }
     // m_comps might be changed here

--- a/src/lib/rtm/ExecutionContextWorker.h
+++ b/src/lib/rtm/ExecutionContextWorker.h
@@ -593,7 +593,6 @@ namespace RTC_impl
     std::vector<RTC_impl::RTObjectStateMachine*> m_removedComps;
     mutable std::mutex m_removedMutex;
     using CompItr = std::vector<RTC_impl::RTObjectStateMachine*>::iterator;
-    mutable std::mutex m_statemutex;
 
   };  // class PeriodicExecutionContext
 } // namespace RTC_impl

--- a/src/lib/rtm/RTObjectStateMachine.cpp
+++ b/src/lib/rtm/RTObjectStateMachine.cpp
@@ -30,7 +30,8 @@ namespace RTC_impl
       m_rtobj(RTC::LightweightRTObject::_duplicate(comp)),
       m_sm(NUM_OF_LIFECYCLESTATE),
       m_ca(false), m_dfc(false), m_fsm(false), m_mode(false),
-      m_rtobjPtr(nullptr), m_measure(false)
+      m_rtobjPtr(nullptr), m_measure(false), m_activation(false),
+      m_deactivation(false), m_reset(false)
   {
     m_caVar   = RTC::ComponentAction::_nil();
     m_dfcVar  = RTC::DataFlowComponentAction::_nil();
@@ -413,6 +414,7 @@ namespace RTC_impl
   // Workers
   void RTObjectStateMachine::workerPreDo()
   {
+    updateState();
     return m_sm.worker_pre();
   }
 
@@ -424,5 +426,63 @@ namespace RTC_impl
   void RTObjectStateMachine::workerPostDo()
   {
     return m_sm.worker_post();
+  }
+
+  bool RTObjectStateMachine::activate()
+  {
+      if (isCurrentState(RTC::INACTIVE_STATE))
+      {
+          m_activation = true;
+          return true;
+      }
+      return false;
+  }
+  bool RTObjectStateMachine::deactivate()
+  {
+      if (isCurrentState(RTC::ACTIVE_STATE))
+      {
+          m_deactivation = true;
+          return true;
+      }
+      return false;
+  }
+  bool RTObjectStateMachine::reset()
+  {
+      if (isCurrentState(RTC::ERROR_STATE))
+      {
+          m_reset = true;
+          return true;
+      }
+      return false;
+  }
+
+  void RTObjectStateMachine::updateState()
+  {
+      if (m_activation)
+      {
+          if (isCurrentState(RTC::INACTIVE_STATE) && !isNextState(RTC::ERROR_STATE))
+          {
+              m_sm.goTo(RTC::ACTIVE_STATE);
+          }
+          m_activation = false;
+      }
+
+      if (m_deactivation)
+      {
+          if (isCurrentState(RTC::ACTIVE_STATE) && !isNextState(RTC::ERROR_STATE))
+          {
+              m_sm.goTo(RTC::INACTIVE_STATE);
+          }
+          m_deactivation = false;
+      }
+
+      if (m_reset)
+      {
+          if (isCurrentState(RTC::ERROR_STATE))
+          {
+              m_sm.goTo(RTC::INACTIVE_STATE);
+          }
+          m_reset = false;
+      }
   }
 } // namespace RTC_impl

--- a/src/lib/rtm/RTObjectStateMachine.cpp
+++ b/src/lib/rtm/RTObjectStateMachine.cpp
@@ -432,7 +432,7 @@ namespace RTC_impl
   {
       if (isCurrentState(RTC::INACTIVE_STATE))
       {
-          m_activation = true;
+          m_activation.store(true);
           return true;
       }
       return false;
@@ -441,7 +441,7 @@ namespace RTC_impl
   {
       if (isCurrentState(RTC::ACTIVE_STATE))
       {
-          m_deactivation = true;
+          m_deactivation.store(true);
           return true;
       }
       return false;
@@ -450,7 +450,7 @@ namespace RTC_impl
   {
       if (isCurrentState(RTC::ERROR_STATE))
       {
-          m_reset = true;
+          m_reset.store(true);
           return true;
       }
       return false;
@@ -458,31 +458,31 @@ namespace RTC_impl
 
   void RTObjectStateMachine::updateState()
   {
-      if (m_activation)
+      if (m_activation.load())
       {
           if (isCurrentState(RTC::INACTIVE_STATE) && !isNextState(RTC::ERROR_STATE))
           {
               m_sm.goTo(RTC::ACTIVE_STATE);
           }
-          m_activation = false;
+          m_activation.store(false);
       }
 
-      if (m_deactivation)
+      if (m_deactivation.load())
       {
           if (isCurrentState(RTC::ACTIVE_STATE) && !isNextState(RTC::ERROR_STATE))
           {
               m_sm.goTo(RTC::INACTIVE_STATE);
           }
-          m_deactivation = false;
+          m_deactivation.store(false);
       }
 
-      if (m_reset)
+      if (m_reset.load())
       {
           if (isCurrentState(RTC::ERROR_STATE))
           {
               m_sm.goTo(RTC::INACTIVE_STATE);
           }
-          m_reset = false;
+          m_reset.store(false);
       }
   }
 } // namespace RTC_impl

--- a/src/lib/rtm/RTObjectStateMachine.h
+++ b/src/lib/rtm/RTObjectStateMachine.h
@@ -85,11 +85,16 @@ namespace RTC_impl
     void workerDo();
     void workerPostDo();
 
+    bool activate();
+    bool deactivate();
+    bool reset();
+
   protected:
     void setComponentAction(RTC::LightweightRTObject_ptr comp);
     void setDataFlowComponentAction(RTC::LightweightRTObject_ptr comp);
     void setFsmParticipantAction(RTC::LightweightRTObject_ptr comp);
     void setMultiModeComponentAction(RTC::LightweightRTObject_ptr comp);
+    void updateState();
 
   private:  // member variables
     RTC::Logger rtclog;
@@ -113,6 +118,9 @@ namespace RTC_impl
     // Component action invoker
     coil::TimeMeasure m_svtMeasure;
     coil::TimeMeasure m_refMeasure;
+    bool m_activation;
+    bool m_deactivation;
+    bool m_reset;
   };
 } // namespace RTC_impl
 

--- a/src/lib/rtm/RTObjectStateMachine.h
+++ b/src/lib/rtm/RTObjectStateMachine.h
@@ -26,6 +26,7 @@
 #include <rtm/StateMachine.h>
 #include <cassert>
 #include <iostream>
+#include <atomic>
 
 #define NUM_OF_LIFECYCLESTATE 4
 namespace RTC
@@ -118,9 +119,9 @@ namespace RTC_impl
     // Component action invoker
     coil::TimeMeasure m_svtMeasure;
     coil::TimeMeasure m_refMeasure;
-    bool m_activation;
-    bool m_deactivation;
-    bool m_reset;
+    std::atomic<bool> m_activation;
+    std::atomic<bool> m_deactivation;
+    std::atomic<bool> m_reset;
   };
 } // namespace RTC_impl
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#653 の修正がまずかったらしく、RTSE等でdeactivate_componentを実行すると実行中に以下の箇所でブロックされてしまう。

```CPP
  RTC::ReturnCode_t
  ExecutionContextWorker::activateComponent(RTC::LightweightRTObject_ptr comp,
                                            RTObjectStateMachine*& rtobj)
  {
    RTC_TRACE(("activateComponent()"));
    RTObjectStateMachine* obj = findComponent(comp);
    if (obj == nullptr)
      {
        RTC_ERROR(("Given RTC is not participant of this EC."));
        return RTC::BAD_PARAMETER;
      }
    RTC_DEBUG(("Component found in the EC."));
    std::lock_guard<std::mutex> stateguard(m_statemutex); //ここでブロック
    if (!(obj->isCurrentState(RTC::INACTIVE_STATE)))
      {
        RTC_ERROR(("State of the RTC is not INACTIVE_STATE."));
        return RTC::PRECONDITION_NOT_MET;
      }
    RTC_DEBUG(("Component is in INACTIVE state. Going to ACTIVE state."));
    obj->goTo(RTC::ACTIVE_STATE); 
    rtobj = obj;
    RTC_DEBUG(("activateComponent() done."));
    return RTC::RTC_OK;
  }
```

`m_statemutex`のロックとアンロックは`invokeWorkerDo`関数等で実行しているが、deactivate_componentの`m_statemutex`でブロックされている間にもinvokeWorkerDo関数は複数回実行する。つまり`m_statemutex`をアンロックしているにもかかわらずdeactivate_component関数でロックができないということになっている。

```CPP
  void ExecutionContextWorker::invokeWorkerDo()
  {
    RTC_PARANOID(("invokeWorkerDo()"));
    // m_comps never changes its size here
    for (auto & comp : m_comps) { 
        std::lock_guard<std::mutex> stateguard(m_statemutex); 
        comp->workerDo();     
    }
  }

```

Windowsの場合は`A:ロック獲得成功→B:ロック獲得要求→A:1→A:ロック解放→A:2→A:ロック獲得成功`という状況が発生するらしく、deactivate_componentがロック獲得できないままinvokeWorkerDo関数等がロック獲得を行っていると推測する。

- https://yohhoy.hatenadiary.jp/entry/20121002/p1


## Description of the Change

`activate_component`、`deactivate_component`、`reset_component`ではフラグだけ設定して、次状態の設定(goTo関数)は`workerPreDo`関数で実行するように変更した。

1つのRTCの次状態設定を複数スレッドで実行しないようにする。
フラグ設定後にエラー状態に遷移した場合には`goTo(RTC::INACTIVE_STATE)`は実行しない。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
