### PR TITLE
トピック通信機能使用時、ns_uniqueのネーミングポリシー使用時に異常終了する問題の修正

### DIFF
--- a/src/lib/rtm/CorbaNaming.cpp
+++ b/src/lib/rtm/CorbaNaming.cpp
@@ -814,7 +814,7 @@ namespace RTC
    */
   CosNaming::NamingContext_ptr CorbaNaming::getRootContext()
   {
-    return m_rootContext;
+    return CosNaming::NamingContext::_duplicate(m_rootContext);
   }
 
   /*!

--- a/src/lib/rtm/NamingManager.cpp
+++ b/src/lib/rtm/NamingManager.cpp
@@ -104,7 +104,7 @@ namespace RTC
   void NamingOnCorba::bindObject(const char* name,
                                  const PortBase* port)
   {
-    RTC_TRACE(("bindObject(name = %s, rtobj)", name));
+    RTC_TRACE(("bindObject(name = %s, port)", name));
 #ifdef ORB_IS_OMNIORB
     if (!m_endpoint.empty() && m_replaceEndpoint)
       {
@@ -352,7 +352,7 @@ namespace RTC
   void NamingOnManager::bindObject(const char* name,
 	  const PortBase*  /*port*/)
   {
-	  RTC_TRACE(("bindObject(name = %s, rtobj)", name));
+	  RTC_TRACE(("bindObject(name = %s, port)", name));
 	  return;
   }
 
@@ -741,6 +741,19 @@ namespace RTC
       for (auto & mgrName : m_mgrNames)
         {
           names.emplace_back(mgrName->name);
+        }
+      for (auto & name : names)
+        {
+          unbindObject(name.c_str());
+        }
+    }
+    {
+      std::lock_guard<std::mutex> guard(m_mgrNamesMutex);
+      coil::vstring names;
+      // unbindObject modifiy m_mgrNames
+      for (auto & portName : m_portNames)
+        {
+          names.emplace_back(portName->name);
         }
       for (auto & name : names)
         {

--- a/src/lib/rtm/NamingManager.cpp
+++ b/src/lib/rtm/NamingManager.cpp
@@ -748,7 +748,7 @@ namespace RTC
         }
     }
     {
-      std::lock_guard<std::mutex> guard(m_mgrNamesMutex);
+      std::lock_guard<std::mutex> guard(m_portNamesMutex);
       coil::vstring names;
       // unbindObject modifiy m_mgrNames
       for (auto & portName : m_portNames)

--- a/src/lib/rtm/NamingServiceNumberingPolicy.cpp
+++ b/src/lib/rtm/NamingServiceNumberingPolicy.cpp
@@ -25,10 +25,10 @@ namespace RTM
   //============================================================
   // NamingServiceNumberingPolicy
   //============================================================
-	NamingServiceNumberingPolicy::NamingServiceNumberingPolicy()
-	{
-		m_mgr = &RTC::Manager::instance();
-	}
+  NamingServiceNumberingPolicy::NamingServiceNumberingPolicy()
+    {
+	  m_mgr = &RTC::Manager::instance();
+    }
   /*!
    * @if jp
    * @brief オブジェクト生成時の名称作成
@@ -36,8 +36,8 @@ namespace RTM
    * @brief Create the name when creating objects
    * @endif
    */
-	std::string NamingServiceNumberingPolicy::onCreate(void* obj)
-  {
+  std::string NamingServiceNumberingPolicy::onCreate(void* obj)
+    {
 	  int num = 0;
 	  while (true)
 	  {
@@ -57,7 +57,7 @@ namespace RTM
 		  }
 	  }
 	  return  coil::otos<int>(num);
-  }
+    }
   
   /*!
    * @if jp
@@ -66,9 +66,9 @@ namespace RTM
    * @brief Delete the name when deleting objects
    * @endif
    */
-	void NamingServiceNumberingPolicy::onDelete(void* /*obj*/)
-  {
-  }
+  void NamingServiceNumberingPolicy::onDelete(void* /*obj*/)
+    {
+    }
   
 	/*!
 	* @if jp
@@ -93,8 +93,8 @@ namespace RTM
 	*
 	* @endif
 	*/
-	bool NamingServiceNumberingPolicy::find(std::string name)
-  {
+  bool NamingServiceNumberingPolicy::find(std::string name)
+    {
 	  RTC::RTCList rtcs;
 	  std::string rtc_name = "rtcname://*/*/";
 	  rtc_name += name;
@@ -102,19 +102,19 @@ namespace RTM
 	  rtcs = m_mgr->getNaming()->string_to_component(rtc_name);
 
 	  return rtcs.length() > 0;
-  }
+    }
 } //namespace RTM 
 
 extern "C"
 {
-	void NamingServiceNumberingPolicyInit()
-  {
+  void NamingServiceNumberingPolicyInit()
+    {
     ::RTM::NumberingPolicyFactory::
       instance().addFactory("ns_unique",
                             ::coil::Creator< ::RTM::NumberingPolicyBase,
 							::RTM::NamingServiceNumberingPolicy>,
                             ::coil::Destructor< ::RTM::NumberingPolicyBase,
 							::RTM::NamingServiceNumberingPolicy>);
-  }
+    }
 }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- rtc.confに`port.inport.in.subscribe_topic`、`port.outport.out.publish_topic`を記述すると異常終了する
- トピック通信機能使用時にネームサーバーに登録したデータポート、サービスポートがRTC終了時に削除されない
- rtc.confに`manager.components.naming_policy`を記述すると異常終了する


## Description of the Change

- coil::replaceString関数の使い方に間違いがあったため修正
- resolve関数が例外を投げた場合にエラーメッセージを出力するように修正
- ポートのリファレンスを_duplicateしていなかった部分の修正
- CorbaNaming::getRootContext関数が_duplicateせずに値を返していたため修正
- bindObject関数でポートをネームサーバーに追加する場合のログメッセージが間違っていたため修正


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
