### PR TITLE
DockerfileにROS2Transportビルドの設定を追加

### DIFF
--- a/scripts/ubuntu_1804/Dockerfile
+++ b/scripts/ubuntu_1804/Dockerfile
@@ -1,9 +1,21 @@
 FROM openrtm/devel-rtm:ubuntu18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV ROS_DISTRO=melodic
 RUN apt-get update
-RUN apt-get -y install gnupg2
+RUN apt-get -y install curl gnupg2
+
+ENV ROS_DISTRO=dashing
+RUN curl http://repo.ros2.org/repos.key | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main bionic main" > /etc/apt/sources.list.d/ros2-latest.list'
+RUN apt-get update
+RUN apt-get -y install ros-${ROS_DISTRO}-ros-core
+ENV AMENT_PREFIX_PATH=/opt/ros/${ROS_DISTRO}
+ENV ROS_VERSION=2
+ENV ROS_PYTHON_VERSION=3
+ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python3.6/site-packages:${PYTHONPATH}
+ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
+
+ENV ROS_DISTRO=melodic
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list'
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654
 RUN apt-get -y update
@@ -13,8 +25,6 @@ RUN rosdep update
 ENV CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}:${CMAKE_PREFIX_PATH}
 ENV ROS_ETC_DIR=/opt/ros/${ROS_DISTRO}/etc/ros
 ENV ROS_ROOT=/opt/ros/${ROS_DISTRO}/share/ros
-ENV ROS_VERSION=1
-ENV ROS_PYTHON_VERSION=2
 ENV ROS_PACKAGE_PATH=/opt/ros/${ROS_DISTRO}/share
 ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python2.7/dist-packages:${PYTHONPATH}
 ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
@@ -26,6 +36,8 @@ RUN cmake\
  -DFLUENTBIT_ENABLE=ON\
  -DFLUENTBIT_ROOT=/usr/local/include\
  -DROS_ENABLE=ON\
+ -DFASTRTPS_ENABLE=ON\
+ -DROS2_ENABLE=ON\
  -DCMAKE_BUILD_TYPE=Release\
  -S /root/OpenRTM-aist\
  -B/tmp/rtm/build\

--- a/scripts/ubuntu_1804/Dockerfile
+++ b/scripts/ubuntu_1804/Dockerfile
@@ -1,11 +1,31 @@
 FROM openrtm/devel-rtm:ubuntu18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=melodic
+RUN apt-get update
+RUN apt-get -y install gnupg2
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list'
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654
+RUN apt-get -y update
+RUN apt-get -y install ros-${ROS_DISTRO}-ros-base
+RUN rosdep init
+RUN rosdep update
+ENV CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}:${CMAKE_PREFIX_PATH}
+ENV ROS_ETC_DIR=/opt/ros/${ROS_DISTRO}/etc/ros
+ENV ROS_ROOT=/opt/ros/${ROS_DISTRO}/share/ros
+ENV ROS_VERSION=1
+ENV ROS_PYTHON_VERSION=2
+ENV ROS_PACKAGE_PATH=/opt/ros/${ROS_DISTRO}/share
+ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python2.7/dist-packages:${PYTHONPATH}
+ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
+
 COPY OpenRTM-aist /root/OpenRTM-aist
 RUN cmake\
  -DSSL_ENABLE=ON\
  -DOBSERVER_ENABLE=ON\
  -DFLUENTBIT_ENABLE=ON\
  -DFLUENTBIT_ROOT=/usr/local/include\
+ -DROS_ENABLE=ON\
  -DCMAKE_BUILD_TYPE=Release\
  -S /root/OpenRTM-aist\
  -B/tmp/rtm/build\

--- a/scripts/ubuntu_1804/Dockerfile.package
+++ b/scripts/ubuntu_1804/Dockerfile.package
@@ -7,12 +7,24 @@ RUN apt-get update\
  debhelper\
  devscripts\
  fakeroot\
- python
+ python\
+ curl\
+ gnupg2
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV ROS_DISTRO=melodic
+
+ENV ROS_DISTRO=dashing
+RUN curl http://repo.ros2.org/repos.key | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main bionic main" > /etc/apt/sources.list.d/ros2-latest.list'
 RUN apt-get update
