### PR TITLE
fluentbit_streamのログ出力にホスト名、プロセスID、マネージャ名を追加

### DIFF
--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -16,6 +16,7 @@
  */
 #include <algorithm>
 
+#include <rtm/Manager.h>
 #include <rtm/LogstreamBase.h>
 #include <rtm/SystemLogger.h>
 #include <coil/stringutil.h>
@@ -129,11 +130,15 @@ namespace RTC
   {
     char tmp[BUFFER_LEN];
     std::streamsize n(0);
+    coil::Properties& conf = ::RTC::Manager::instance().getConfig();
+    const std::string& pid = conf["manager.pid"];
+    const std::string& host_name = conf["os.hostname"];
+    const std::string& manager_name = conf["manager.instance_name"];
     for(auto & flb : m_flbIn)
       {
 
         n = snprintf(tmp, sizeof(tmp) - 1,
-                     R"([%ld, {"message": "%s", "time":"%s","name":"%s","level":"%s"}])", time(nullptr), mes, date.c_str(), name.c_str(), Logger::getLevelString(level).c_str());
+                     R"([%ld, {"time":"%s","name":"%s","level":"%s","pid":"%s","host":"%s","manager":"%s","message": "%s"}])", time(nullptr), date.c_str(), name.c_str(), Logger::getLevelString(level).c_str(), pid.c_str(), host_name.c_str(), manager_name.c_str(), mes);
 
         flb_lib_push(s_flbContext, flb, tmp, n);
       }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#789


## Description of the Change

fluentbit_streamの出力のrecordにホスト名、プロセスID、マネージャ名を追加した。

```
2020-02-18 18:08:01.000000000 +0900 fluentd: {"time":"Feb 18 09:08:01.384","name":"ManagerServant","level":"INFO","pid":"6465","host":"xxxx","manager":"manager","message":"Master manager not found"}
```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
