### PR TITLE
WebサーバのTLSバージョン制限に対応してwgetコマンドのオプション指定を追加する

### DIFF
--- a/scripts/pkg_install_ubuntu.sh
+++ b/scripts/pkg_install_ubuntu.sh
@@ -18,7 +18,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.0.03
+VERSION=2.0.0.04
 
 #
 #---------------------------------------
@@ -343,7 +343,7 @@ update_source_list () {
     fi
   fi
   # 公開鍵登録
-  wget -O- --no-check-certificate https://openrtm.org/pub/openrtm.key | apt-key add -
+  wget -O- --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key | apt-key add -
 }
 
 #----------------------------------------


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #812 


## Description of the Change

- pkg_install_ubuntu.sh 内でopenrtm.orgサーバからwgetしている処理に、「--secure-protocol=TLSv1_2」オプションを追加した



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  

- Ubuntu16.04と18.04のDocker環境で pkg_install_ubuntu.sh を使い、OpenRTMのC++とPythonパッケージをインストールできる動作を確認した
- 使用Dockerfile（Ubuntu16.04の場合）
```
FROM ubuntu:16.04

RUN apt update\
 && apt install -y --no-install-recommends \
 wget \
 gnupg \
 && wget --secure-protocol=TLSv1_2 --no-check-certificate https://raw.githubusercontent.com/n-kawauchi/OpenRTM-aist/set_tls_option/scripts/pkg_install_ubuntu.sh -O pkg_install_ubuntu.sh \
 && sh pkg_install_ubuntu.sh -l c++ -l python -l rtshell -d --yes
```