-RUN apt-get -y install gnupg2
+RUN apt-get -y install ros-${ROS_DISTRO}-ros-core
+ENV AMENT_PREFIX_PATH=/opt/ros/${ROS_DISTRO}
+ENV ROS_VERSION=2
+ENV ROS_PYTHON_VERSION=3
+ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python3.6/site-packages:${PYTHONPATH}
+ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
+
+ENV ROS_DISTRO=melodic
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list'
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654
 RUN apt-get -y update
@@ -22,8 +34,6 @@ RUN rosdep update
 ENV CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}:${CMAKE_PREFIX_PATH}
 ENV ROS_ETC_DIR=/opt/ros/${ROS_DISTRO}/etc/ros
 ENV ROS_ROOT=/opt/ros/${ROS_DISTRO}/share/ros
-ENV ROS_VERSION=1
-ENV ROS_PYTHON_VERSION=2
 ENV ROS_PACKAGE_PATH=/opt/ros/${ROS_DISTRO}/share
 ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python2.7/dist-packages:${PYTHONPATH}
 ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
@@ -37,6 +47,8 @@ RUN cmake\
  -DFLUENTBIT_ENABLE=ON\
  -DFLUENTBIT_ROOT=/usr/local/include\
  -DROS_ENABLE=ON\
+ -DFASTRTPS_ENABLE=ON\
+ -DROS2_ENABLE=ON\
  -DDOCUMENTS_ENABLE=ON\
  -DCMAKE_BUILD_TYPE=Release\
  -DCMAKE_INSTALL_PREFIX=/tmp/rtm/install\

--- a/scripts/ubuntu_1804/Dockerfile.package
+++ b/scripts/ubuntu_1804/Dockerfile.package
@@ -9,12 +9,34 @@ RUN apt-get update\
  fakeroot\
  python
 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=melodic
+RUN apt-get update
+RUN apt-get -y install gnupg2
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list'
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654
+RUN apt-get -y update
+RUN apt-get -y install ros-${ROS_DISTRO}-ros-base
+RUN rosdep init
+RUN rosdep update
+ENV CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}:${CMAKE_PREFIX_PATH}
+ENV ROS_ETC_DIR=/opt/ros/${ROS_DISTRO}/etc/ros
+ENV ROS_ROOT=/opt/ros/${ROS_DISTRO}/share/ros
+ENV ROS_VERSION=1
+ENV ROS_PYTHON_VERSION=2
+ENV ROS_PACKAGE_PATH=/opt/ros/${ROS_DISTRO}/share
+ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python2.7/dist-packages:${PYTHONPATH}
+ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
+
+
+
 COPY OpenRTM-aist /root/OpenRTM-aist
 RUN cmake\
  -DSSL_ENABLE=ON\
  -DOBSERVER_ENABLE=ON\
  -DFLUENTBIT_ENABLE=ON\
  -DFLUENTBIT_ROOT=/usr/local/include\
+ -DROS_ENABLE=ON\
  -DDOCUMENTS_ENABLE=ON\
  -DCMAKE_BUILD_TYPE=Release\
  -DCMAKE_INSTALL_PREFIX=/tmp/rtm/install\

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
@@ -173,10 +173,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2StringData()
-    {
-
-    }
+    ROS2StringData() = default;
     /*!
      * @if jp
      *
@@ -188,10 +185,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2StringData() override
-    {
-
-    }
+    ~ROS2StringData() override = default;
 
     /*!
      * @if jp
@@ -305,10 +299,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2Point3DData()
-    {
-
-    }
+    ROS2Point3DData() = default;
 
     /*!
      * @if jp
@@ -321,10 +312,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2Point3DData() override
-    {
-
-    }
+    ~ROS2Point3DData() override = default;
 
     /*!
      * @if jp
@@ -447,10 +435,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2QuaternionData()
-    {
-
-    }
+    ROS2QuaternionData() = default;
     /*!
      * @if jp
      *
@@ -462,10 +447,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2QuaternionData() override
-    {
-
-    }
+    ~ROS2QuaternionData() override = default;
 
     /*!
      * @if jp
@@ -590,10 +572,8 @@ namespace RTC
      *
      * @endif
      */
-    ROS2Vector3DData()
-    {
+    ROS2Vector3DData() = default;
 
-    }
     /*!
      * @if jp
      *
@@ -605,10 +585,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2Vector3DData() override
-    {
-
-    }
+    ~ROS2Vector3DData() override = default;
 
     /*!
      * @if jp
@@ -735,10 +712,7 @@ namespace RTC
      *
      * @endif
      */
