### PR TITLE
ROSTransport、ROS2Transportの警告を修正

### DIFF
--- a/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.h
+++ b/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.h
@@ -41,16 +41,17 @@ namespace RTC
     	~CORBACdrDataPubSubType() override;
         void init(std::string name, bool header_enable);
         void setEndian(bool endian);
-    	bool serialize(void *data, eprosima::fastrtps::rtps::SerializedPayload_t *payload);
-    	bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t *payload, void *data);
-        std::function<uint32_t()> getSerializedSizeProvider(void* data);
+    	bool serialize(void *data, eprosima::fastrtps::rtps::SerializedPayload_t *payload) override;
+    	bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t *payload, void *data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
 #if (FASTRTPS_VERSION_MAJOR <= 1) && (FASTRTPS_VERSION_MINOR <= 6)
-    	bool getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t *ihandle);
+    	bool getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t *ihandle) override;
 #else
-        bool getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t *ihandle, bool force_md5);
+        bool getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t *ihandle, bool force_md5) override;
 #endif
-    	void* createData();
-    	void deleteData(void * data);
+    	void* createData() override;
+    	void deleteData(void * data) override;
+    private:
     	MD5 m_md5;
     	unsigned char* m_keyBuffer;
         bool m_endian;

--- a/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
@@ -44,7 +44,7 @@ namespace RTC
    * @endif
    */
   FastRTPSInPort::FastRTPSInPort(void)
-   : m_buffer(0), m_listener(this)
+   : m_buffer(nullptr), m_listener(this)
   {
     // PortProfile setting
     setInterfaceType("fast-rtps");
@@ -176,12 +176,14 @@ namespace RTC
         topicmgr.registerType(type);
     }
 
-    eprosima::fastrtps::SubscriberAttributes Rparam;
-    Rparam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
-    Rparam.topic.topicDataType = m_dataType;
-    Rparam.topic.topicName = m_topic;
-    Rparam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    m_subscriber = eprosima::fastrtps::Domain::createSubscriber(participant,Rparam,(eprosima::fastrtps::SubscriberListener*)&m_listener);
+    
+    eprosima::fastrtps::SubscriberAttributes *Rparam = new eprosima::fastrtps::SubscriberAttributes();
+    Rparam->topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
+    Rparam->topic.topicDataType = m_dataType;
+    Rparam->topic.topicName = m_topic;
+    Rparam->historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    m_subscriber = eprosima::fastrtps::Domain::createSubscriber(participant,*Rparam,(eprosima::fastrtps::SubscriberListener*)&m_listener);
+    delete Rparam;
     if(m_subscriber == nullptr)
     {
         return;
@@ -387,6 +389,8 @@ namespace RTC
         onBufferWriteTimeout(data);
         onReceiverTimeout(data);
         return;
+
+      case BufferStatus::NOT_SUPPORTED:
 
       default:
         onReceiverError(data);

--- a/src/ext/transport/FastRTPS/FastRTPSMessageInfo.h
+++ b/src/ext/transport/FastRTPS/FastRTPSMessageInfo.h
@@ -370,7 +370,7 @@ namespace RTC
   class __declspec(dllimport) GlobalFastRTPSMessageInfoList
 #endif
 #else
-  class GlobalFastRTPSMessageInfo
+  class GlobalFastRTPSMessageInfoList
 #endif
       : public FastRTPSMessageInfoList,
       public coil::Singleton<GlobalFastRTPSMessageInfoList >

--- a/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSOutPort.cpp
@@ -151,13 +151,14 @@ namespace RTC
         topicmgr.registerType(type);
     }
 
