### PR TITLE
ROS2Transportの警告の修正

### DIFF
--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -903,8 +903,8 @@ namespace RTC
       
       data.tm.sec = m_msg.header.stamp.sec;
       data.tm.nsec = m_msg.header.stamp.nsec;
-      data.height = m_msg.height;
-      data.width = m_msg.width;
+      data.height = static_cast<CORBA::UShort>(m_msg.height);
+      data.width = static_cast<CORBA::UShort>(m_msg.width);
       data.format = CORBA::string_dup(m_msg.encoding.c_str());
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROSSerializer.cppの以下の部分で変換の警告が発生する。

```CPP
      data.height = m_msg.height;
      data.width = m_msg.width;
```


## Description of the Change

static_castを記述することで警告が発生しないようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
