### PR TITLE
SSMTransportの実装

### DIFF
--- a/src/ext/transport/CMakeLists.txt
+++ b/src/ext/transport/CMakeLists.txt
@@ -23,3 +23,11 @@ if(OPENSPLICE_ENABLE)
 	add_subdirectory(OpenSplice)
 endif()
 
+
+if(UNIX)
+	set(SSM_ENABLE OFF CACHE BOOL "set SSM_ENABLE")
+
+	if(SSM_ENABLE)
+		add_subdirectory(SSMTransport)
+	endif()
+endif()

--- a/src/ext/transport/SSMTransport/CMakeLists.txt
+++ b/src/ext/transport/SSMTransport/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required (VERSION 3.5.1)
+
+project (SSMTransport
+	VERSION ${RTM_VERSION}
+	LANGUAGES CXX)
+
+
+link_directories(${ORB_LINK_DIR})
+add_definitions(${ORB_C_FLAGS_LIST})
+
+if(WIN32)
+	add_definitions(-DRTM_SKEL_IMPORT_SYMBOL)
+	add_definitions(-DNOGDI)
+	add_definitions(-DNOMINMAX)
+	add_definitions(-DTRANSPORT_PLUGIN)
+endif()
+
+
+set(target SSMTransport)
+
+set(srcs SSMTransport.cpp SSMTransport.h SSMInPort.cpp SSMInPort.h SSMOutPort.cpp SSMOutPort.h)
+
+
+if(VXWORKS AND NOT RTP)
+	set(libs ${RTCSKEL_PROJECT_NAME})
+
+	add_executable(${target} ${srcs})
+	openrtm_common_set_compile_props(${target})
+	openrtm_set_link_props_shared(${target})
+	openrtm_include_rtm(${target})
+	target_link_libraries(${target} ${libs} ssm)
+
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+				COMPONENT ext)
+else()
+	set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${DATATYPE_FACTORIES})
+
+
+	add_library(${target} SHARED ${srcs})
+	openrtm_common_set_compile_props(${target})
+	openrtm_include_rtm(${target})
+	openrtm_set_link_props_shared(${target})
+	target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} ssm)
+	set_target_properties(${target} PROPERTIES PREFIX "")
+
+	set_target_properties(${target} PROPERTIES
+				CXX_STANDARD 11
+				CXX_STANDARD_REQUIRED YES
+				CXX_EXTENSIONS NO
+				)
+
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+				COMPONENT ext)
+endif()
+
+
+if(VXWORKS)
+	if(RTP)
+	else(RTP)	
+		set_target_properties(${target} PROPERTIES SUFFIX ".out")
+	endif(RTP)
+endif(VXWORKS)
+

