### PR TITLE
Analyzerコンポーネントの修正

### DIFF
--- a/examples/Analyzer/Analyzer.cpp
+++ b/examples/Analyzer/Analyzer.cpp
@@ -185,7 +185,7 @@ RTC::ReturnCode_t Analyzer::onExecute(RTC::UniqueId  /*ec_id*/)
 
 	{
 		std::lock_guard<std::mutex> guard(m_mu);
-		m_datalist.emplace_back(m_out);
+		m_datalist.emplace_back(m_out.tm);
 	}
 	std::this_thread::sleep_until(start + m_sleep_time);
 
@@ -234,8 +234,8 @@ RTC::ReturnCode_t Analyzer::onRateChanged(RTC::UniqueId ec_id)
 void Analyzer::writeData(const RTC::TimedOctetSeq &data)
 {
 	std::lock_guard<std::mutex> guard(m_mu);
-	for (std::vector<TimedOctetSeq>::iterator itr = m_datalist.begin(); itr != m_datalist.end(); ) {
-		if (data.tm.nsec == (*itr).tm.nsec && data.tm.sec == (*itr).tm.sec)
+	for (std::vector<RTC::Time>::iterator itr = m_datalist.begin(); itr != m_datalist.end(); ) {
+		if (data.tm.nsec == (*itr).nsec && data.tm.sec == (*itr).sec)
 		{
 			auto end = std::chrono::system_clock::now().time_since_epoch();
 			auto start = std::chrono::seconds(data.tm.sec) + std::chrono::nanoseconds(data.tm.nsec);

--- a/examples/Analyzer/Analyzer.h
+++ b/examples/Analyzer/Analyzer.h
@@ -319,7 +319,7 @@ class Analyzer
 
  private:
 	 std::ofstream m_fs;
-	 std::vector<RTC::TimedOctetSeq> m_datalist;
+	 std::vector<RTC::Time> m_datalist;
 	 std::mutex m_mu;
 	 int data_size;
   // <rtc-template block="private_attribute">

--- a/examples/Analyzer/Analyzer.h
+++ b/examples/Analyzer/Analyzer.h
@@ -248,9 +248,15 @@ class Analyzer
   /*!
    * 出力ファイル名
    * - Name: outputfile outputfile
-   * - DefaultValue: test.dat
+   * - DefaultValue: test_callback.dat
    */
   std::string m_outputfile;
+  /*!
+   * 出力ファイル名
+   * - Name: outputwritefile outputwritefile
+   * - DefaultValue: test_writefunc.dat
+   */
+  std::string m_outputwritefile;
   /*!
   * データ長さ
   * - Name: datalength datalength
@@ -319,9 +325,10 @@ class Analyzer
 
  private:
 	 std::ofstream m_fs;
+   std::ofstream m_fsw;
 	 std::vector<RTC::Time> m_datalist;
 	 std::mutex m_mu;
-	 int data_size;
+	 int m_data_size;
   // <rtc-template block="private_attribute">
   
   // </rtc-template>


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Analyzerコンポーネントでは以下の動作で時間を計測する。

- TimedOctetSeq型データにタイムスタンプを設定、データサイズを設定
- TimedOctetSeq型データを動的配列に格納
- write関数でデータ送信
- コネクタのコールバック関数(ON_BUFFER_WRITE)で時間を計測

以下の問題がある。

- 配列に格納する際のデータのコピーに時間がかかる。
- コールバック関数で時間を計測しているがdirect通信の場合は時間がかかるのはそのあとのデータのコピーのため目的通りに計測できていない。


## Description of the Change

- 配列に格納するデータをRTC::Time型に変更。
- write関数を計測してファイルに出力する機能を新たに追加

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