-    ROS2CameraImageData()
-    {
-
-    }
+    ROS2CameraImageData() = default;
     /*!
      * @if jp
      *
@@ -750,10 +724,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2CameraImageData() override
-    {
-
-    }
+    ~ROS2CameraImageData() override = default;
 
     /*!
      * @if jp
@@ -879,9 +850,8 @@ extern "C"
    * @brief Module initialization
    * @endif
    */
-  void ROS2SerializerInit(RTC::Manager* manager)
+  void ROS2SerializerInit(RTC::Manager* /*manager*/)
   {
-    (void)manager;
     
     RTC::ROS2SimpleDataInit<RTC::TimedState, CORBA::Short>();
     RTC::ROS2SimpleDataInit<RTC::TimedShort, CORBA::Short>();

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.h
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.h
@@ -106,7 +106,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROS2SerializerBase() override = default;
+    ~ROS2SerializerBase() override;
 
     /*!
      * @if jp
@@ -439,6 +439,9 @@ namespace RTC
   protected:
     eprosima::fastrtps::rtps::SerializedPayload_t m_message;
   };
+
+  template <class DataType>
+  ROS2SerializerBase<DataType>::~ROS2SerializerBase() = default;
 
   /*!
    * @if jp

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -197,10 +197,8 @@ namespace RTC
      *
      * @endif
      */
-    ROSStringData()
-    {
+    ROSStringData() = default;
 
-    }
     /*!
      * @if jp
      *
@@ -212,10 +210,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSStringData() override
-    {
-
-    }
+    ~ROSStringData() override = default;
 
     /*!
      * @if jp
@@ -330,10 +325,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSPoint3DData()
-    {
-
-    }
+    ROSPoint3DData() = default;
     /*!
      * @if jp
      *
@@ -345,10 +337,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSPoint3DData() override
-    {
-
-    }
+    ~ROSPoint3DData() override = default;
 
     /*!
      * @if jp
@@ -474,10 +463,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSQuaternionData()
-    {
-
-    }
+    ROSQuaternionData() = default;
     /*!
      * @if jp
      *
@@ -489,10 +475,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSQuaternionData() override
-    {
-
-    }
+    ~ROSQuaternionData() override = default;
 
     /*!
      * @if jp
@@ -620,10 +603,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSVector3DData()
-    {
-
-    }
+    ROSVector3DData() = default;
     /*!
      * @if jp
      *
@@ -635,10 +615,7 @@ namespace RTC
      *
      * @endif
      */
-    ~ROSVector3DData() override
-    {
-
-    }
+    ~ROSVector3DData() override = default;
 
     /*!
      * @if jp
@@ -765,10 +742,7 @@ namespace RTC
      *
      * @endif
      */
-    ROSCameraImageData()
-    {
-
-    }
+    ROSCameraImageData() = default;
     /*!
      * @if jp
      *
@@ -911,9 +885,8 @@ extern "C"
    * @brief Module initialization
    * @endif
    */
-  void ROSSerializerInit(RTC::Manager* manager)
+  void ROSSerializerInit(RTC::Manager* /*manager*/)
   {
-    (void)manager;
     RTC::ROSSimpleDataInit<RTC::TimedState, CORBA::Short>();
     RTC::ROSSimpleDataInit<RTC::TimedShort, CORBA::Short>();
     RTC::ROSSimpleDataInit<RTC::TimedLong, CORBA::Long>();


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

現状はGitHub ActionsでROS2Transportをビルドしない。

## Description of the Change


`ubuntu_1804/Dockerfile`、`ubuntu_1804/Dockerfile.package`にROS2のインストール、環境変数の設定、CMakeのオプションの設定を追加した。

環境変数`ROS_VERSION`、`ROS_PYTHON_VERSION`について、ROS2の場合は設定していないとCMakeでエラーになる。
ROSの場合は`ROS_VERSION=1`、`ROS_PYTHON_VERSION=2`、ROS2の場合は`ROS_VERSION=2`、`ROS_PYTHON_VERSION=3`が正しい設定であるが、ROSは何に設定しても影響がないようなのでROS2に合わせて設定している。
逆に環境変数`ROS_DISTRO`を設定していないとROSの場合はCMakeで失敗するため`ROS_DISTRO=melodic`に設定している。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
