### PR TITLE
rtm-naming.bat内のomniNamesのパス変更(1.2)

### DIFF
--- a/win32/OpenRTM-aist/bin/rtm-naming.bat
+++ b/win32/OpenRTM-aist/bin/rtm-naming.bat
@@ -6,8 +6,8 @@ set cosnames="omninames"
 set orb="omniORB"
 set port=%1
 rem set OMNIORB_USEHOSTNAME=localhost
-call set omni_root=%OMNI_ROOT%
-set PATH=%OMNI_ROOT%\bin\x86_win32;%PATH%
+call set RTM_ROOT=%RTM_ROOT%
+set PATH=%RTM_ROOT%\bin;%PATH%
 
 if NOT DEFINED port set port=2809
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #695


## Description of the Change
omniNames.exeのインストール先変更に対応し、本スクリプトでネームサーバを起動できるようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- omniNames.exeを手動で「C:\Program Files\OpenRTM-aist\1.2.1\bin」に配置し、修正した本スクリプトにて下記動作を確認した
  - スタートメニューから「Start Naming Service」をクリックしての起動確認
  - RTSEのネームサーバボタン押下での起動確認
