### PR TITLE
ConsoleInで不正な値を入力したときにエラー状態に遷移するようにする

### DIFF
--- a/examples/ExtTrigger/ConsoleIn.cpp
+++ b/examples/ExtTrigger/ConsoleIn.cpp
@@ -63,6 +63,14 @@ RTC::ReturnCode_t ConsoleIn::onExecute(RTC::UniqueId  /*ec_id*/)
 {
   std::cout << "Please input number: ";
   std::cin >> m_out.data;
+
+  if(std::cin.fail())
+  {
+      std::cin.clear();
+      std::cin.ignore(1024, '\n');
+      return RTC::RTC_ERROR;
+  }
+  
   std::cout << "Sending to subscriber: " << m_out.data << std::endl;
   m_outOut.write();
 

--- a/examples/Serializer/ConsoleInShort.cpp
+++ b/examples/Serializer/ConsoleInShort.cpp
@@ -103,6 +103,12 @@ RTC::ReturnCode_t ConsoleInShort::onExecute(RTC::UniqueId  /*ec_id*/)
   count++;
 #else
   std::cin >> m_out.data;
+  if(std::cin.fail())
+  {
+      std::cin.clear();
+      std::cin.ignore(1024, '\n');
+      return RTC::RTC_ERROR;
+  }
 #endif
   if (m_out.data == 666) return RTC::RTC_ERROR;
   m_outOut.write();

--- a/examples/SimpleIO/ConsoleIn.cpp
+++ b/examples/SimpleIO/ConsoleIn.cpp
@@ -103,6 +103,12 @@ RTC::ReturnCode_t ConsoleIn::onExecute(RTC::UniqueId  /*ec_id*/)
   count++;
 #else
   std::cin >> m_out.data;
+  if(std::cin.fail())
+  {
+      std::cin.clear();
+      std::cin.ignore(1024, '\n');
+      return RTC::RTC_ERROR;
+  }
 #endif
   if (m_out.data == 666) return RTC::RTC_ERROR;
   m_outOut.write();


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#722 


## Description of the Change

ConsoleInコンポーネントで数値以外の文字列等を入力した場合は、std::cinのエラー状態を解除、入力データの破棄後、RTCをエラーに遷移するようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
