### PR TITLE
OpenSpliceTransportの関数の引数の型がstd::string&となっている箇所をconst std::string&に変更

### DIFF
--- a/src/ext/transport/OpenSplice/OpenSpliceManager.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceManager.cpp
@@ -341,7 +341,7 @@ namespace RTC
    *
    * @endif
    */
-  DDS::DataWriter_ptr OpenSpliceManager::createWriter(std::string& topic_name, DDS::DataWriterListener_ptr listener)
+  DDS::DataWriter_ptr OpenSpliceManager::createWriter(const std::string& topic_name, DDS::DataWriterListener_ptr listener)
   {
       DDS::Duration_t timeout = DDS::DURATION_INFINITE;
 
@@ -393,7 +393,7 @@ namespace RTC
    *
    * @endif
    */
-  DDS::DataReader_ptr OpenSpliceManager::createReader(std::string &topic_name, DDS::DataReaderListener_ptr listener)
+  DDS::DataReader_ptr OpenSpliceManager::createReader(const std::string &topic_name, DDS::DataReaderListener_ptr listener)
   {
       if (m_topics.count(topic_name) == 0)
       {
@@ -483,7 +483,7 @@ namespace RTC
    *
    * @endif
    */
-  bool OpenSpliceManager::createTopic(std::string& topic_name, std::string& typeName)
+  bool OpenSpliceManager::createTopic(const std::string& topic_name, const std::string& typeName)
   {
       DDS::ReturnCode_t result;
       DDS::TopicQos tQos;
@@ -521,7 +521,7 @@ namespace RTC
    *
    * @endif
    */
-  bool OpenSpliceManager::registerType(std::string& datatype, std::string& idlpath)
+  bool OpenSpliceManager::registerType(const std::string& datatype, const std::string& idlpath)
   {
       if (m_typesupports.count(datatype))
       {
@@ -631,7 +631,7 @@ namespace RTC
    *
    * @endif
    */
-  bool OpenSpliceManager::unregisterType(std::string& /*name*/)
+  bool OpenSpliceManager::unregisterType(const std::string& /*name*/)
   {
       return false;
   }
@@ -651,7 +651,7 @@ namespace RTC
    *
    * @endif
    */
-  bool OpenSpliceManager::registeredType(std::string& name)
+  bool OpenSpliceManager::registeredType(const std::string& name)
   {
       if (m_typesupports.count(name) == 0)
       {

--- a/src/ext/transport/OpenSplice/OpenSpliceManager.h
+++ b/src/ext/transport/OpenSplice/OpenSpliceManager.h
@@ -140,7 +140,7 @@ namespace RTC
          *
          * @endif
          */
-        DDS::DataWriter_ptr createWriter(std::string& topic_name, DDS::DataWriterListener_ptr listener);
+        DDS::DataWriter_ptr createWriter(const std::string& topic_name, DDS::DataWriterListener_ptr listener);
         /*!
          * @if jp
          * @brief DataReader生成
@@ -154,7 +154,7 @@ namespace RTC
          *
          * @endif
          */
-        DDS::DataReader_ptr createReader(std::string& topic_name, DDS::DataReaderListener_ptr listener);
+        DDS::DataReader_ptr createReader(const std::string& topic_name, DDS::DataReaderListener_ptr listener);
         /*!
          * @if jp
          * @brief DataWriter削除
@@ -196,7 +196,7 @@ namespace RTC
          *
          * @endif
          */
-        bool createTopic(std::string& topic_name, std::string& typeName);
+        bool createTopic(const std::string& topic_name, const std::string& typeName);
         /*!
          * @if jp
          * @brief Publisher生成
@@ -240,7 +240,7 @@ namespace RTC
          *
          * @endif
          */
-        bool registerType(std::string& datatype, std::string& idlpath);
+        bool registerType(const std::string& datatype, const std::string& idlpath);
         /*!
          * @if jp
          * @brief 型の登録解除
@@ -256,7 +256,7 @@ namespace RTC
          *
          * @endif
          */
-        bool unregisterType(std::string& name);
+        bool unregisterType(const std::string& name);
         /*!
          * @if jp
          * @brief 型が登録済みかを確認
@@ -272,7 +272,7 @@ namespace RTC
          *
          * @endif
          */
-        bool registeredType(std::string& name);
+        bool registeredType(const std::string& name);
 
         /*!
          * @if jp

--- a/src/ext/transport/OpenSplice/OpenSpliceManagerFunc.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceManagerFunc.cpp
@@ -31,20 +31,20 @@ namespace RTC_OpenSplice
 {
     void start()
     {
-        RTC::OpenSpliceManager& topicmgr = RTC::OpenSpliceManager::instance();
+        RTC::OpenSpliceManager::instance();
     }
     void shutdown()
     {
         RTC::OpenSpliceManager::shutdown_global();
         
     }
-    bool registerType(std::string& datatype, std::string& idlpath)
+    bool registerType(const std::string& datatype, const std::string& idlpath)
     {
         RTC::OpenSpliceManager& topicmgr = RTC::OpenSpliceManager::instance();
         return topicmgr.registerType(datatype, idlpath);
     }
 
-    bool registeredType(std::string& datatype)
+    bool registeredType(const std::string& datatype)
     {
         RTC::OpenSpliceManager& topicmgr = RTC::OpenSpliceManager::instance();
         return topicmgr.registeredType(datatype);

--- a/src/ext/transport/OpenSplice/OpenSpliceManagerFunc.h
+++ b/src/ext/transport/OpenSplice/OpenSpliceManagerFunc.h
@@ -25,8 +25,8 @@ namespace RTC_OpenSplice
 {
     void start();
     void shutdown();
-    bool registerType(std::string& datatype, std::string& idlpath);
-    bool registeredType(std::string& datatype);
+    bool registerType(const std::string& datatype, const std::string& idlpath);
+    bool registeredType(const std::string& datatype);
 }
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug


## Description of the Change

OpenSpliceTransport関連のファイルで定義した関数の一部で引数の型が`std::string&`になっているが、関数内部で値を変更はしないためconstを付けた。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
