### PR TITLE
FastRTPSMessageInfoの仕様変更

### DIFF
--- a/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
@@ -122,7 +122,7 @@ namespace RTC
 
     if (!is_serializer_cdr)
     {
-        FastRTPSMessageInfoBase* info = FastRTPSMessageInfoFactory::instance().createObject(marshaling_type);
+        FastRTPSMessageInfoBase* info = GlobalFastRTPSMessageInfoList::instance().getInfo(marshaling_type);
 
         if (!info)
         {
@@ -132,8 +132,6 @@ namespace RTC
 
         m_dataType = info->data_type();
         m_topic = info->topic_name(m_topic);
-
-        FastRTPSMessageInfoFactory::instance().deleteObject(info);
     }
     else
     {

--- a/src/ext/transport/FastRTPS/FastRTPSMessageInfo.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSMessageInfo.cpp
@@ -20,8 +20,235 @@
 
 namespace RTC
 {
-    FastRTPSMessageInfoBase::~FastRTPSMessageInfoBase(void)
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoBase::~FastRTPSMessageInfoBase(void) = default;
+
+
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList::FastRTPSMessageInfoList() = default;
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList::~FastRTPSMessageInfoList()
     {
+        for (auto info : m_data)
+        {
+            info.second.deleteObject();
+        }
+    }
+
+
+    /*!
+     * @if jp
+     *
+     * @brief FastRTPSMessageInfoを削除
+     *
+     * @param id 名前
+     * @return 削除に成功した場合はtrue
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param id 名前
+     * @return
+     *
+     * @endif
+     */
+    bool FastRTPSMessageInfoList::removeInfo(const std::string& id)
+    {
+        auto data = m_data.find(id);
+        if (data == m_data.end())
+        {
+            return false;
+        }
+
+        data->second.deleteObject();
+        m_data.erase(data);
+        return true;
         
+    }
+    /*!
+     * @if jp
+     *
+     * @brief 指定名のFastRTPSMessageInfoを取得
+     *
+     * @param id 名前
+     * @return FastRTPSMessageInfo
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param id
+     * @return
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoBase* FastRTPSMessageInfoList::getInfo(const std::string& id)
+    {
+        if (m_data.find(id) == m_data.end())
+        {
+            return nullptr;
+        }
+        return m_data[id].object_;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @param object FastRTPSMessageInfo
+     * @param destructor 終了関数
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @param object 
+     * @param destructor 
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList::FastRTPSMessageInfoEntry::FastRTPSMessageInfoEntry(FastRTPSMessageInfoBase* object, void(*destructor)(FastRTPSMessageInfoBase*&))
+        : object_(object), destructor_(destructor)
+    {
+    }
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList::FastRTPSMessageInfoEntry::FastRTPSMessageInfoEntry() = default;
+
+    /*!
+     * @if jp
+     *
+     * @brief コピーコンストラクタ
+     *
+     * @param obj コピー元のオブジェクト
+     *
+     * @else
+     *
+     * @brief Copy Constructor
+     *
+     * @param obj
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList::FastRTPSMessageInfoEntry::FastRTPSMessageInfoEntry(const FastRTPSMessageInfoList::FastRTPSMessageInfoEntry& obj)
+    {
+        object_ = obj.object_;
+        destructor_ = obj.destructor_;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 代入演算子
+     *
+     * @param obj コピー元のオブジェクト
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param obj
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList::FastRTPSMessageInfoEntry& FastRTPSMessageInfoList::FastRTPSMessageInfoEntry::operator = (const FastRTPSMessageInfoList::FastRTPSMessageInfoEntry& obj)
+    {
+        object_ = obj.object_;
+        destructor_ = obj.destructor_;
+        return *this;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 比較演算子
+     *
+     * @param obj 比較対象のオブジェクト
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param obj
+     *
+     * @endif
+     */
+    bool FastRTPSMessageInfoList::FastRTPSMessageInfoEntry::operator==(const FastRTPSMessageInfoList::FastRTPSMessageInfoEntry& obj)
+    {
+        return (object_ == obj.object_);
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList::FastRTPSMessageInfoEntry::~FastRTPSMessageInfoEntry() = default;
+
+    /*!
+     * @if jp
+     *
+     * @brief 終了関数呼び出し
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @endif
+     */
+    void FastRTPSMessageInfoList::FastRTPSMessageInfoEntry::deleteObject()
+    {
+        if (object_)
+        {
+            destructor_(object_);
+            object_ = nullptr;
+        }
     }
 }

--- a/src/ext/transport/FastRTPS/FastRTPSMessageInfo.h
+++ b/src/ext/transport/FastRTPS/FastRTPSMessageInfo.h
@@ -24,13 +24,17 @@
 #include <coil/Factory.h>
 
 
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#pragma warning( push )
+#pragma warning( disable : 4251 )
+#endif
 
 namespace RTC
 {
   /*!
    * @if jp
    *
-   * @class FastRTPSMessageInfo
+   * @class FastRTPSMessageInfoBase
    *
    * @brief FastRTPSのメッセージ型に関する情報を格納する基底クラス
    *
@@ -39,7 +43,7 @@ namespace RTC
    *
    * @else
    *
-   * @class FastRTPSessageInfo
+   * @class FastRTPSMessageInfoBase
    *
    * @brief 
    *
@@ -106,21 +110,281 @@ namespace RTC
     virtual std::string data_type() = 0;
   };
 
+  /*!
+   * @if jp
+   *
+   * @class FastRTPSMessageInfoList
+   *
+   * @brief FastRTPSのメッセージ型に関する情報のリストを名前とセットで保持するクラス
+   *
+   *
+   * @since 2.0.0
+   *
+   * @else
+   *
+   * @class FastRTPSMessageInfoList
+   *
+   * @brief 
+   *
+   *
+   * @endif
+   */
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#ifdef TRANSPORT_PLUGIN
+    class __declspec(dllexport) FastRTPSMessageInfoList
+#else
+    class __declspec(dllimport) FastRTPSMessageInfoList
+#endif
+#else
+    class FastRTPSMessageInfoList
+#endif
+  {
+    class FastRTPSMessageInfoEntry;
+  public:
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoList();
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    ~FastRTPSMessageInfoList();
+    /*!
+     * @if jp
+     *
+     * @brief FastRTPSMessageInfoを追加
+     * 
+     * @param id 名前
+     * @param info FastRTPSMessageInfo
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @param id 
+     * @param info 
+     *
+     * @endif
+     */
+    inline void addInfo(const std::string &id, FastRTPSMessageInfoBase* info)
+    {
+        auto data = m_data.find(id);
+        if (data != m_data.end())
+        {
+            data->second.deleteObject();
+        }
+        m_data[id] = FastRTPSMessageInfoEntry(info, [](FastRTPSMessageInfoBase*& obj) { delete obj; });
+    }
+    /*!
+     * @if jp
+     *
+     * @brief FastRTPSMessageInfoを削除
+     *
+     * @param id 名前
+     * @return 削除に成功した場合はtrue
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param id 名前
+     * @return
+     *
+     * @endif
+     */
+    bool removeInfo(const std::string& id);
+    /*!
+     * @if jp
+     *
+     * @brief 指定名のFastRTPSMessageInfoを取得
+     *
+     * @param id 名前
+     * @return FastRTPSMessageInfo
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param id 
+     * @return
+     *
+     * @endif
+     */
+    FastRTPSMessageInfoBase* getInfo(const std::string& id);
+  public:
 
-  using FastRTPSMessageInfoFactory = coil::GlobalFactory<FastRTPSMessageInfoBase>;
-}
+    std::map<std::string, FastRTPSMessageInfoEntry> m_data;
 
+  private:
+    /*!
+     * @if jp
+     *
+     * @class FastRTPSMessageInfoEntry
+     *
+     * @brief FastRTPSMessageInfoと終了関数を登録するクラス
+     * dllから登録したFastRTPSMessageInfoはdllでdeleteする必要があるため、
+     * 必ず終了関数を登録する。
+     *
+     * @since 2.0.0
+     *
+     * @else
+     *
+     * @class FastRTPSMessageInfoEntry
+     *
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    class FastRTPSMessageInfoEntry
+    {
+    public:
+        /*!
+         * @if jp
+         *
+         * @brief コンストラクタ
+         *
+         * @param object FastRTPSMessageInfo
+         * @param destructor 終了関数
+         *
+         * @else
+         *
+         * @brief Constructor
+         *
+         * @param object 
+         * @param destructor 
+         *
+         * @endif
+         */
+        FastRTPSMessageInfoEntry(FastRTPSMessageInfoBase* object, void(*destructor)(FastRTPSMessageInfoBase*&));
+        /*!
+         * @if jp
+         *
+         * @brief コンストラクタ
+         *
+         * @else
+         *
+         * @brief Constructor
+         *
+         * @endif
+         */
+        FastRTPSMessageInfoEntry();
+        /*!
+         * @if jp
+         *
+         * @brief コピーコンストラクタ
+         *
+         * @param obj コピー元のオブジェクト
+         *
+         * @else
+         *
+         * @brief Copy Constructor
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        FastRTPSMessageInfoEntry(const FastRTPSMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief 代入演算子
+         *
+         * @param obj コピー元のオブジェクト
+         *
+         * @else
+         *
+         * @brief 
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        FastRTPSMessageInfoEntry& operator = (const FastRTPSMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief 比較演算子
+         *
+         * @param obj 比較対象のオブジェクト
+         *
+         * @else
+         *
+         * @brief
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        bool operator==(const FastRTPSMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief デストラクタ
+         *
+         * @else
+         *
+         * @brief Destructor
+         *
+         * @endif
+         */
+        ~FastRTPSMessageInfoEntry();
+        /*!
+         * @if jp
+         *
+         * @brief 終了関数呼び出し
+         *
+         * @else
+         *
+         * @brief 
+         *
+         * @endif
+         */
+        void deleteObject();
+        FastRTPSMessageInfoBase* object_;
+        void(*destructor_)(FastRTPSMessageInfoBase*&);
 
+    };
+  };
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #ifdef TRANSPORT_PLUGIN
-  template class __declspec(dllexport) coil::GlobalFactory<RTC::FastRTPSMessageInfoBase>;
+  class __declspec(dllexport) GlobalFastRTPSMessageInfoList
 #else
-  extern template class __declspec(dllimport) coil::GlobalFactory<RTC::FastRTPSMessageInfoBase>;
+  class __declspec(dllimport) GlobalFastRTPSMessageInfoList
 #endif
+#else
+  class GlobalFastRTPSMessageInfo
 #endif
+      : public FastRTPSMessageInfoList,
+      public coil::Singleton<GlobalFastRTPSMessageInfoList >
+  {
+  public:
+  private:
+      friend class coil::Singleton<GlobalFastRTPSMessageInfoList>;
+  };
 
+}
 
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#pragma warning( pop )
+#endif
 
 
 #endif // RTC_FASTRTPSMESSAGEINFO_H

--- a/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
@@ -97,7 +97,7 @@ namespace RTC
 
     if (!is_serializer_cdr)
     {
-        FastRTPSMessageInfoBase* info = FastRTPSMessageInfoFactory::instance().createObject(marshaling_type);
+        FastRTPSMessageInfoBase* info = GlobalFastRTPSMessageInfoList::instance().getInfo(marshaling_type);
 
         if (!info)
         {
@@ -107,8 +107,6 @@ namespace RTC
 
         m_dataType = info->data_type();
         m_topic = info->topic_name(m_topic);
-
-        FastRTPSMessageInfoFactory::instance().deleteObject(info);
 
     }
     else

--- a/src/ext/transport/OpenSplice/OpenSpliceInPort.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceInPort.cpp
@@ -125,7 +125,7 @@ namespace RTC
     }
     
 
-    OpenSpliceMessageInfoBase* info = OpenSpliceMessageInfoFactory::instance().createObject(dataname);
+    OpenSpliceMessageInfoBase* info = GlobalOpenSpliceMessageInfoList::instance().getInfo(dataname);
 
     if (!info)
     {
@@ -136,8 +136,6 @@ namespace RTC
     std::string dataType = info->data_type();
     topic = info->topic_name(topic);
     std::string idlPath = info->idl_path();
-
-    OpenSpliceMessageInfoFactory::instance().deleteObject(info);
 
     std::string endian_type{coil::normalize(
       prop.getProperty("serializer.cdr.endian", ""))};

--- a/src/ext/transport/OpenSplice/OpenSpliceMessageInfo.h
+++ b/src/ext/transport/OpenSplice/OpenSpliceMessageInfo.h
@@ -21,8 +21,13 @@
 
 
 #include <coil/Properties.h>
-#include <coil/Factory.h>
-#include <rtm/Manager.h>
+#include <coil/Singleton.h>
+
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#pragma warning( push )
+#pragma warning( disable : 4251 )
+#endif
 
 
 
@@ -31,7 +36,7 @@ namespace RTC
   /*!
    * @if jp
    *
-   * @class OpenSpliceMessageInfo
+   * @class OpenSpliceMessageInfoBase
    *
    * @brief OpenSpliceのメッセージ型に関する情報を格納する基底クラス
    *
@@ -40,7 +45,7 @@ namespace RTC
    *
    * @else
    *
-   * @class OpenSpliceessageInfo
+   * @class OpenSpliceMessageInfoBase
    *
    * @brief 
    *
@@ -123,23 +128,284 @@ namespace RTC
     virtual std::string idl_path() = 0;
   };
 
+  
+  /*!
+   * @if jp
+   *
+   * @class OpenSpliceMessageInfoList
+   *
+   * @brief OpenSpliceのメッセージ型に関する情報のリストを名前とセットで保持するクラス
+   *
+   *
+   * @since 2.0.0
+   *
+   * @else
+   *
+   * @class OpenSpliceMessageInfoList
+   *
+   * @brief 
+   *
+   *
+   * @endif
+   */
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#ifdef TRANSPORT_PLUGIN
+    class __declspec(dllexport) OpenSpliceMessageInfoList
+#else
+    class __declspec(dllimport) OpenSpliceMessageInfoList
+#endif
+#else
+    class OpenSpliceMessageInfoList
+#endif
+  {
+    class OpenSpliceMessageInfoEntry;
+  public:
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @endif
+     */
+    OpenSpliceMessageInfoList();
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    ~OpenSpliceMessageInfoList();
+    /*!
+     * @if jp
+     *
+     * @brief OpenSpliceMessageInfoを追加
+     * 
+     * @param id 名前
+     * @param info OpenSpliceMessageInfo
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @param id 
+     * @param info 
+     *
+     * @endif
+     */
+    inline void addInfo(const std::string &id, OpenSpliceMessageInfoBase* info)
+    {
+        auto data = m_data.find(id);
+        if (data != m_data.end())
+        {
+            data->second.deleteObject();
+        }
+        m_data[id] = OpenSpliceMessageInfoEntry(info, [](OpenSpliceMessageInfoBase*& obj) { delete obj; });
+    }
+    /*!
+     * @if jp
+     *
+     * @brief OpenSpliceMessageInfoを削除
+     *
+     * @param id 名前
+     * @return 削除に成功した場合はtrue
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param id 名前
+     * @return
+     *
+     * @endif
+     */
+    bool removeInfo(const std::string& id);
+    /*!
+     * @if jp
+     *
+     * @brief 指定名のOpenSpliceMessageInfoを取得
+     *
+     * @param id 名前
+     * @return OpenSpliceMessageInfo
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param id 
+     * @return
+     *
+     * @endif
+     */
+    OpenSpliceMessageInfoBase* getInfo(const std::string& id);
+  public:
 
-  using OpenSpliceMessageInfoFactory = coil::GlobalFactory<OpenSpliceMessageInfoBase>;
-}
+    std::map<std::string, OpenSpliceMessageInfoEntry> m_data;
 
+  private:
+    /*!
+     * @if jp
+     *
+     * @class OpenSpliceMessageInfoEntry
+     *
+     * @brief OpenSpliceMessageInfoと終了関数を登録するクラス
+     * dllから登録したOpenSpliceMessageInfoはdllでdeleteする必要があるため、
+     * 必ず終了関数を登録する。
+     *
+     * @since 2.0.0
+     *
+     * @else
+     *
+     * @class OpenSpliceMessageInfoEntry
+     *
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    class OpenSpliceMessageInfoEntry
+    {
+    public:
+        /*!
+         * @if jp
+         *
+         * @brief コンストラクタ
+         *
+         * @param object OpenSpliceMessageInfo
+         * @param destructor 終了関数
+         *
+         * @else
+         *
+         * @brief Constructor
+         *
+         * @param object 
+         * @param destructor 
+         *
+         * @endif
+         */
+        OpenSpliceMessageInfoEntry(OpenSpliceMessageInfoBase* object, void(*destructor)(OpenSpliceMessageInfoBase*&));
+        /*!
+         * @if jp
+         *
+         * @brief コンストラクタ
+         *
+         * @else
+         *
+         * @brief Constructor
+         *
+         * @endif
+         */
+        OpenSpliceMessageInfoEntry();
+        /*!
+         * @if jp
+         *
+         * @brief コピーコンストラクタ
+         *
+         * @param obj コピー元のオブジェクト
+         *
+         * @else
+         *
+         * @brief Copy Constructor
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        OpenSpliceMessageInfoEntry(const OpenSpliceMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief 代入演算子
+         *
+         * @param obj コピー元のオブジェクト
+         *
+         * @else
+         *
+         * @brief 
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        OpenSpliceMessageInfoEntry& operator = (const OpenSpliceMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief 比較演算子
+         *
+         * @param obj 比較対象のオブジェクト
+         *
+         * @else
+         *
+         * @brief
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        bool operator==(const OpenSpliceMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief デストラクタ
+         *
+         * @else
+         *
+         * @brief Destructor
+         *
+         * @endif
+         */
+        ~OpenSpliceMessageInfoEntry();
+        /*!
+         * @if jp
+         *
+         * @brief 終了関数呼び出し
+         *
+         * @else
+         *
+         * @brief 
+         *
+         * @endif
+         */
+        void deleteObject();
+        OpenSpliceMessageInfoBase* object_;
+        void(*destructor_)(OpenSpliceMessageInfoBase*&);
 
+    };
+  };
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #ifdef TRANSPORT_PLUGIN
-  template class __declspec(dllexport) coil::GlobalFactory<RTC::OpenSpliceMessageInfoBase>;
+  class __declspec(dllexport) GlobalOpenSpliceMessageInfoList
 #else
