### PR TITLE
Initialize std::chrono::nanoseconds timeout by 0

### DIFF
--- a/src/lib/rtm/ExecutionContextBase.cpp
+++ b/src/lib/rtm/ExecutionContextBase.cpp
@@ -75,7 +75,7 @@ namespace RTC
     setTransitionMode(props, "sync_reset", m_syncReset);
 
     // getting transition timeout
-    std::chrono::nanoseconds timeout;
+    std::chrono::nanoseconds timeout(0);
     if (setTimeout(props, "transition_timeout", timeout))
       {
         m_activationTimeout   = timeout;


### PR DESCRIPTION
#780 

Initialize std::chrono::nanoseconds timeout was not initialized. Now it is initialized by 0.

## Identify the Bug

#780 

## Description of the Change

Initialize std::chrono::nanoseconds timeout was not initialized. Now it is initialized by 0.

## Verification 

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