--- a/src/ext/transport/SSMTransport/SSMInPort.cpp
+++ b/src/ext/transport/SSMTransport/SSMInPort.cpp
@@ -1,0 +1,226 @@
+﻿// -*- C++ -*-
+
+/*!
+ * @file  SSMInPort.cpp
+ * @brief SSMInPort class
+ * @date  $Date: 2020-03-11 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2020
+ *     Nobuhiko Miyamoto
+ *     Robot Innovation Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+
+#include <rtm/Manager.h>
+#include "SSMInPort.h"
+#include <rtm/NVUtil.h>
+#include <libssm.h>
+
+
+
+
+namespace RTC
+{
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   * @else
+   * @brief Constructor
+   * @endif
+   */
+  SSMInPort::SSMInPort(void)
+   : m_buffer(nullptr),
+     m_sens_sid(nullptr),
+     m_stream_id(0)
+  {
+   rtclog.setName("SSMInPort");
+
+  }
+
+  
+
+  /*!
+   * @if jp
+   * @brief デストラクタ
+   * @else
+   * @brief Destructor
+   * @endif
+   */
+  SSMInPort::~SSMInPort(void) = default;
+
+
+  /*!
+   * @if jp
+   * @brief 設定初期化
+   *
+   * 
+   * @param prop 設定情報
+   *
+   * @else
+   *
+   * @brief Initializing configuration
+   *
+   *
+   * @param prop Configuration information
+   *
+   * @endif
+   */
+  void SSMInPort::init(coil::Properties& prop)
+  {
+    RTC_PARANOID(("SSMInPort::init()"));
+    m_stream_name = prop.getProperty("stream_name", "sensor_test");
+    std::string stream_id_str = prop.getProperty("stream_id", "0");
+    if(!coil::stringTo(m_stream_id, stream_id_str.c_str()))
+    {
+      RTC_ERROR(("stream_id is invalid value"));
+    }
+
+  }
+
+
+  /*!
+   * @if jp
+   * @brief バッファをセットする
+   * @else
+   * @brief Setting outside buffer's pointer
+   * @endif
+   */
+  void SSMInPort::
+  setBuffer(CdrBufferBase* buffer)
+  {
+    m_buffer = buffer;
+  }
+
+  /*!
+   * @if jp
+   * @brief リスナを設定する
+   * @else
+   * @brief Set the listener
+   * @endif
+   */
+  void SSMInPort::setListener(ConnectorInfo& info,
+                                           ConnectorListenersBase* listeners)
+  {
+    RTC_TRACE(("SSMInPort::setListener()"));
+    m_profile = info;
+    m_listeners = listeners;
+  }
+
+  /*!
+   * @if jp
+   * @brief データを読み出す
+   * @else
+   * @brief Read data
+   * @endif
+   */
+  DataPortStatus
+  SSMInPort::get(ByteData& data)
+  {
+    ssmTimeT measured_time;
+    ssmTimeT time;
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if(m_sens_sid == nullptr)
+    {
+      m_sens_sid = openSSM(m_stream_name.c_str(), m_stream_id, 0);
+      if(m_sens_sid == nullptr)
+      {
+        return DataPortStatus::PRECONDITION_NOT_MET;
+      }
+      return DataPortStatus::PORT_OK;
+    }
+
+    data.setDataLength(shm_get_address(m_sens_sid)->size);
+    SSM_tid tid = readSSM_time(m_sens_sid, reinterpret_cast<char*>(data.getBuffer()), measured_time, &time);
+
+    RTC_PARANOID(("data length: %d",  data.getDataLength()));
+    RTC_PARANOID(("data count: %d",  tid));
+
+    if (m_buffer->full())
+    {
+      RTC_INFO(("InPort buffer is full."));
+      onBufferFull(data);
+      onReceiverFull(data);
+    }
+    m_buffer->put(data);
+    m_buffer->advanceWptr();
+    m_buffer->advanceRptr();
+
+    return DataPortStatus::PORT_OK;
+
+  }
+
+
+
+  /*!
+   * @if jp
+   * @brief データ受信通知への登録
+   * @else
+   * @brief Subscribe the data receive notification
+   * @endif
+   */
+  bool SSMInPort::
+  subscribeInterface(const SDOPackage::NVList& properties)
+  {
+    RTC_TRACE(("SSMInPort::subscribeInterface()"));
+    return true;
+  }
+
+  /*!
+   * @if jp
+   * @brief データ受信通知からの登録解除
+   * @else
+   * @brief Unsubscribe the data receive notification
+   * @endif
+   */
+  void SSMInPort::
+  unsubscribeInterface(const SDOPackage::NVList& properties)
+  {
+    RTC_TRACE(("SSMInPort::unsubscribeInterface()"));
+    closeSSM(&m_sens_sid);
+  }
+
+
+  /*!
+   * @if jp
+   * @brief リターンコード変換
+   * @else
+   * @brief Return codes conversion
+   * @endif
+   */
+  void
+  SSMInPort::convertReturnCode(DataPortStatus ret, ByteData&  /*data*/)
+  {
+    switch (ret)
+      {
+      case DataPortStatus::PORT_OK:
+        break;
+      case DataPortStatus::PORT_ERROR:
+        onSenderError();
+        break;
+      case DataPortStatus::SEND_FULL:
+        break;
+      case DataPortStatus::BUFFER_FULL:
+        break;
+      case DataPortStatus::BUFFER_EMPTY:
+        onSenderEmpty();
+        break;
+      case DataPortStatus::BUFFER_TIMEOUT:
+        onSenderTimeout();
+        break;
+      case DataPortStatus::UNKNOWN_ERROR:
+        onSenderError();
+        break;
+      default:
+        onSenderError();
+        break;
+      }
+  }
+
+} // namespace RTC