-  extern template class __declspec(dllimport) coil::GlobalFactory<RTC::OpenSpliceMessageInfoBase>;
+  class __declspec(dllimport) GlobalOpenSpliceMessageInfoList
 #endif
+#else
+  class GlobalOpenSpliceMessageInfo
 #endif
+      : public OpenSpliceMessageInfoList,
+      public coil::Singleton<GlobalOpenSpliceMessageInfoList >
+  {
+  public:
+  private:
+      friend class coil::Singleton<GlobalOpenSpliceMessageInfoList>;
+  };
+
+}
 
 void OpenSpliceMessageInfoInit(const coil::Properties& prop);
 
-
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#pragma warning( pop )
+#endif
 
 #endif // RTC_OPENSPLICEMESSAGEINFO_H
 

--- a/src/ext/transport/OpenSplice/OpenSpliceOutPort.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceOutPort.cpp
@@ -97,7 +97,7 @@ namespace RTC
     }
 
 
-    OpenSpliceMessageInfoBase* info = OpenSpliceMessageInfoFactory::instance().createObject(dataname);
+    OpenSpliceMessageInfoBase* info = GlobalOpenSpliceMessageInfoList::instance().getInfo(dataname);
 
     if (!info)
     {
@@ -108,8 +108,6 @@ namespace RTC
     std::string dataType = info->data_type();
     topic = info->topic_name(topic);
     std::string idlPath = info->idl_path();
-
-    OpenSpliceMessageInfoFactory::instance().deleteObject(info);
 
     std::string endian_type{coil::normalize(
       prop.getProperty("serializer.cdr.endian", ""))};

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
@@ -56,12 +56,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<DataType>,
             RTC::ROS2SimpleData<DataType, MessageType, originalType, convertedType> >);
 
