### PR TITLE
UbuntuでOpenRTM1.2.0がインストールされている環境でpkg_install_ubuntu.shにより1.2.1へアップデートする際エラー対応

### DIFF
--- a/scripts/pkg_install_ubuntu.sh
+++ b/scripts/pkg_install_ubuntu.sh
@@ -18,7 +18,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.0.01
+VERSION=2.0.0.02
 
 #
 #---------------------------------------
@@ -82,7 +82,7 @@ deb_pkg="uuid-dev libboost-filesystem-dev"
 pkg_tools="build-essential debhelper devscripts"
 omni_devel="libomniorb4-dev omniidl"
 omni_runtime="omniorb-nameserver"
-openrtm_devel="openrtm-aist-doc openrtm-aist-idl openrtm-aist-dev"
+openrtm_devel="openrtm-aist-doc openrtm-aist-dev openrtm-aist-idl"
 openrtm_runtime="openrtm-aist openrtm-aist-example"
 
 runtime_pkgs="$omni_runtime $openrtm_runtime"


### PR DESCRIPTION

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #729 

## Description of the Change

- pkg_install_ubuntu.sh で定義している openrtm-aist-idl と openrtm-aist-dev のインストール順番を入れ替えた



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 下記手順にて修正したスクリプトでopenrtm-aistパッケージを1.2.0から1.2.1へアップデートできることを確認した

- 1.2.0版のC++をインストールする（openrtm.orgリポジトリから）
- 1.2.0版ではopenrtm-aist-idlパッケージは提供していないので、スクリプトから外しておく
openrtm_devel="openrtm-aist-doc openrtm-aist-dev"
```
$ sudo sh pkg_install_ubuntu.sh -l c++ -d --yes
$ dpkg -l | grep openrtm
ii  openrtm-aist:amd64                         1.2.0-0 
ii  openrtm-aist-dev:amd64                     1.2.0-0 
ii  openrtm-aist-doc                           1.2.0-0 
ii  openrtm-aist-example:amd64                 1.2.0-0
```

-  続けて1.2.1版へのアップデートを確認する（テスト用リポジトリから）
-  スクリプトは、今回のPR修正の状態へ戻し、テスト用リポジトリ指定に変更してからC++をインストールする
default_reposerver="150.29.99.185"
reposervers="150.29.99.185"
```
$ sudo sh pkg_install_ubuntu.sh -l c++ -d --yes
$ dpkg -l | grep openrtm
ii  openrtm-aist:amd64                         1.2.1-0
ii  openrtm-aist-dev:amd64                     1.2.1-0
ii  openrtm-aist-doc                           1.2.1-0
ii  openrtm-aist-example:amd64                 1.2.1-0
ii  openrtm-aist-idl:amd64                     1.2.1-0
```
- エラーなくアップデートできることを確認した

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
