### PR TITLE
1.2のdebパッケージにSSLTransportが含まれるようにする

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,6 @@ AC_ARG_WITH(rtorb,            [  --with-rtorb=dir                Find RtORB inst
 AC_ARG_WITH(generic-orb,      [  --with-generic-orb              Use other CORBA 2.3 ORB])
 AC_ARG_WITH(generic-orb-lib,  [  --with-generic-orb-lib	=libs    ORB libraries (-l...)])
 AC_ARG_WITH(doxygen,          [  --without-doxygen               Don't create documentation by doxygen])
-AC_ARG_WITH(omnissl,          [  --without-omnissl               Don't use OmniSSL library])
 
 dnl  Script wrapper selection
 #AC_ARG_WITH(python,           [  --with-python=dir               Find Python installation below dir])
@@ -1107,7 +1106,7 @@ if test "x$have_omniorb" = "xyes" ; then
 	LDFLAGS="-L$omniorb_lib_dir $LDFLAGS"
 
         dnl Library with / without SSL
-        if test "x$with_omnissl" = "xno" ; then
+        if test "x$enable_ssl" = "xyes" ; then
                 AC_DEFINE([ENABLE_OMNISSL], [TRUE], [omniSSL is used])
                 LIBS="$LIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
                 LDSOLIBS="$LDSOLIBS -lomniORB4 -lomnithread -lomniDynamic4 -lomnisslTP4"
@@ -1545,13 +1544,11 @@ dnl ext/ssl
 dnl
 dnl ------------------------------------------------------------
 if test "x$orb_to_use" = "xomniORB" ; then
-        if test "x$with_omnissl" = "xno" ; then
-                if test "x$enable_ssl" = "xyes" ; then
-                        AC_DEFINE([BUILD_EXTSSL], [TRUE], [Build ext/ssl])
-                        EXT_TARGET="$EXT_TARGET ssl"
-                else
-                        AC_DEFINE([BUILD_EXTSSL], [FALSE], [Build ext/ssl])
-                fi
+        if test "x$enable_ssl" = "xyes" ; then
+                AC_DEFINE([BUILD_EXTSSL], [TRUE], [Build ext/ssl])
+                EXT_TARGET="$EXT_TARGET ssl"
+        else
+                AC_DEFINE([BUILD_EXTSSL], [FALSE], [Build ext/ssl])
         fi
 fi
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #754 


## Description of the Change

- 下記の理由により修正した
  - configureのオプションで --enable-ssl =yes （デフォルト設定なので指定しなくても同じ動作）としても src/ext/ssl がビルドされない
  - --without-omnissl オプションが動作しない。withoutの後はパッケージ名を指定するようであるが、Ubuntu18.04の場合、libomnissltp4はlibomniorb4-2パッケージに含まれている。
    ```
    $ ./configure --prefix=/usr --without-omnissl=no
    configure: error: invalid package name: omnissl=no
    ```

- 修正内容
  - --without-omnissl オプションを廃止した
  - 処理で with_omnissl が使用されていたが、これを定義している場所を見つけられなかったこともあり、enable_ssl で判断するように変更した


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu18.04でのconfigureオプションを変更してのビルド確認結果は下記の通りです。　OSX mojave 環境での確認、よろしくお願いします。

- (1) fluentd=yes(default), observer=yes(default), ssl=no
```
$ ./build/autogen
$ ./configure --prefix=/usr --enable-ssl=no
$ make

ライブラリ確認（抜粋）
$ find src/ext/ -name "*.la"
src/ext/sdo/observer/libComponentObserverConsumer.la
src/ext/sdo/observer/libComponentObserverStub.la
src/ext/logger/fluentbit_stream/FluentBit.la
sslライブラリの生成はなし <-- OK
```

- (2) fluentd=no, observer=yes(default), ssl=yes(default)
これはOpenRTM-aistのソースパッケージ作成 (make dist) 時の設定
```
$ ./build/autogen
$ ./configure --prefix=/usr --enable-fluentd=no
$ make 
$ make dist

ライブラリ確認（抜粋）
$ find src/ext/ -name "*.la"
src/ext/sdo/observer/libComponentObserverConsumer.la
src/ext/sdo/observer/libComponentObserverStub.la
src/ext/ssl/SSLTransport.la
fluentbitライブラリの生成はなし <-- OK
```

- (3) fluentd=yes(default), observer=yes(default), ssl=yes(default)
OpenRTM-aistのLinuxパッケージ作成時の設定　・・・(2)で生成したOpenRTM-aist-1.2.1.tar.gzを利用
```
$ tar xvzf OpenRTM-aist-1.2.1.tar.gz
$ cd OpenRTM-aist-1.2.1/
$ ./configure --prefix=/usr
$ cd packages
$ make

ライブラリ確認（抜粋）
$ find src/ext/ -name "*.la"
src/ext/sdo/observer/libComponentObserverConsumer.la
src/ext/sdo/observer/libComponentObserverStub.la
src/ext/logger/fluentbit_stream/FluentBit.la
src/ext/ssl/SSLTransport.la
```

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