-    RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory(name,
-            ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<MessageType> >,
-            ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<MessageType> >);
+    RTC::GlobalFastRTPSMessageInfoList::
+            instance().addInfo(name,
+            new RTC::ROS2MessageInfo<MessageType>());
   }
 
   /*!
@@ -118,12 +115,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<DataType>,
             RTC::ROS2SequenceData<DataType, MessageType, originalType, convertedType> >);
 
-    RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory(name,
-            ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<MessageType> >,
-            ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<MessageType> >);
+    RTC::GlobalFastRTPSMessageInfoList::
+            instance().addInfo(name,
+            new RTC::ROS2MessageInfo<MessageType>());
   }
 
   /*!
@@ -286,12 +280,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedString>,
             RTC::ROS2StringData>);
 
-    RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ros2:std_msgs/String",
-            ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<std_msgs::msg::String> >,
-            ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<std_msgs::msg::String> >);
+    RTC::GlobalFastRTPSMessageInfoList::
+            instance().addInfo("ros2:std_msgs/String",
+            new RTC::ROS2MessageInfo<std_msgs::msg::String>());
   }
 
   /*!
@@ -436,12 +427,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedPoint3D>,
             RTC::ROS2Point3DData>);
 
-    RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ros2:geometry_msgs/PointStamped",
-            ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<geometry_msgs::msg::PointStamped> >,
-            ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<geometry_msgs::msg::PointStamped> >);
+    RTC::GlobalFastRTPSMessageInfoList::
+            instance().addInfo("ros2:geometry_msgs/PointStamped",
+            new RTC::ROS2MessageInfo<geometry_msgs::msg::PointStamped>());
   }
 
   /*!
@@ -587,12 +575,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedQuaternion>,
             RTC::ROS2QuaternionData>);
 
-    RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ros2:geometry_msgs/QuaternionStamped",
-            ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<geometry_msgs::msg::QuaternionStamped > >,
-            ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<geometry_msgs::msg::QuaternionStamped > >);
+    RTC::GlobalFastRTPSMessageInfoList::
+            instance().addInfo("ros2:geometry_msgs/QuaternionStamped",
+            new RTC::ROS2MessageInfo<geometry_msgs::msg::QuaternionStamped >());
   }
 
   /*!
@@ -737,12 +722,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedVector3D>,
             RTC::ROS2Vector3DData>);
 
-    RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ros2:geometry_msgs/Vector3Stamped",
-            ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<geometry_msgs::msg::Vector3Stamped > >,
-            ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<geometry_msgs::msg::Vector3Stamped > >);
+    RTC::GlobalFastRTPSMessageInfoList::
+            instance().addInfo("ros2:geometry_msgs/Vector3Stamped",
+            new RTC::ROS2MessageInfo<geometry_msgs::msg::Vector3Stamped >());
   }
 
   
@@ -907,12 +889,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::CameraImage>,
             RTC::ROS2CameraImageData>);
 
-    RTC::FastRTPSMessageInfoFactory::
-            instance().addFactory("ros2:sensor_msgs/Image",
-            ::coil::Creator< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<sensor_msgs::msg::Image > >,
-            ::coil::Destructor< ::RTC::FastRTPSMessageInfoBase,
-            RTC::ROS2MessageInfo<sensor_msgs::msg::Image > >);
+    RTC::GlobalFastRTPSMessageInfoList::
+            instance().addInfo("ros2:sensor_msgs/Image",
+            new RTC::ROS2MessageInfo<sensor_msgs::msg::Image >());
   }
 
 }

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -173,7 +173,7 @@ namespace RTC
 
     XmlRpc::XmlRpcClient *master = ros::XMLRPCManager::instance()->getXMLRPCClient(m_roscorehost, m_roscoreport, "/");
 
-    ROSMessageInfoBase* info = ROSMessageInfoFactory::instance().createObject(m_messageType);
+    ROSMessageInfoBase* info = GlobalROSMessageInfoList::instance().getInfo(m_messageType);
 
     if(!info)
     {
@@ -186,8 +186,6 @@ namespace RTC
     m_datatype = info->type();
     request[2] = m_datatype;
     request[3] = std::string(ros::XMLRPCManager::instance()->getServerURI());
-
-    ROSMessageInfoFactory::instance().deleteObject(info);
 
 
     bool b = master->execute("registerSubscriber", request, response);
@@ -343,7 +341,7 @@ namespace RTC
 
       m_tcp_connecters[xmlrpc_uri] = PublisherLink(connection, m_pubnum);
       m_pubnum++;
-      ROSMessageInfoBase* info = ROSMessageInfoFactory::instance().createObject(m_messageType);
+      ROSMessageInfoBase* info = GlobalROSMessageInfoList::instance().getInfo(m_messageType);
 
       if(!info)
       {
@@ -365,8 +363,6 @@ namespace RTC
       RTC_VERBOSE(("Caller ID:%s", m_callerid.c_str()));
       RTC_VERBOSE(("Topic Name:%s", topic.c_str()));
       RTC_VERBOSE(("TCPTransPort created"));
-
-      ROSMessageInfoFactory::instance().deleteObject(info);
 
 
 

--- a/src/ext/transport/ROSTransport/ROSMessageInfo.cpp
+++ b/src/ext/transport/ROSTransport/ROSMessageInfo.cpp
@@ -34,6 +34,198 @@ namespace RTC
     {
         return m_message_definition;
     }
+
+
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @endif
+     */
+    ROSMessageInfoList::ROSMessageInfoList() = default;
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    ROSMessageInfoList::~ROSMessageInfoList()
+    {
+        for (auto info : m_data)
+        {
+            info.second.deleteObject();
+        }
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief ROSMessageInfoを削除
+     *
+     * @param id 名前
+     * @return 削除に成功した場合はtrue
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param id 名前
+     * @return
+     *
+     * @endif
+     */
+    bool ROSMessageInfoList::removeInfo(const std::string& id)
+    {
+        auto data = m_data.find(id);
+        if (data == m_data.end())
+        {
+            return false;
+        }
+
+        data->second.deleteObject();
+        m_data.erase(data);
+        return true;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @param object ROSMessageInfo
+     * @param destructor 終了関数
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @param object 
+     * @param destructor 
+     *
+     * @endif
+     */
+    ROSMessageInfoList::ROSMessageInfoEntry::ROSMessageInfoEntry(ROSMessageInfoBase* object, void(*destructor)(ROSMessageInfoBase*&))
+        : object_(object), destructor_(destructor)
+    {
+    }
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @endif
+     */
+    ROSMessageInfoList::ROSMessageInfoEntry::ROSMessageInfoEntry() = default;
+
+    /*!
+     * @if jp
+     *
+     * @brief コピーコンストラクタ
+     *
+     * @param obj コピー元のオブジェクト
+     *
+     * @else
+     *
+     * @brief Copy Constructor
+     *
+     * @param obj
+     *
+     * @endif
+     */
+    ROSMessageInfoList::ROSMessageInfoEntry::ROSMessageInfoEntry(const ROSMessageInfoList::ROSMessageInfoEntry& obj)
+    {
+        object_ = obj.object_;
+        destructor_ = obj.destructor_;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 代入演算子
+     *
+     * @param obj コピー元のオブジェクト
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param obj
+     *
+     * @endif
+     */
+    ROSMessageInfoList::ROSMessageInfoEntry& ROSMessageInfoList::ROSMessageInfoEntry::operator = (const ROSMessageInfoList::ROSMessageInfoEntry& obj)
+    {
+        object_ = obj.object_;
+        destructor_ = obj.destructor_;
+        return *this;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 比較演算子
+     *
+     * @param obj 比較対象のオブジェクト
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param obj
+     *
+     * @endif
+     */
+    bool ROSMessageInfoList::ROSMessageInfoEntry::operator==(const ROSMessageInfoList::ROSMessageInfoEntry& obj)
+    {
+        return (object_ == obj.object_);
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    ROSMessageInfoList::ROSMessageInfoEntry::~ROSMessageInfoEntry() = default;
+
+    /*!
+     * @if jp
+     *
+     * @brief 終了関数呼び出し
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @endif
+     */
+    void ROSMessageInfoList::ROSMessageInfoEntry::deleteObject()
+    {
+        if (object_)
+        {
+            destructor_(object_);
+            object_ = nullptr;
+        }
+    }
 }
 
 

--- a/src/ext/transport/ROSTransport/ROSMessageInfo.h
+++ b/src/ext/transport/ROSTransport/ROSMessageInfo.h
@@ -62,9 +62,9 @@ namespace RTC
      * @endif
      */
     virtual ~ROSMessageInfoBase(void) {}
-    std::string type();
-    std::string md5sum();
-    std::string message_definition();
+    virtual std::string type();
+    virtual std::string md5sum();
+    virtual std::string message_definition();
   protected:
     std::string m_type;
     std::string m_md5sum;
@@ -96,19 +96,277 @@ namespace RTC
 
   };
 
-  using ROSMessageInfoFactory = coil::GlobalFactory<ROSMessageInfoBase>;
-}
+  /*!
+   * @if jp
+   *
+   * @class ROSMessageInfoList
+   *
+   * @brief ROSのメッセージ型に関する情報のリストを名前とセットで保持するクラス
+   *
+   *
+   * @since 2.0.0
+   *
+   * @else
+   *
+   * @class ROSMessageInfoList
+   *
+   * @brief 
+   *
+   *
+   * @endif
+   */
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#ifdef TRANSPORT_PLUGIN
+    class __declspec(dllexport) ROSMessageInfoList
+#else
+    class __declspec(dllimport) ROSMessageInfoList
+#endif
+#else
+    class ROSMessageInfoList
+#endif
+  {
+    class ROSMessageInfoEntry;
+  public:
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * @endif
+     */
+    ROSMessageInfoList();
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @endif
+     */
+    ~ROSMessageInfoList();
+    /*!
+     * @if jp
+     *
+     * @brief ROSMessageInfoを追加
+     * 
+     * @param id 名前
+     * @param info ROSMessageInfo
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * @param id 
+     * @param info 
+     *
+     * @endif
+     */
+    inline void addInfo(const std::string &id, ROSMessageInfoBase* info)
+    {
+        auto data = m_data.find(id);
+        if (data != m_data.end())
+        {
+            data->second.deleteObject();
+        }
+        m_data[id] = ROSMessageInfoEntry(info, [](ROSMessageInfoBase*& obj) { delete obj; });
+    }
+    /*!
+     * @if jp
+     *
+     * @brief ROSMessageInfoを削除
+     *
+     * @param id 名前
+     * @return 削除に成功した場合はtrue
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param id 名前
+     * @return
+     *
+     * @endif
+     */
+    bool removeInfo(const std::string& id);
+    /*!
+     * @if jp
+     *
+     * @brief 指定名のROSMessageInfoを取得
+     *
+     * @param id 名前
+     * @return ROSMessageInfo
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param id 
+     * @return
+     *
+     * @endif
+     */
+    ROSMessageInfoBase* getInfo(const std::string& id);
+  public:
 
+    std::map<std::string, ROSMessageInfoEntry> m_data;
+
+  private:
+    /*!
+     * @if jp
+     *
+     * @class ROSMessageInfoEntry
+     *
+     * @brief ROSMessageInfoと終了関数を登録するクラス
+     * dllから登録したROSMessageInfoはdllでdeleteする必要があるため、
+     * 必ず終了関数を登録する。
+     *
+     * @since 2.0.0
+     *
+     * @else
+     *
+     * @class ROSMessageInfoEntry
+     *
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    class ROSMessageInfoEntry
+    {
+    public:
+        /*!
+         * @if jp
+         *
+         * @brief コンストラクタ
+         *
+         * @param object ROSMessageInfo
+         * @param destructor 終了関数
+         *
+         * @else
+         *
+         * @brief Constructor
+         *
+         * @param object 
+         * @param destructor 
+         *
+         * @endif
+         */
+        ROSMessageInfoEntry(ROSMessageInfoBase* object, void(*destructor)(ROSMessageInfoBase*&));
+        /*!
+         * @if jp
+         *
+         * @brief コンストラクタ
+         *
+         * @else
+         *
+         * @brief Constructor
+         *
+         * @endif
+         */
+        ROSMessageInfoEntry();
+        /*!
+         * @if jp
+         *
+         * @brief コピーコンストラクタ
+         *
+         * @param obj コピー元のオブジェクト
+         *
+         * @else
+         *
+         * @brief Copy Constructor
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        ROSMessageInfoEntry(const ROSMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief 代入演算子
+         *
+         * @param obj コピー元のオブジェクト
+         *
+         * @else
+         *
+         * @brief 
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        ROSMessageInfoEntry& operator = (const ROSMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief 比較演算子
+         *
+         * @param obj 比較対象のオブジェクト
+         *
+         * @else
+         *
+         * @brief
+         *
+         * @param obj
+         *
+         * @endif
+         */
+        bool operator==(const ROSMessageInfoEntry& obj);
+        /*!
+         * @if jp
+         *
+         * @brief デストラクタ
+         *
+         * @else
+         *
+         * @brief Destructor
+         *
+         * @endif
+         */
+        ~ROSMessageInfoEntry();
+        /*!
+         * @if jp
+         *
+         * @brief 終了関数呼び出し
+         *
+         * @else
+         *
+         * @brief 
+         *
+         * @endif
+         */
+        void deleteObject();
+        ROSMessageInfoBase* object_;
+        void(*destructor_)(ROSMessageInfoBase*&);
+
+    };
+  };
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #ifdef TRANSPORT_PLUGIN
-  template class __declspec(dllexport) coil::GlobalFactory<RTC::ROSMessageInfoBase>;
+  class __declspec(dllexport) GlobalROSMessageInfoList
 #else
-  extern template class __declspec(dllimport) coil::GlobalFactory<RTC::ROSMessageInfoBase;
+  class __declspec(dllimport) GlobalROSMessageInfoList
 #endif
+#else
+  class GlobalROSMessageInfoList
 #endif
+      : public ROSMessageInfoList,
+      public coil::Singleton<GlobalROSMessageInfoList >
+  {
+  public:
+  private:
+      friend class coil::Singleton<GlobalROSMessageInfoList>;
+  };
 
-
+}
 
 
 #endif // RTC_ROSMESSAGEINFO_H