-    eprosima::fastrtps::PublisherAttributes Wparam;
-    Wparam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
-    Wparam.topic.topicDataType = m_dataType;
-    Wparam.topic.topicName = m_topic;
-    Wparam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    Wparam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-    m_publisher = eprosima::fastrtps::Domain::createPublisher(participant, Wparam, (eprosima::fastrtps::PublisherListener*)&m_listener);
+    eprosima::fastrtps::PublisherAttributes *Wparam = new eprosima::fastrtps::PublisherAttributes();
+    Wparam->topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
+    Wparam->topic.topicDataType = m_dataType;
+    Wparam->topic.topicName = m_topic;
+    Wparam->historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    Wparam->qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    m_publisher = eprosima::fastrtps::Domain::createPublisher(participant, *Wparam, (eprosima::fastrtps::PublisherListener*)&m_listener);
+    delete Wparam;
     if (m_publisher == nullptr)
     {
         RTC_ERROR(("Publisher initialize failed"));

--- a/src/ext/transport/FastRTPS/FastRTPSTransport.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSTransport.cpp
@@ -23,30 +23,34 @@
 #include "FastRTPSManager.h"
 
 
-ManagerActionListener::ManagerActionListener()
+namespace FastRTPSRTC
 {
 
-}
-ManagerActionListener::~ManagerActionListener()
-{
+  ManagerActionListener::ManagerActionListener()
+  {
 
-}
-void ManagerActionListener::preShutdown()
-{
+  }
+  ManagerActionListener::~ManagerActionListener()
+  {
 
-}
-void ManagerActionListener::postShutdown()
-{
-    RTC::FastRTPSManager::shutdown_global();
-}
-void ManagerActionListener::postReinit()
-{
+  }
+  void ManagerActionListener::preShutdown()
+  {
 
-}
+  }
+  void ManagerActionListener::postShutdown()
+  {
+      RTC::FastRTPSManager::shutdown_global();
+  }
+  void ManagerActionListener::postReinit()
+  {
 
-void ManagerActionListener::preReinit()
-{
+  }
 
+  void ManagerActionListener::preReinit()
+  {
+
+  }
 }
 
 extern "C"
@@ -80,11 +84,11 @@ extern "C"
                                             ::RTC::FastRTPSOutPort>);
     }
 
-    ManagerActionListener *listener = new ManagerActionListener();
+    FastRTPSRTC::ManagerActionListener *listener = new FastRTPSRTC::ManagerActionListener();
     manager->addManagerActionListener(listener);
     
   }
   
-};
+}
 
 

--- a/src/ext/transport/FastRTPS/FastRTPSTransport.h
+++ b/src/ext/transport/FastRTPS/FastRTPSTransport.h
@@ -23,16 +23,19 @@
 
 #include <rtm/Manager.h>
 
-class ManagerActionListener : public RTM::ManagerActionListener
+namespace FastRTPSRTC
 {
-public:
-    ManagerActionListener();
-    ~ManagerActionListener() override;
-    void preShutdown() override;
-    void postShutdown() override;
-    void postReinit() override;
-    void preReinit() override;
-};
+  class ManagerActionListener : public RTM::ManagerActionListener
+  {
+  public:
+      ManagerActionListener();
+      ~ManagerActionListener() override;
+      void preShutdown() override;
+      void postShutdown() override;
+      void postReinit() override;
+      void preReinit() override;
+  };
+}
 
 
 extern "C"
@@ -51,7 +54,7 @@ extern "C"
    * @endif
    */
   DLL_EXPORT void FastRTPSTransportInit(RTC::Manager* manager);
-};
+}
 
 #endif // RTC_FASTRTPSTRANSPORT_H
 

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.h
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.h
@@ -92,7 +92,7 @@ namespace RTC
      * @endif
      */
     ROS2SerializerBase(){
-      m_message.reserve(65000);
+      m_message.reserve(2147483647);
     };
 
     /*!

--- a/src/ext/transport/ROS2Transport/ROS2Transport.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Transport.cpp
@@ -33,7 +33,6 @@ extern "C"
    */
   void ROS2TransportInit(RTC::Manager* manager)
   {
-    (void)manager;
     ROS2SerializerInit(manager);
   }
   

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -95,3 +95,4 @@ if(VXWORKS)
 endif(VXWORKS)
 
 
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/devel/include/ros)

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -44,7 +44,7 @@ namespace RTC
    * @endif
    */
   ROSInPort::ROSInPort(void)
