### PR TITLE
Remove VS2017-2019 CI on Appveyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,18 +8,10 @@ environment:
   omniorb: omniORB-4.2.3
   cmake_flags: -DOMNI_VERSION=42 -DOMNI_MINOR=3 -DOMNITHREAD_VERSION=41 -DCORBA=omniORB -DSSL_ENABLE=ON -DOBSERVER_ENABLE=ON
   matrix:
-    - cmake_generator: Visual Studio 16 2019          # CMake -G
+    - cmake_generator: Visual Studio 14 2015          # CMake -G
       cmake_archtecture: x64                          # CMake -A
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 # Choices: Appveyor depend
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015 # Choices: Appveyor depend
       python: 37-x64                                  # Choices: Appveyor depend
-    - cmake_generator: Visual Studio 15 2017
-      cmake_archtecture: x64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      python: 37-x64
-    - cmake_generator: Visual Studio 14 2015
-      cmake_archtecture: x64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      python: 37-x64
     - cmake_generator: Visual Studio 12 2013
       cmake_archtecture: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015


### PR DESCRIPTION
## Description of the Change

Azure pipelines による Windows/Visual Studio 2017, 2019 のビルドが出来ているので、AppVeyor の CI から削除する。
Appveyor のビルドは並列で行われないため、ボトルネックになっていたが少し緩和される。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