--- a/src/ext/transport/SSMTransport/SSMInPort.cpp
+++ b/src/ext/transport/SSMTransport/SSMInPort.cpp
@@ -123,8 +123,8 @@ namespace RTC
   DataPortStatus
   SSMInPort::get(ByteData& data)
   {
-    ssmTimeT measured_time;
-    ssmTimeT time;
+    ssmTimeT measured_time = 0.0;
+    ssmTimeT time = 0.0;
     std::lock_guard<std::mutex> guard(m_mutex);
     if(m_sens_sid == nullptr)
     {
@@ -166,7 +166,7 @@ namespace RTC
    * @endif
    */
   bool SSMInPort::
-  subscribeInterface(const SDOPackage::NVList& properties)
+  subscribeInterface(const SDOPackage::NVList& /*properties*/)
   {
     RTC_TRACE(("SSMInPort::subscribeInterface()"));
     return true;
@@ -180,7 +180,7 @@ namespace RTC
    * @endif
    */
   void SSMInPort::
-  unsubscribeInterface(const SDOPackage::NVList& properties)
+  unsubscribeInterface(const SDOPackage::NVList& /*properties*/)
   {
     RTC_TRACE(("SSMInPort::unsubscribeInterface()"));
     closeSSM(&m_sens_sid);
@@ -215,8 +215,13 @@ namespace RTC
         onSenderTimeout();
         break;
       case DataPortStatus::UNKNOWN_ERROR:
-        onSenderError();
-        break;
+      case DataPortStatus::BUFFER_ERROR:
+      case DataPortStatus::SEND_TIMEOUT:
+      case DataPortStatus::RECV_EMPTY:
+      case DataPortStatus::RECV_TIMEOUT:
+      case DataPortStatus::INVALID_ARGS:
+      case DataPortStatus::PRECONDITION_NOT_MET:
+      case DataPortStatus::CONNECTION_LOST:
       default:
         onSenderError();
         break;

--- a/src/ext/transport/SSMTransport/SSMInPort.cpp
+++ b/src/ext/transport/SSMTransport/SSMInPort.cpp
@@ -75,8 +75,8 @@ namespace RTC
   void SSMInPort::init(coil::Properties& prop)
   {
     RTC_PARANOID(("SSMInPort::init()"));
-    m_stream_name = prop.getProperty("stream_name", "sensor_test");
-    std::string stream_id_str = prop.getProperty("stream_id", "0");
+    m_stream_name = prop.getProperty("ssm.stream_name", "sensor_test");
+    std::string stream_id_str = prop.getProperty("ssm.stream_id", "0");
     if(!coil::stringTo(m_stream_id, stream_id_str.c_str()))
     {
       RTC_ERROR(("stream_id is invalid value"));

--- a/src/ext/transport/SSMTransport/SSMInPort.h
+++ b/src/ext/transport/SSMTransport/SSMInPort.h
@@ -1,0 +1,387 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  SSMInPort.h
+ * @brief SSMInPort class
+ * @date  $Date: 2020-03-11 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2020
+ *     Nobuhiko Miyamoto
+ *     Robot Innovation Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#ifndef RTC_SSMINPORT_H
+#define RTC_SSMINPORT_H
+
+#include <map>
+#include <rtm/OutPortConsumer.h>
+#include <rtm/ConnectorListener.h>
+#include <rtm/ConnectorBase.h>
+#include <ssm.h>
+
+
+
+
+
+namespace RTC
+{
+  /*!
+   * @if jp
+   * @class SSMInPort
+   * @brief SSMInPort クラス
+   *
+   * InPortProvider 
+   *
+   * データ転送に SSM(Streaming data Sharing Manager) の 共有メモリを利用
+   * した、push 型データフロー型を実現する InPort プロバイダクラス。
+   *
+   * @since 2.0.0
+   *
+   * @else
+   * @class SSMInPort
+   * @brief SSMInPort class
+   *
+   * 
+   *
+   * @since 2.0.0
+   *
+   * @endif
+   */
+  class SSMInPort
+    : public OutPortConsumer
+  {
+  public:
+    /*!
+     * @if jp
+     * @brief コンストラクタ
+     *
+     * コンストラクタ
+     *
+     * @else
+     * @brief Constructor
+     *
+     * Constructor
+     *
+     * @endif
+     */
+    SSMInPort(void);
+    
+    /*!
+     * @if jp
+     * @brief デストラクタ
+     *
+     * デストラクタ
+     *
+     * @else
+     * @brief Destructor
+     *
+     * Destructor
+     *
+     * @endif
+     */
+    ~SSMInPort(void) override;
+
+    /*!
+     * @if jp
+     * @brief 設定初期化
+     *
+     * SSMInPort の各種設定を行う。与えられた
+     * Propertiesから必要な情報を取得して各種設定を行う。この init() 関
+     * 数は、InPortProvider生成直後および、接続時にそれぞれ呼ばれる可
+     * 能性がある。したがって、この関数は複数回呼ばれることを想定して記
+     * 述されるべきである。
+     * 
+     * @param prop 設定情報
+     *
+     * @else
+     *
+     * @brief Initializing configuration
+     *
+     * This operation would be called to configure in initialization.
+     * In the concrete class, configuration should be performed
+     * getting appropriate information from the given Properties data.
+     * This function might be called right after instantiation and
+     * connection sequence respectivly.  Therefore, this function
+     * should be implemented assuming multiple call.
+     *
+     * @param prop Configuration information
+     *
+     * @endif
+     */
+    void init(coil::Properties& prop) override;
+
+    /*!
+     * @if jp
+     * @brief バッファをセットする
+     *
+     * OutPortProvider がデータを取り出すバッファをセットする。
+     * すでにセットされたバッファがある場合、以前のバッファへの
+     * ポインタに対して上書きされる。
+     * OutPortProviderはバッファの所有権を仮定していないので、
+     * バッファの削除はユーザの責任で行わなければならない。
+     *
+     * @param buffer OutPortProviderがデータを取り出すバッファへのポインタ
+     *
+     * @else
+     * @brief Setting outside buffer's pointer
+     *
+     * A pointer to a buffer from which OutPortProvider retrieve data.
+     * If already buffer is set, previous buffer's pointer will be
+     * overwritten by the given pointer to a buffer.  Since
+     * OutPortProvider does not assume ownership of the buffer
+     * pointer, destructor of the buffer should be done by user.
+     * 
+     * @param buffer A pointer to a data buffer to be used by OutPortProvider
+     *
+     * @endif
+     */
+    void setBuffer(CdrBufferBase* buffer) override;
+
+    /*!
+     * @if jp
+     * @brief リスナを設定する。
+     *
+     * InPort はデータ送信処理における各種イベントに対して特定のリスナ
+     * オブジェクトをコールするコールバック機構を提供する。詳細は
+     * ConnectorListener.h の ConnectorDataListener, ConnectorListener
+     * 等を参照のこと。SSMInPort では、以下のコールバック
+     * が提供される。
+     * 
+     * - ON_BUFFER_WRITE
+     * - ON_BUFFER_FULL
+     * - ON_BUFFER_WRITE_TIMEOUT
+     * - ON_BUFFER_OVERWRITE
+     * - ON_RECEIVED
+     * - ON_RECEIVER_FULL
+     * - ON_RECEIVER_FULL
+     * - ON_RECEIVER_TIMEOUT
+     * - ON_RECEIVER_ERROR
+     *
+     * @param info 接続情報
+     * @param listeners リスナオブジェクト
+     *
+     * @else
+     * @brief Set the listener. 
+     *
+     * InPort provides callback functionality that calls specific
+     * listener objects according to the events in the data publishing
+     * process. For details, see documentation of
+     * ConnectorDataListener class and ConnectorListener class in
+     * ConnectorListener.h. In this SSMInPort provides
+     * the following callbacks.
+     * 
+     * - ON_BUFFER_WRITE
+     * - ON_BUFFER_FULL
+     * - ON_BUFFER_WRITE_TIMEOUT
+     * - ON_BUFFER_OVERWRITE
+     * - ON_RECEIVED
+     * - ON_RECEIVER_FULL
+     * - ON_RECEIVER_FULL
+     * - ON_RECEIVER_TIMEOUT
+     * - ON_RECEIVER_ERROR
+     *
+     * @param info Connector information
+     * @param listeners Listener objects
+     *
+     * @endif
+     */
+    void setListener(ConnectorInfo& info,
+                             ConnectorListenersBase* listeners) override;
+
+    /*!
+     * @if jp
+     * @brief データを読み出す
+     *
+     * 設定されたデータを読み出す。
+     *
+     * @param data 読み出したデータを受け取るオブジェクト
+     *
+     * @return データ読み出し処理結果(読み出し成功:true、読み出し失敗:false)
+     *
+     * @else
+     * @brief Read data
+     *
+     * Read set data
+     *
+     * @param data Object to receive the read data
+     *
+     * @return Read result (Successful:true, Failed:false)
+     *
+     * @endif
+     */
+    DataPortStatus get(ByteData& data) override;
+
+    /*!
+     * @if jp
+     * @brief データ受信通知への登録
+     *
+     * 指定されたプロパティに基づいて、データ受信通知の受け取りに登録する。
+     *
+     * @param properties 登録情報
+     *
+     * @return 登録処理結果(登録成功:true、登録失敗:false)
+     *
+     * @else
+     * @brief Subscribe the data receive notification
+     *
+     * Subscribe the data receive notification based on specified property
+     * information
+     *
+     * @param properties Subscription information
+     *
+     * @return Subscription result (Successful:true, Failed:false)
+     *
+     * @endif
+     */
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
+
+    /*!
+     * @if jp
+     * @brief データ受信通知からの登録解除
+     *
+     * データ受信通知の受け取りから登録を解除する。
+     *
+     * @param properties 登録解除情報
+     *
+     * @else
+     * @brief Unsubscribe the data receive notification
+     *
+     * Unsubscribe the data receive notification.
+     *
+     * @param properties Unsubscription information
+     *
+     * @endif
+     */
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
+    
+  private:
+      /*!
+     * @if jp
+     * @brief リターンコード変換 (DataPortStatus -> BufferStatus)
+     * @else
+     * @brief Return codes conversion
+     * @endif
+     */
+    void convertReturnCode(DataPortStatus ret,
+                                              ByteData& data);
+    /*!
+     * @if jp
+     * @brief ON_BUFFER_WRITE のリスナへ通知する。
+     * @param data cdrMemoryStream
+     * @else
+     * @brief Notify an ON_BUFFER_WRITE event to listeners
+     * @param data cdrMemoryStream
+     * @endif
+     */
+    inline void onBufferWrite(ByteData& data)
+    {
+      m_listeners->notifyIn(ON_BUFFER_WRITE, m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_BUFFER_FULL のリスナへ通知する。
+     * @param data cdrMemoryStream
+     * @else
+     * @brief Notify an ON_BUFFER_FULL event to listeners
+     * @param data cdrMemoryStream
+     * @endif
+     */
+    inline void onBufferFull(ByteData& data)
+    {
+      m_listeners->notifyIn(ON_BUFFER_FULL, m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_RECEIVED のリスナへ通知する。
+     * @param data cdrMemoryStream
+     * @else
+     * @brief Notify an ON_RECEIVED event to listeners
+     * @param data cdrMemoryStream
+     * @endif
+     */
+    inline void onReceived(ByteData& data)
+    {
+      m_listeners->notifyIn(ON_RECEIVED, m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_RECEIVER_FULL のリスナへ通知する。
+     * @param data cdrMemoryStream
+     * @else
+     * @brief Notify an ON_RECEIVER_FULL event to listeners
+     * @param data cdrMemoryStream
+     * @endif
+     */
+    inline void onReceiverFull(ByteData& data)
+    {
+      m_listeners->notifyIn(ON_RECEIVER_FULL, m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_SENDER_EMPTYのリスナへ通知する。
+     * @else
+     * @brief Notify an ON_SENDER_EMPTY event to listeners
+     * @endif
+     */
+    inline void onSenderEmpty()
+    {
+      m_listeners->notify(ON_SENDER_EMPTY, m_profile);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_SENDER_TIMEOUT のリスナへ通知する。
+     * @else
+     * @brief Notify an ON_SENDER_TIMEOUT event to listeners
+     * @endif
+     */
+    inline void onSenderTimeout()
+    {
+      m_listeners->notify(ON_SENDER_TIMEOUT, m_profile);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_SENDER_ERRORのリスナへ通知する。
+     * @else
+     * @Brief Notify an ON_SENDER_ERROR event to listeners
+     * @endif
+     */
+    inline void onSenderError()
+    {
+      m_listeners->notify(ON_SENDER_ERROR, m_profile);
+    }
+  private:
+
+
+    CdrBufferBase* m_buffer;
+    ConnectorListenersBase* m_listeners;
+    ConnectorInfo m_profile;
+
+    std::mutex m_mutex;
+
+    SSM_sid m_sens_sid;
+    std::string m_stream_name;
+    int m_stream_id;
+
+
+  };  // class InPortCorCdrbaProvider
+
+
+
+} // namespace RTC
+
+
+
+#endif // RTC_FASTRTPSINPORT_H
+

--- a/src/ext/transport/SSMTransport/SSMOutPort.cpp
+++ b/src/ext/transport/SSMTransport/SSMOutPort.cpp
@@ -65,25 +65,24 @@ namespace RTC
   void SSMOutPort::init(coil::Properties& prop)
   { 
     RTC_PARANOID(("SSMOutPort::init()"));
-    std::cout << "prop:" << prop << std::endl;
     
-    m_stream_name = prop.getProperty("stream_name", "sensor_test");
+    m_stream_name = prop.getProperty("ssm.stream_name", "sensor_test");
     std::string stream_id_str = prop.getProperty("stream_id", "0");
     if(!coil::stringTo(m_stream_id, stream_id_str.c_str()))
     {
       RTC_ERROR(("stream_id is invalid value"));
     }
-    std::string stream_size_str = prop.getProperty("stream_size", "0");
+    std::string stream_size_str = prop.getProperty("ssm.stream_size", "0");
     if(!coil::stringTo(m_stream_size, stream_size_str.c_str()))
     {
       RTC_ERROR(("stream_size is invalid value"));
     }
-    std::string life_ssm_time_str = prop.getProperty("life_ssm_time", "5.0");
+    std::string life_ssm_time_str = prop.getProperty("ssm.life_ssm_time", "5.0");
     if(!coil::stringTo(m_life_ssm_time, life_ssm_time_str.c_str()))
     {
       RTC_ERROR(("life_ssm_time is invalid value"));
     }
-    std::string cycle_ssm_time_str = prop.getProperty("cycle_ssm_time", "0.05");
+    std::string cycle_ssm_time_str = prop.getProperty("ssm.cycle_ssm_time", "0.05");
     if(!coil::stringTo(m_cycle_ssm_time, cycle_ssm_time_str.c_str()))
     {
       RTC_ERROR(("cycle_ssm_time is invalid value"));

--- a/src/ext/transport/SSMTransport/SSMOutPort.cpp
+++ b/src/ext/transport/SSMTransport/SSMOutPort.cpp
@@ -1,0 +1,166 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  SSMOutPort.cpp
+ * @brief SSMOutPort class
+ * @date  $Date: 2020-03-10 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2020
+ *     Nobuhiko Miyamoto
+ *     Robot Innovation Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#include <rtm/NVUtil.h>
+#include <coil/UUID.h>
+#include "SSMOutPort.h"
+
+
+
+namespace RTC
+{
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   * @else
+   * @brief Constructor
+   * @param buffer The buffer object that is attached to this Consumer
+   * @endif
+   */
+  SSMOutPort::SSMOutPort(void)
+    : rtclog("SSMOutPort"),
+      m_sens_sid(nullptr),
+      m_stream_id(0),
+      m_stream_size(0),
+      m_life_ssm_time(5.0),
+      m_cycle_ssm_time(0.05)
+  {
+  }
+  
+  /*!
+   * @if jp
+   * @brief デストラクタ
+   * @else
+   * @brief Destructor
+   * @endif
+   */
+  SSMOutPort::~SSMOutPort(void)
+  {
+    RTC_PARANOID(("~SSMOutPort()"));
+    
+  }
+
+  /*!
+   * @if jp
+   * @brief 設定初期化
+   * @else
+   * @brief Initializing configuration
+   * @endif
+   */
+  void SSMOutPort::init(coil::Properties& prop)
+  { 
+    RTC_PARANOID(("SSMOutPort::init()"));
+    std::cout << "prop:" << prop << std::endl;
+    
+    m_stream_name = prop.getProperty("stream_name", "sensor_test");
+    std::string stream_id_str = prop.getProperty("stream_id", "0");
+    if(!coil::stringTo(m_stream_id, stream_id_str.c_str()))
+    {
+      RTC_ERROR(("stream_id is invalid value"));
+    }
+    std::string stream_size_str = prop.getProperty("stream_size", "0");
+    if(!coil::stringTo(m_stream_size, stream_size_str.c_str()))
+    {
+      RTC_ERROR(("stream_size is invalid value"));
+    }
+    std::string life_ssm_time_str = prop.getProperty("life_ssm_time", "5.0");
+    if(!coil::stringTo(m_life_ssm_time, life_ssm_time_str.c_str()))
+    {
+      RTC_ERROR(("life_ssm_time is invalid value"));
+    }
+    std::string cycle_ssm_time_str = prop.getProperty("cycle_ssm_time", "0.05");
+    if(!coil::stringTo(m_cycle_ssm_time, cycle_ssm_time_str.c_str()))
+    {
+      RTC_ERROR(("cycle_ssm_time is invalid value"));
+    }
+
+  }
+
+  /*!
+   * @if jp
+   * @brief バッファへのデータ書込
+   * @else
+   * @brief Write data into the buffer
+   * @endif
+   */
+  DataPortStatus SSMOutPort::put(ByteData& data)
+  {
+    RTC_PARANOID(("put()"));
+    RTC_VERBOSE(("Data size:%d", data.getDataLength()));
+    std::lock_guard<std::mutex> guard(m_mutex);
+    if(m_sens_sid == nullptr)
+    {
+      m_sens_sid = createSSM_time(m_stream_name.c_str(), m_stream_id, data.getDataLength(), m_life_ssm_time, m_cycle_ssm_time);
+      if(m_sens_sid == nullptr)
+      {
+        return DataPortStatus::PRECONDITION_NOT_MET;
+      }
+    }
+    ssmTimeT measured_time;
+    writeSSM(m_sens_sid, reinterpret_cast<char*>(data.getBuffer()), measured_time);
+    return DataPortStatus::PORT_OK;
+    
+  }
+
+  /*!
+   * @if jp
+   * @brief InterfaceProfile情報を公開する
+   * @else
+   * @brief Publish InterfaceProfile information
+   * @endif
+   */
+  void SSMOutPort::
+  publishInterfaceProfile(SDOPackage::NVList& /*properties*/)
+  {
+    return;
+  }
+
+  /*!
+   * @if jp
+   * @brief データ送信通知への登録
+   * @else
+   * @brief Subscribe to the data sending notification
+   * @endif
+   */
+  bool SSMOutPort::
+  subscribeInterface(const SDOPackage::NVList& properties)
+  {
+    RTC_TRACE(("subscribeInterface()"));
+    RTC_DEBUG_STR((NVUtil::toString(properties)));
+    
+    
+    return true;
+  }
+  
+  /*!
+   * @if jp
+   * @brief データ送信通知からの登録解除
+   * @else
+   * @brief Unsubscribe the data send notification
+   * @endif
+   */
+  void SSMOutPort::
+  unsubscribeInterface(const SDOPackage::NVList& properties)
+  {
+    RTC_TRACE(("unsubscribeInterface()"));
+    RTC_DEBUG_STR((NVUtil::toString(properties)));
+
+    releaseSSM(&m_sens_sid);
+  }
+  
+} // namespace RTC

--- a/src/ext/transport/SSMTransport/SSMOutPort.cpp
+++ b/src/ext/transport/SSMTransport/SSMOutPort.cpp
@@ -88,6 +88,11 @@ namespace RTC
       RTC_ERROR(("cycle_ssm_time is invalid value"));
     }
 
+    if(m_stream_size > 0)
+    {
+      m_sens_sid = createSSM_time(m_stream_name.c_str(), m_stream_id, m_stream_size, m_life_ssm_time, m_cycle_ssm_time);
+    }
+
   }
 
   /*!

--- a/src/ext/transport/SSMTransport/SSMOutPort.cpp
+++ b/src/ext/transport/SSMTransport/SSMOutPort.cpp
@@ -115,7 +115,7 @@ namespace RTC
         return DataPortStatus::PRECONDITION_NOT_MET;
       }
     }
-    ssmTimeT measured_time;
+    ssmTimeT measured_time = 0;
     writeSSM(m_sens_sid, reinterpret_cast<char*>(data.getBuffer()), measured_time);
     return DataPortStatus::PORT_OK;
     

--- a/src/ext/transport/SSMTransport/SSMOutPort.h
+++ b/src/ext/transport/SSMTransport/SSMOutPort.h
@@ -1,0 +1,249 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  SSMOutPort.h
+ * @brief SSMOutPort class
+ * @date  $Date: 2020-03-10 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2020
+ *     Nobuhiko Miyamoto
+ *     Robot Innovation Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#ifndef RTC_SSMOUTPORT_H
+#define RTC_SSMOUTPORT_H
+
+
+
+#include <map>
+#include <rtm/InPortConsumer.h>
+#include <rtm/Manager.h>
+#include <ssm.h>
+
+
+
+namespace RTC
+{
+  /*!
+   * @if jp
+   * @class SSMOutPort
+   * @brief SSMOutPort クラス
+   *
+   * InPortConsumer 
+   *
+   * データ転送に SSM(Streaming data Sharing Manager) の 共有メモリを利用
+   * した、pull 型データフロー型を実現する InPort コンシューマクラス。
+   *
+   * @since 2.0.0
+   *
+   * @else
+   * @class SSMOutPort
+   * @brief SSMOutPort class
+   *
+   * The InPort consumer class which uses the shared memory
+   * in SSM for data transfer and realizes a pull-type
+   * dataflow.
+   *
+   * @since 2.0.0
+   *
+   * @endif
+   */
+  class SSMOutPort
+    : public InPortConsumer
+  {
+  public:
+    /*!
+     * @if jp
+     * @brief コンストラクタ
+     *
+     * コンストラクタ
+     *
+     * @param buffer 当該コンシューマに割り当てるバッファオブジェクト
+     *
+     * @else
+     * @brief Constructor
+     *
+     * Constructor
+     *
+     * @param buffer The buffer object that is attached to this Consumer
+     *
+     * @endif
+     */
+    SSMOutPort(void);
+    
+    /*!
+     * @if jp
+     * @brief デストラクタ
+     *
+     * デストラクタ
+     *
+     * @else
+     * @brief Destructor
+     *
+     * Destructor
+     *
+     * @endif
+     */
+    ~SSMOutPort(void) override;
+
+    /*!
+     * @if jp
+     * @brief 設定初期化
+     *
+     * InPortConsumerの各種設定を行う。実装クラスでは、与えられた
+     * Propertiesから必要な情報を取得して各種設定を行う。この init() 関
+     * 数は、InPortProvider生成直後および、接続時にそれぞれ呼ばれる可
+     * 能性がある。したがって、この関数は複数回呼ばれることを想定して記
+     * 述されるべきである。
+     * 
+     * @param prop 設定情報
+     *
+     * @else
+     *
+     * @brief Initializing configuration
+     *
+     * This operation would be called to configure in initialization.
+     * In the concrete class, configuration should be performed
+     * getting appropriate information from the given Properties data.
+     * This function might be called right after instantiation and
+     * connection sequence respectivly.  Therefore, this function
+     * should be implemented assuming multiple call.
+     *
+     * @param prop Configuration information
+     *
+     * @endif
+     */
+    void init(coil::Properties& prop) override;
+
+    /*!
+     * @if jp
+     * @brief 接続先へのデータ送信
+     *
+     * 接続先のポートへデータを送信するための純粋仮想関数。
+     * 
+     * この関数は、以下のリターンコードを返す。
+     *
+     * - PORT_OK:       正常終了。
+     * - PORT_ERROR:    データ送信の過程で何らかのエラーが発生した。
+     * - SEND_FULL:     データを送信したが、相手側バッファがフルだった。
+     * - SEND_TIMEOUT:  データを送信したが、相手側バッファがタイムアウトした。
+     * - UNKNOWN_ERROR: 原因不明のエラー
+     *
+     * @param data 送信するデータ
+     * @return リターンコード
+     *
+     * @else
+     * @brief Send data to the destination port
+     *
+     * Pure virtual function to send data to the destination port.
+     *
+     * This function might the following return codes
+     *
+     * - PORT_OK:       Normal return
+     * - PORT_ERROR:    Error occurred in data transfer process
+     * - SEND_FULL:     Buffer full although OutPort tried to send data
+     * - SEND_TIMEOUT:  Timeout although OutPort tried to send data
+     * - UNKNOWN_ERROR: Unknown error
+     *
+     * @endif
+     */
+    DataPortStatus put(ByteData& data) override;
+
+    /*!
+     * @if jp
+     * @brief InterfaceProfile情報を公開する
+     *
+     * InterfaceProfile情報を公開する。
+     * 引数で指定するプロパティ情報内の NameValue オブジェクトの
+     * dataport.interface_type 値を調べ、当該ポートに設定されている
+     * インターフェースタイプと一致する場合のみ情報を取得する。
+     *
+     * @param properties InterfaceProfile情報を受け取るプロパティ
+     *
+     * @else
+     * @brief Publish InterfaceProfile information
+     *
+     * Publish interfaceProfile information.
+     * Check the dataport.interface_type value of the NameValue object 
+     * specified by an argument in property information and get information
+     * only when the interface type of the specified port is matched.
+     *
+     * @param properties Properties to get InterfaceProfile information
+     *
+     * @endif
+     */
+    void publishInterfaceProfile(SDOPackage::NVList& properties) override;
+
+    /*!
+     * @if jp
+     * @brief データ送信通知への登録
+     *
+     * 指定されたプロパティに基づいて、データ送出通知の受け取りに登録する。
+     *
+     * @param properties 登録情報
+     *
+     * @return 登録処理結果(登録成功:true、登録失敗:false)
+     *
+     * @else
+     * @brief Subscribe to the data sending notification
+     *
+     * Subscribe to the data sending notification based on specified 
+     * property information.
+     *
+     * @param properties Information for subscription
+     *
+     * @return Subscription result (Successful:true, Failed:false)
+     *
+     * @endif
+     */
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
+    
+    /*!
+     * @if jp
+     * @brief データ送信通知からの登録解除
+     *
+     * データ送出通知の受け取りから登録を解除する。
+     *
+     * @param properties 登録解除情報
+     *
+     * @else
+     * @brief Unsubscribe the data send notification
+     *
+     * Unsubscribe the data send notification.
+     *
+     * @param properties Information for unsubscription
+     *
+     * @endif
+     */
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
+
+
+
+  private:
+
+    mutable Logger rtclog;
+    coil::Properties m_properties;
+    
+    std::mutex m_mutex;
+
+    SSM_sid m_sens_sid;
+    std::string m_stream_name;
+    int m_stream_id;
+    size_t m_stream_size;
+    ssmTimeT m_life_ssm_time;
+    ssmTimeT m_cycle_ssm_time;
+
+
+  };
+} // namespace RTC
+
+
+
+#endif // RTC_FASTRTPSOUTPORT_H
+

--- a/src/ext/transport/SSMTransport/SSMTransport.cpp
+++ b/src/ext/transport/SSMTransport/SSMTransport.cpp
@@ -1,0 +1,102 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  SSMOutPort.cpp
+ * @brief SSMOutPort class
+ * @date  $Date: 2020-03-10 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2020
+ *     Nobuhiko Miyamoto
+ *     Robot Innovation Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+
+#include <ssm.h>
+#include "SSMTransport.h"
+#include "SSMOutPort.h"
+#include "SSMInPort.h"
+
+namespace SSMRTM
+{
+
+  ManagerActionListener::ManagerActionListener()
+  {
+
+  }
+  ManagerActionListener::~ManagerActionListener()
+  {
+
+  }
+  void ManagerActionListener::preShutdown()
+  {
+
+  }
+  void ManagerActionListener::postShutdown()
+  {
+    endSSM();
+  }
+  void ManagerActionListener::postReinit()
+  {
+
+  }
+
+  void ManagerActionListener::preReinit()
+  {
+
+  }
+
+}
+
+
+
+
+extern "C"
+{
+  /*!
+   * @if jp
+   * @brief モジュール初期化関数
+   * @else
+   * @brief Module initialization
+   * @endif
+   */
+  void SSMTransportInit(RTC::Manager* manager)
+  {
+    if(!initSSM())
+    {
+      return;
+    }
+
+    {
+      RTC::OutPortConsumerFactory& factory(RTC::OutPortConsumerFactory::instance());
+      factory.addFactory("ssm",
+                        ::coil::Creator< ::RTC::OutPortConsumer,
+                                          ::RTC::SSMInPort>,
+                        ::coil::Destructor< ::RTC::OutPortConsumer,
+                                            ::RTC::SSMInPort>);
+    }
+
+    {
+      RTC::InPortConsumerFactory& factory(RTC::InPortConsumerFactory::instance());
+      factory.addFactory("ssm",
+                        ::coil::Creator< ::RTC::InPortConsumer,
+                                          ::RTC::SSMOutPort>,
+                        ::coil::Destructor< ::RTC::InPortConsumer,
+                                            ::RTC::SSMOutPort>);
+    }
+
+
+
+    SSMRTM::ManagerActionListener *listener = new SSMRTM::ManagerActionListener();
+    manager->addManagerActionListener(listener);
+    
+  }
+  
+}
+
+

--- a/src/ext/transport/SSMTransport/SSMTransport.h
+++ b/src/ext/transport/SSMTransport/SSMTransport.h
@@ -1,0 +1,61 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  SSMTransport.h
+ * @brief SSMTransport class
+ * @date  $Date: 2020-03-11 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2020
+ *     Nobuhiko Miyamoto
+ *     Robot Innovation Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#ifndef RTC_SSMTRANSPORT_H
+#define RTC_SSMTRANSPORT_H
+
+
+
+#include <rtm/Manager.h>
+
+
+namespace SSMRTM
+{
+  class ManagerActionListener : public RTM::ManagerActionListener
+  {
+  public:
+      ManagerActionListener();
+      ~ManagerActionListener() override;
+      void preShutdown() override;
+      void postShutdown() override;
+      void postReinit() override;
+      void preReinit() override;
+  };
+}
+
+
+extern "C"
+{
+  /*!
+   * @if jp
+   * @brief モジュール初期化関数
+   *
+   * SSMOutPort、SSMInPort のファクトリを登録する初期化関数。
+   *
+   * @else
+   * @brief Module initialization
+   *
+   * 
+   *
+   * @endif
+   */
+  DLL_EXPORT void SSMTransportInit(RTC::Manager* manager);
+}
+
+#endif // RTC_SSMTRANSPORT_H
+


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

## Description of the Change
SSM(Streaming data Sharing Manager)を使用した共有メモリによるデータ転送のためのインターフェース型を実装した。

- https://github.com/sitRyo/Distributed-Streaming-data-Sharing-Manager
- https://www.roboken.iit.tsukuba.ac.jp/platform/wiki/ssm/index

以下の手順でビルドする。

```
git clone https://github.com/sitRyo/Distributed-Streaming-data-Sharing-Manager
cd Distributed-Streaming-data-Sharing-Manager
autoreconf -i -f
./configure
make
sudo make install

cd ..
git clone -b feature/SSMTransport https://github.com/Nobu19800/OpenRTM-aist
cd OpenRTM-aist
mkdir build
cd build
cmake -DSSM_ENABLE=ON -DCMAKE_BUILD_TYPE=Release ..
cmake --build . --config Release -- -j$(nproc)
```

以下のようなrtc.confを作成してRTCを起動する。InPort側をpush型、OutPort側をpull型のデータフロー型に設定する。

```
manager.modules.load_path: /usr/local/share/openrtm-2.0/components/c++/examples/rtc, /usr/local/lib/openrtm-2.0/transport
manager.modules.preload: ConsoleOut.so, SSMTransport.so
manager.components.precreate: ConsoleOut
manager.components.preactivation: ConsoleIn0, ConsoleOut0
manager.components.preconnect: ConsoleIn0.out?port=ConsoleOut0.in&inport.dataflow_type=pull&outport.dataflow_type=push&interface_type=ssm
```

ssm登録名、ssm登録番号、センサデータの保持時間、データの更新周期はコネクタ接続時に設定する。

```
manager.components.preconnect: ConsoleIn0.out?port=ConsoleOut0.in&inport.dataflow_type=pull&outport.dataflow_type=push&interface_type=ssm&ssm.stream_name=sensor_test&ssm.stream_id=1&ssm.life_ssm_time=5.0&ssm.cycle_ssm_time=0.05
```

- ssm.stream_name(ssm登録名)
- ssm.stream_id(ssm登録番号)
- ssm.life_ssm_time(センサデータの保持時間)
- ssm.cycle_ssm_time(データの更新周期)


共有メモリのサイズは最初に送信したデータのサイズに固定されるためデフォルトでは可変サイズのデータは送信できないが、以下のようにコネクタプロファイルで大きめのサイズを設定する事で対応できる。
```
ssm.stream_size=10000
```

実行前に`ssm-coordinator`を起動する。

```
ssm-coordinator
```


- OutPortコネクタをpush型、InPortコネクタをpull型に設定する必要があるが、SSMはreadNew関数で新規データ書き込みを検知できるため原理的にはOutPortのisNew関数を使用できる。
機能拡張のためにはOpenRTM-aistのisNew関数の拡張が必要。

- RTC同士の通信であればCDR形式のバイト列の通信で問題ないが、それ以外のSSMを使用したアプリケーションと通信する場合は独自シリアライザの実装が必要

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
