### PR TITLE
use CMAKE_DL_LIBS to link with dl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,7 @@ elseif(UNIX)
 		# for std::thread
 		set(THREADS_PREFER_PTHREAD_FLAG ON)
 		find_package(Threads)
-		set(RTM_LINKER_OPTION dl rt Threads::Threads)
+		set(RTM_LINKER_OPTION ${CMAKE_DL_LIBS} rt Threads::Threads)
 	endif()
 elseif(WIN32)
 	set(COIL_OS_DIR "win32")


### PR DESCRIPTION
# Description of the Change

CMake の作法として、 dl_open() 等のライブラリは CMAKE_DL_LIBS 変数で指定するらしいので変更する。
実行時のオプションを確認すると結局 dl とリンクするので、変更前と変わっていない。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  不要
