### PR TITLE
create_process関数の不具合修正

### DIFF
--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -35,7 +35,7 @@ namespace coil
     std::string cmd = "cmd.exe /c ";
     command = cmd + command;
 #ifdef UNICODE
-    // std::string -> LPTSTR
+    // std::wstring -> LPTSTR
     std::wstring wcommand = string2wstring(command);
     LPTSTR lpcommand = new TCHAR[wcommand.size() + 1];
     _tcscpy(lpcommand, wcommand.c_str());
@@ -101,7 +101,7 @@ namespace coil
 
 
 #ifdef UNICODE
-      // std::string -> LPTSTR
+      // std::wstring -> LPTSTR
       std::wstring wcommand = string2wstring(command);
       LPTSTR lpcommand = new TCHAR[wcommand.size() + 1];
       _tcscpy_s(lpcommand, wcommand.size() + 1, wcommand.c_str());


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Windowsでのcreate_process関数を実行時に以下の不具合が発生する。

- 取得した標準出力が空の場合に動作が停止する
- バッチファイルを実行した場合にエラーになり標準出力を取得できない

## Description of the Change

- 取得した標準出力が空の場合はcreate_process関数を終了する
- CreateProcess関数が0(エラー)を返した場合、`cmd.exe /c rtcprof ****`のようにコマンドプロンプトで実行する。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
