### PR TITLE
Fix warnings of travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+os: linux
 dist: bionic
-language: minimal
-sudo: required
+language: shell
 
 services:
   - docker


### PR DESCRIPTION
## Identify the Bug

Travis CI で警告がある。(動作に問題は無い。)
例: 以下のページから view config をクリック
https://travis-ci.org/OpenRTM/OpenRTM-aist/builds/642406181/config?utm_medium=notification&utm_source=github_status

##  Description of the Change
警告への対応：
- 廃止された sudo: を削除する。

インフォメーションへの対応 (直す必要は無いが目につくので)
- os を指定する。
- language を shell にする。 (元々使っている minimal は shell の別名)

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  ビルド結果に影響なし