--- a/src/ext/transport/ROSTransport/ROSOutPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSOutPort.cpp
@@ -119,7 +119,7 @@ namespace RTC
     
     XmlRpc::XmlRpcClient *master = ros::XMLRPCManager::instance()->getXMLRPCClient(m_roscorehost, m_roscoreport, "/");
 
-    ROSMessageInfoBase* info = ROSMessageInfoFactory::instance().createObject(m_messageType);
+    ROSMessageInfoBase* info = GlobalROSMessageInfoList::instance().getInfo(m_messageType);
 
     if(!info)
     {
@@ -133,8 +133,6 @@ namespace RTC
     m_datatype = info->type();
     request[2] = m_datatype;
     request[3] = std::string(ros::XMLRPCManager::instance()->getServerURI());
-
-    ROSMessageInfoFactory::instance().deleteObject(info);
 
     bool b = master->execute("registerPublisher", request, response);
 

--- a/src/ext/transport/ROSTransport/ROSOutPort.h
+++ b/src/ext/transport/ROSTransport/ROSOutPort.h
@@ -303,7 +303,7 @@ namespace RTC
 
       
 
-      ROSMessageInfoBase* info = ROSMessageInfoFactory::instance().createObject(m_messageType);
+      ROSMessageInfoBase* info = GlobalROSMessageInfoList::instance().getInfo(m_messageType);
       
       if(!info)
       {
@@ -328,8 +328,6 @@ namespace RTC
       RTC_VERBOSE(("Topic Name:%s", topic.c_str()));
       RTC_VERBOSE(("TCPTransPort created"));
 
-
-      ROSMessageInfoFactory::instance().deleteObject(info);
 
       conn->writeHeader(m, boost::bind(&ROSOutPort::onHeaderWritten, this, _1));
       return true;

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -81,12 +81,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<DataType>,
             RTC::ROSSimpleData<DataType, MessageType, originalType, convertedType> >);
 
-    RTC::ROSMessageInfoFactory::
-            instance().addFactory(name,
-            ::coil::Creator< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<MessageType> >,
-            ::coil::Destructor< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<MessageType> >);
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo(name,
+            new RTC::ROSMessageInfo<MessageType>());
   }
 
   /*!
@@ -142,12 +139,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<DataType>,
             RTC::ROSSequenceData<DataType, MessageType, originalType, convertedType> >);
 
-    RTC::ROSMessageInfoFactory::
-            instance().addFactory(name,
-            ::coil::Creator< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<MessageType> >,
-            ::coil::Destructor< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<MessageType> >);
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo(name,
+            new RTC::ROSMessageInfo<MessageType>());
   }
 
   /*!
@@ -311,12 +305,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedString>,
             RTC::ROSStringData>);
 
-    RTC::ROSMessageInfoFactory::
-            instance().addFactory("ros:std_msgs/String",
-            ::coil::Creator< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<std_msgs::String> >,
-            ::coil::Destructor< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<std_msgs::String> >);
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo("ros:std_msgs/String",
+            new RTC::ROSMessageInfo<std_msgs::String>());
   }
 
   /*!
@@ -462,12 +453,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedPoint3D>,
             RTC::ROSPoint3DData>);
 
-    RTC::ROSMessageInfoFactory::
-            instance().addFactory("ros:geometry_msgs/PointStamped",
-            ::coil::Creator< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<geometry_msgs::PointStamped> >,
-            ::coil::Destructor< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<geometry_msgs::PointStamped> >);
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo("ros:geometry_msgs/PointStamped",
+            new RTC::ROSMessageInfo<geometry_msgs::PointStamped>());
   }
 
 
@@ -616,12 +604,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedQuaternion>,
             RTC::ROSQuaternionData>);
 
-    RTC::ROSMessageInfoFactory::
-            instance().addFactory("ros:geometry_msgs/QuaternionStamped",
-            ::coil::Creator< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<geometry_msgs::QuaternionStamped > >,
-            ::coil::Destructor< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<geometry_msgs::QuaternionStamped > >);
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo("ros:geometry_msgs/QuaternionStamped",
+            new RTC::ROSMessageInfo<geometry_msgs::QuaternionStamped >());
   }
 
 
@@ -768,12 +753,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::TimedVector3D>,
             RTC::ROSVector3DData>);
 
-    RTC::ROSMessageInfoFactory::
-            instance().addFactory("ros:geometry_msgs/Vector3Stamped",
-            ::coil::Creator< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<geometry_msgs::Vector3Stamped > >,
-            ::coil::Destructor< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<geometry_msgs::Vector3Stamped > >);
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo("ros:geometry_msgs/Vector3Stamped",
+            new RTC::ROSMessageInfo<geometry_msgs::Vector3Stamped >());
   }
 
   /*!
@@ -940,12 +922,9 @@ namespace RTC
             ::coil::Destructor< ::RTC::ByteDataStream<RTC::CameraImage>,
             RTC::ROSCameraImageData>);
 
-    RTC::ROSMessageInfoFactory::
-            instance().addFactory("ros:sensor_msgs/Image",
-            ::coil::Creator< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<sensor_msgs::Image > >,
-            ::coil::Destructor< ::RTC::ROSMessageInfoBase,
-            RTC::ROSMessageInfo<sensor_msgs::Image > >);
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo("ros:sensor_msgs/Image",
+            new RTC::ROSMessageInfo<sensor_msgs::Image >());
   }
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

FastRTPSTransportではFastRTPsの通信時に設定するデータの型名(例えばROS2のImage型を通信する場合は`sensor_msgs::msg::_dds::Image_`)等の情報を格納するためのFastRTPSMessageInfoクラスを定義し、情報を取得するためのFastRTPSMessageInfoFactoryを定義していたが、情報取得のためにいちいちファクトリからFastRTPSMessageInfoオブジェクトを生成するのは無駄である。


## Description of the Change

FastRTPSMessageInfo、ROSMessageInfo、OpenSpliceMessageInfoについてファクトリの利用はやめて、新たにFastRTPSMessageInfoList、ROSMessageInfoList、OpenSpliceMessageInfoListクラスを定義した。

使用する場合はaddInfo関数で追加、getInfo関数で取得する。getInfo関数は登録したFastRTPSMessageInfoのポインタを返すだけの関数である。

```CPP
    RTC::GlobalFastRTPSMessageInfoList::
            instance().addInfo("ros2:sensor_msgs/Image",
            new RTC::ROS2MessageInfo<sensor_msgs::msg::Image >());
```


```CPP
FastRTPSMessageInfoBase* info = GlobalFastRTPSMessageInfoList::instance().getInfo("ros2:sensor_msgs/Image");
```

addInfo関数内でdeleteするだけの関数をFastRTPSMessageInfoEntryの引数に与えているが、ロードしたdllの中でnewしたオブジェクトは同じdllでdeleteしなければならないため、終了関数を設定して削除するときにはdeleteObject関数を呼び出すようにしている。

```
    inline void addInfo(const std::string &id, FastRTPSMessageInfoBase* info)
    {
        auto data = m_data.find(id);
        if (data != m_data.end())
        {
            data->second.deleteObject();
        }
        m_data[id] = FastRTPSMessageInfoEntry(info, [](FastRTPSMessageInfoBase*& obj) { delete obj; });
    }
```

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  