### PR TITLE
Remove debug output in EC.

### DIFF
--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -99,50 +99,24 @@ namespace RTC
   int ExtTrigExecutionContext::svc()
   {
     RTC_TRACE(("svc()"));
-    unsigned int count(0);
     do
       {
         {
           std::unique_lock<std::mutex> guard(m_worker.mutex_);
-          RTC_DEBUG(("Start of worker invocation. ticked = %s",
-                     m_worker.ticked_ ? "true" : "false"));
           while (!m_worker.ticked_)
             {
               m_worker.cond_.wait(guard);  // wait for tick
-              RTC_DEBUG(("Thread was woken up."));
             }
-          if (!m_worker.ticked_) { continue; }
         }
         auto t0 = std::chrono::high_resolution_clock::now();
         ExecutionContextBase::invokeWorkerPreDo();
         ExecutionContextBase::invokeWorkerDo();
         ExecutionContextBase::invokeWorkerPostDo();
-        auto t1 = std::chrono::high_resolution_clock::now();
         {
           std::lock_guard<std::mutex> guard(m_worker.mutex_);
           m_worker.ticked_ = false;
         }
-        auto period = getPeriod();
-        auto rest = period - (t1 - t0);
-        if (true)  // count > 1000)
-          {
-            RTC_PARANOID(("Period:    %f [s]", std::chrono::duration<double>(period).count()));
-            RTC_PARANOID(("Execution: %f [s]", std::chrono::duration<double>(t1 - t0).count()));
-            RTC_PARANOID(("Sleep:     %f [s]", std::chrono::duration<double>(rest).count()));
-          }
-        auto t2 = std::chrono::high_resolution_clock::now();
-        if (rest > std::chrono::seconds::zero())
-          {
-            if (true /*count > 1000*/) { RTC_PARANOID(("sleeping...")); }
-            std::this_thread::sleep_until(t0 + period);
-          }
-        if (true)  // count > 1000)
-          {
-            auto t3 = std::chrono::high_resolution_clock::now();
-            RTC_PARANOID(("Slept:       %f [s]", std::chrono::duration<double>(t3 - t2).count()));
-            count = 0;
-          }
-        ++count;
+        std::this_thread::sleep_until(t0 + getPeriod());
       } while (threadRunning());
 
     return 0;

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -70,39 +70,14 @@ namespace RTC
    */
   void OpenHRPExecutionContext::tick()
   {
-    RTC_TRACE(("tick()"));
     if (!isRunning()) { return; }
     std::lock_guard<std::mutex> guard(m_tickmutex);
 
     ExecutionContextBase::invokeWorkerPreDo();  // update state
     auto t0 = std::chrono::high_resolution_clock::now();
     ExecutionContextBase::invokeWorkerDo();
-    auto t1 = std::chrono::high_resolution_clock::now();
     ExecutionContextBase::invokeWorkerPostDo();
-    auto t2 = std::chrono::high_resolution_clock::now();
-
-    auto period = getPeriod();
-    auto rest = period - (t2 - t0);
-    if (m_count > 1000)
-      {
-        RTC_PARANOID(("Period:      %f [s]", std::chrono::duration<double>(period).count()));
-        RTC_PARANOID(("Exec-Do:     %f [s]", std::chrono::duration<double>(t1 - t0).count()));
-        RTC_PARANOID(("Exec-PostDo: %f [s]", std::chrono::duration<double>(t2 - t1).count()));
-        RTC_PARANOID(("Sleep:       %f [s]", std::chrono::duration<double>(rest).count()));
-      }
-    auto t3 = std::chrono::high_resolution_clock::now();
-    if (rest > std::chrono::seconds::zero())
-      {
-        if (m_count > 1000) { RTC_PARANOID(("sleeping...")); }
-        std::this_thread::sleep_until(t0 + period);
-      }
-    if (m_count > 1000)
-      {
-        auto t4 = std::chrono::high_resolution_clock::now();
-        RTC_PARANOID(("Slept:       %f [s]", std::chrono::duration<double>(t4 - t3).count()));
-        m_count = 0;
-      }
-    ++m_count;
+    std::this_thread::sleep_until(t0 + getPeriod());
     return;
   }
 

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -491,12 +491,6 @@ namespace RTC
      * @endif
      */
     RTC::Logger rtclog{"exttrig_sync_ec"};
-
-    /*!
-     * @brief A counter for log message in worker
-     */
-    unsigned int m_count{0};
-
   };  // class OpenHRPExecutionContext
 } // namespace RTC
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- #485
- RTPreemptEC が m_nowiat = true の時に決してスレッドが終了しないバグ

## Description of the Change

- fix #485 
  EC のメインループ (while 文)  の中にある RTC_DEBUG, RTC_PARANOID の削除。
   上記に関係する変数や処理の削除。
-  RTPreemptEC のバグ
   m_nowait の場合もスレッドの終了判定をする。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  一部実施

環境: Ubuntu 18.04 amd64

* PeridoicExecutionContext: 
  時間計測だけする onExecute() を作成して、周期を計測し、問題無かった。
  - 1hz設定
     Period:999640156[ns]
     Period:999640[us]
     Period:999[ms]
     count=2227, time=2226198627430
  - 100 hz設定
     Period:10076074[ns]
     Period:10076[us]
     Period:10[ms]
     count=15961, time=160824232097
  - 250 hz設定
     Period:4080562[ns]
     Period:4080[us]
     Period:4[ms]
   count=217175, time=886196163966
  - 1000hz 設定
    Period:1063864[ns]
    Period:1063[us]
    Period:1[ms]
    count=6782, time=7215129259
* ExternelTrrigerExecutionContext
Examples の ExtTrig で tick 動作が行われることを確認した。