### PR TITLE
ROSTransportビルドで発生する関数未定義のエラーの修正

### DIFF
--- a/src/ext/transport/ROSTransport/ROSMessageInfo.cpp
+++ b/src/ext/transport/ROSTransport/ROSMessageInfo.cpp
@@ -100,6 +100,32 @@ namespace RTC
     /*!
      * @if jp
      *
+     * @brief 指定名のROSMessageInfoを取得
+     *
+     * @param id 名前
+     * @return ROSMessageInfo
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param id
+     * @return
+     *
+     * @endif
+     */
+    ROSMessageInfoBase* ROSMessageInfoList::getInfo(const std::string& id)
+    {
+        if (m_data.find(id) == m_data.end())
+        {
+            return nullptr;
+        }
+        return m_data[id].object_;
+    }
+
+    /*!
+     * @if jp
+     *
      * @brief コンストラクタ
      *
      * @param object ROSMessageInfo


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#714 の修正ミスにより`ROSMessageInfoList::getInfo`関数が未定義であったためROSTransportビルド時にエラーになる。

## Description of the Change

`ROSMessageInfoList::getInfo`関数を定義した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
