### PR TITLE
apt update時、openrtm.orgリポジトリへの「binary-i386/Packages」ワーニングが出ないようにした

### DIFF
--- a/scripts/pkg_install_ubuntu.sh
+++ b/scripts/pkg_install_ubuntu.sh
@@ -18,7 +18,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.0.01
+VERSION=2.0.0.02
 
 #
 #---------------------------------------
@@ -314,7 +314,11 @@ create_srclist () {
     echo $msg3
     exit
   fi
-  openrtm_repo="deb http://$reposerver/pub/Linux/ubuntu/ $code_name main"
+  if test "x$code_name" = "xxenial"; then
+    openrtm_repo="deb http://$reposerver/pub/Linux/ubuntu/ $code_name main"
+  else
+    openrtm_repo="deb [arch=amd64] http://$reposerver/pub/Linux/ubuntu/ $code_name main"
+  fi
 }
 
 #---------------------------------------


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #725 
## Identify the Bug

Link to #725 


## Description of the Change

- このワーニングは、Ubuntu16.04環境では出ず、Ubuntu18.04で確認している
- Ubuntu18.04は64bit OSしか存在しないので、/etc/atp/source.list に openrtm.org を登録する際、
[arch=amd64] を加えてワーニングが出ないようにした
- スクリプトでは、Ubuntu16.04より古いバージョンは考慮せず、16.04以外なら[arch=amd64] を付加するように対応した


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 既に /etc/atp/source.list へ openrtm.org が登録されている環境では、本スクリプトを実行してもワーニングは解消しない
- 初めて /etc/atp/source.list へ登録する環境において、Ubuntu16.04, 18.04 ともにワーニングは表示されず、リポジトリからのパッケージ取得動作も問題ないことを確認した

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