-   : m_buffer(0),
+   : m_buffer(nullptr),
      m_pubnum(0),
      m_roscoreport(11311)
   {
@@ -446,6 +446,8 @@ namespace RTC
         onBufferWriteTimeout(data);
         onReceiverTimeout(data);
         return;
+
+      case BufferStatus::NOT_SUPPORTED:
 
       default:
         onReceiverError(data);

--- a/src/ext/transport/ROSTransport/ROSMessageInfo.cpp
+++ b/src/ext/transport/ROSTransport/ROSMessageInfo.cpp
@@ -100,6 +100,32 @@ namespace RTC
     /*!
      * @if jp
      *
+     * @brief 指定名のROSMessageInfoを取得
+     *
+     * @param id 名前
+     * @return ROSMessageInfo
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param id
+     * @return
+     *
+     * @endif
+     */
+    ROSMessageInfoBase* ROSMessageInfoList::getInfo(const std::string& id)
+    {
+        if (m_data.find(id) == m_data.end())
+        {
+            return nullptr;
+        }
+        return m_data[id].object_;
+    }
+
+    /*!
+     * @if jp
+     *
      * @brief コンストラクタ
      *
      * @param object ROSMessageInfo

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -969,7 +969,7 @@ extern "C"
     RTC::ROSQuaternionDataInit();
     RTC::ROSVector3DDataInit();
     RTC::ROSCameraImageDataInit();
-  };
+  }
 }
 
 

--- a/src/ext/transport/ROSTransport/ROSSerializer.h
+++ b/src/ext/transport/ROSTransport/ROSSerializer.h
@@ -455,7 +455,7 @@ extern "C"
    * @endif
    */
   DLL_EXPORT void ROSSerializerInit(RTC::Manager* manager);
-};
+}
 
 
 

--- a/src/ext/transport/ROSTransport/ROSTransport.cpp
+++ b/src/ext/transport/ROSTransport/ROSTransport.cpp
@@ -26,32 +26,36 @@
 #include "ROSTopicManager.h"
 
 
-ManagerActionListener::ManagerActionListener()
+namespace ROSRTM
 {
 
-}
-ManagerActionListener::~ManagerActionListener()
-{
+  ManagerActionListener::ManagerActionListener()
+  {
+
+  }
+  ManagerActionListener::~ManagerActionListener()
+  {
+
+  }
+  void ManagerActionListener::preShutdown()
+  {
+
+  }
+  void ManagerActionListener::postShutdown()
+  {
+      RTC::ROSTopicManager::shutdown_global();
+  }
+  void ManagerActionListener::postReinit()
+  {
+
+  }
+
+  void ManagerActionListener::preReinit()
+  {
+
+  }
 
 }
-void ManagerActionListener::preShutdown()
-{
-
-}
-void ManagerActionListener::postShutdown()
-{
-    RTC::ROSTopicManager::shutdown_global();
-}
-void ManagerActionListener::postReinit()
-{
-
-}
-
-void ManagerActionListener::preReinit()
-{
-
-}
-
 
 extern "C"
 {
@@ -84,10 +88,10 @@ extern "C"
     }
     ROSSerializerInit(manager);
 
-    ManagerActionListener *listener = new ManagerActionListener();
+    ROSRTM::ManagerActionListener *listener = new ROSRTM::ManagerActionListener();
     manager->addManagerActionListener(listener);
   }
   
-};
+}
 
 

--- a/src/ext/transport/ROSTransport/ROSTransport.h
+++ b/src/ext/transport/ROSTransport/ROSTransport.h
@@ -22,17 +22,19 @@
 
 #include <rtm/Manager.h>
 
-class ManagerActionListener : public RTM::ManagerActionListener
+namespace ROSRTM
 {
-public:
-    ManagerActionListener();
-    ~ManagerActionListener() override;
-    void preShutdown() override;
-    void postShutdown() override;
-    void postReinit() override;
-    void preReinit() override;
-};
-
+  class ManagerActionListener : public RTM::ManagerActionListener
+  {
+  public:
+      ManagerActionListener();
+      ~ManagerActionListener() override;
+      void preShutdown() override;
+      void postShutdown() override;
+      void postReinit() override;
+      void preReinit() override;
+  };
+}
 
 extern "C"
 {
@@ -50,7 +52,7 @@ extern "C"
    * @endif
    */
   DLL_EXPORT void ROSTransportInit(RTC::Manager* manager);
-};
+}
 
 #endif // RTC_ROSTRANSPORT_H
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#749

cmakeで`CMAKE_BUILD_TYPE=Release`にしたときに警告をエラーにするためビルドが失敗する。

## Description of the Change

ROSTransport、ROS2Transportの警告を修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
