### PR TITLE
ROS、ROS2のImage型の画像のサイズがCameraImage型で扱えない場合にエラーにする

### DIFF
--- a/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
@@ -869,8 +869,16 @@ namespace RTC
       
       data.tm.sec = m_msg.header.stamp.sec;
       data.tm.nsec = m_msg.header.stamp.nanosec;
-      data.height = m_msg.height;
-      data.width = m_msg.width;
+
+      if (m_msg.height > USHRT_MAX || m_msg.width > USHRT_MAX)
+      {
+          return false;
+      }
+
+      data.height = static_cast<CORBA::UShort>(m_msg.height);
+      data.width = static_cast<CORBA::UShort>(m_msg.width);
+
+      
       data.format = CORBA::string_dup(m_msg.encoding.c_str());
 
 

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -903,6 +903,12 @@ namespace RTC
       
       data.tm.sec = m_msg.header.stamp.sec;
       data.tm.nsec = m_msg.header.stamp.nsec;
+
+      if (m_msg.height > USHRT_MAX || m_msg.width > USHRT_MAX)
+      {
+          return false;
+      }
+
       data.height = static_cast<CORBA::UShort>(m_msg.height);
       data.width = static_cast<CORBA::UShort>(m_msg.width);
       data.format = CORBA::string_dup(m_msg.encoding.c_str());


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROS、ROS2のImage型では画像の縦横のサイズ(width、height)をuint32_t型で定義しているが、CameraImage型ではuinsigned short型で定義しているため、画像の縦横のサイズが65535を超えた場合に扱うことはできない。


## Description of the Change

Image型のwidth、heightがUSHRT_MAX以上の時はdeserialize関数がfalseを返して終了するようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  