### PR TITLE
ROS2Transportの警告修正

### DIFF
--- a/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
@@ -173,10 +173,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2StringData()
-    {
-
-    }
+    ROS2StringData() = default;
     /*!
      * @if jp
      *
@@ -188,10 +185,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2StringData() override
-    {
-
-    }
+    ~ROS2StringData() override = default;
 
     /*!
      * @if jp
@@ -305,10 +299,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2Point3DData()
-    {
-
-    }
+    ROS2Point3DData() = default;
 
     /*!
      * @if jp
@@ -321,10 +312,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2Point3DData() override
-    {
-
-    }
+    ~ROS2Point3DData() override = default;
 
     /*!
      * @if jp
@@ -447,10 +435,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2QuaternionData()
-    {
-
-    }
+    ROS2QuaternionData() = default;
     /*!
      * @if jp
      *
@@ -462,10 +447,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2QuaternionData() override
-    {
-
-    }
+    ~ROS2QuaternionData() override = default;
 
     /*!
      * @if jp
@@ -590,10 +572,8 @@ namespace RTC
      *
      * @endif
      */
-    ROS2Vector3DData()
-    {
+    ROS2Vector3DData() = default;
 
-    }
     /*!
      * @if jp
      *
@@ -605,10 +585,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2Vector3DData() override
-    {
-
-    }
+    ~ROS2Vector3DData() override = default;
 
     /*!
      * @if jp
@@ -735,10 +712,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2CameraImageData()
-    {
-
-    }
+    ROS2CameraImageData() = default;
     /*!
      * @if jp
      *
@@ -750,10 +724,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2CameraImageData() override
-    {
-
-    }
+    ~ROS2CameraImageData() override = default;
 
     /*!
      * @if jp
@@ -879,9 +850,8 @@ extern "C"
    * @brief Module initialization
    * @endif
    */
-  void ROS2SerializerInit(RTC::Manager* manager)
+  void ROS2SerializerInit(RTC::Manager* /*manager*/)
   {
-    (void)manager;
     
     RTC::ROS2SimpleDataInit<RTC::TimedState, CORBA::Short>();
     RTC::ROS2SimpleDataInit<RTC::TimedShort, CORBA::Short>();

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.h
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.h
@@ -106,7 +106,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2SerializerBase() override = default;
+    ~ROS2SerializerBase() override;
 
     /*!
      * @if jp
@@ -439,6 +439,9 @@ namespace RTC
   protected:
     eprosima::fastrtps::rtps::SerializedPayload_t m_message;
   };
+
+  template <class DataType>
+  ROS2SerializerBase<DataType>::~ROS2SerializerBase() = default;
 
   /*!
    * @if jp

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -197,10 +197,8 @@ namespace RTC
      *
      * @endif
      */
-    ROSStringData()
-    {
+    ROSStringData() = default;
 
-    }
     /*!
      * @if jp
      *
@@ -212,10 +210,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSStringData() override
-    {
-
-    }
+    ~ROSStringData() override = default;
 
     /*!
      * @if jp
@@ -330,10 +325,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSPoint3DData()
-    {
-
-    }
+    ROSPoint3DData() = default;
     /*!
      * @if jp
      *
@@ -345,10 +337,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSPoint3DData() override
-    {
-
-    }
+    ~ROSPoint3DData() override = default;
 
     /*!
      * @if jp
@@ -474,10 +463,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSQuaternionData()
-    {
-
-    }
+    ROSQuaternionData() = default;
     /*!
      * @if jp
      *
@@ -489,10 +475,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSQuaternionData() override
-    {
-
-    }
+    ~ROSQuaternionData() override = default;
 
     /*!
      * @if jp
@@ -620,10 +603,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSVector3DData()
-    {
-
-    }
+    ROSVector3DData() = default;
     /*!
      * @if jp
      *
@@ -635,10 +615,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSVector3DData() override
-    {
-
-    }
+    ~ROSVector3DData() override = default;
 
     /*!
      * @if jp
@@ -765,10 +742,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSCameraImageData()
-    {
-
-    }
+    ROSCameraImageData() = default;
     /*!
      * @if jp
      *
@@ -911,9 +885,8 @@ extern "C"
    * @brief Module initialization
    * @endif
    */
-  void ROSSerializerInit(RTC::Manager* manager)
+  void ROSSerializerInit(RTC::Manager* /*manager*/)
   {
-    (void)manager;
     RTC::ROSSimpleDataInit<RTC::TimedState, CORBA::Short>();
     RTC::ROSSimpleDataInit<RTC::TimedShort, CORBA::Short>();
     RTC::ROSSimpleDataInit<RTC::TimedLong, CORBA::Long>();


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROS2Transportのビルドで警告が発生する。

```
In file included from /root/OpenRTM-aist/src/ext/transport/ROS2Transport/ROS2Serializer.cpp:27:0:
/root/OpenRTM-aist/src/ext/transport/ROS2Transport/ROS2Serializer.h: In function 'AbstractClass* coil::Creator() [with AbstractClass = RTC::ByteDataStreamBase; ConcreteClass = RTC::ROS2CameraImageData]':
/root/OpenRTM-aist/src/ext/transport/ROS2Transport/ROS2Serializer.h:109:5: error: inlining failed in call to 'RTC::ROS2SerializerBase<DataType>::~ROS2SerializerBase() noexcept [with DataType = RTC::CameraImage]': call is unlikely and code size would grow [-Werror=inline]
     ~ROS2SerializerBase() override = default;
     ^
/root/OpenRTM-aist/src/ext/transport/ROS2Transport/ROS2Serializer.cpp:715:5: note: called from here
     ROS2CameraImageData() = default;
```

## Description of the Change

- 上記の警告の修正のために`~ROS2SerializerBase`関数をクラス定義の外に移動
- 一部のコンストラクタ、デストラクタの関数定義をdefault化


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
