### PR TITLE
pkg_install_raspbian.shでjavaとidlパッケージ定義を追加

### DIFF
--- a/scripts/pkg_install_raspbian.sh
+++ b/scripts/pkg_install_raspbian.sh
@@ -6,7 +6,7 @@
 #         Nobu Kawauchi
 #
 
-VERSION=2.0.0.00
+VERSION=2.0.0.01
 
 #---------------------------------------
 # usage
@@ -18,7 +18,7 @@ usage()
 
     $(basename ${0}) -l {all|c++} [-r|-d|-s|-c] [-u|--yes]
     $(basename ${0}) [-u]
-    $(basename ${0}) -l python [-r|-d|-c] [-u|--yes] 
+    $(basename ${0}) -l {python|java} [-r|-d|-c] [-u|--yes]
     $(basename ${0}) {--help|-h|--version} 
 
   Example:
@@ -28,7 +28,7 @@ usage()
     $(basename ${0}) -l all -u
 
   Options:
-    -l <argument>  language or tool [c++|python|rtshell|all]
+    -l <argument>  language or tool [c++|python|java|rtshell|all]
         all        install packages of all the supported languages and tools
     -r             install robot component runtime
     -d             install robot component developer [default]
@@ -70,7 +70,7 @@ deb_pkg="uuid-dev libboost-filesystem-dev"
 pkg_tools="build-essential debhelper devscripts"
 omni_devel="libomniorb4-dev omniidl"
 omni_runtime="omniorb-nameserver"
-openrtm_devel="openrtm-aist-doc openrtm-aist-dev"
+openrtm_devel="openrtm-aist-doc openrtm-aist-idl openrtm-aist-dev"
 openrtm_runtime="openrtm-aist openrtm-aist-example"
 
 runtime_pkgs="$omni_runtime $openrtm_runtime"
@@ -102,7 +102,7 @@ python_core_pkgs="$omni_runtime $python_runtime $python_devel $build_tools $pkg_
 u_python_core_pkgs="$omni_runtime $omnipy"
 
 #--------------------------------------- Java
-java_devel="default-jdk"
+java_devel="openjdk-8-jdk"
 java_build="ant"
 openrtm_j_devel="openrtm-aist-java-doc"
 openrtm_j_runtime="openrtm-aist-java openrtm-aist-java-example"
@@ -140,7 +140,7 @@ check_arg()
     all ) arg_all=true ;;
     c++ ) arg_cxx=true ;;
     python ) arg_python=true ;;
-#    java ) arg_java=true ;;
+    java ) arg_java=true ;;
     rtshell ) arg_rtshell=true ;;
     *) arg_err=-1 ;;
   esac
@@ -611,7 +611,7 @@ apt-get update
 if test "x$arg_all" = "xtrue" ; then
   arg_cxx=true
   arg_python=true
-  #arg_java=true
+  arg_java=true
   arg_rtshell=true
 
   if test "x$OPT_RT" != "xtrue" && 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #741 

## Identify the Bug

Link to #741 


## Description of the Change

- #739 の修正で、openrtm-aist-idl パッケージの定義を追加すべきところ抜けていたので対応した
  - この定義が抜けていても openrtm-aist-dev との依存関係によりインストールされるので動作に問題ないが、アンインストール時に削除されずに残ってしまうので訂正した

- OpenRTM-aist-Java の動作に必要な openjdk-8-jdk をパッケージでインストールできると確認できたので、対応した


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- テスト用リポジトリを指定し、本スクリプトでJavaパッケージがインストールされることを確認した
- Raspberry Pi 上で rtshellを使い、JavaのConsoleInとConsoleOutの接続動作を確認した
```
$ sh /usr/share/openrtm-1.2/components/java/ConsoleIn.sh
$ sh /usr/share/openrtm-1.2/components/java/ConsoleOut.sh
# rtcwd /localhost
# rtcon ConsoleIn0.rtc:out ConsoleOut0.rtc:in -i my_connection
# rtact ConsoleIn0.rtc  ConsoleOut0.rtc
```

- openrtm.orgのraspbian busterリポジトリには既にパッケージをアップロード済みなので、マージ後は本スクリプトを使ってインストール可能です

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
