### PR TITLE
DockerfileのROSTransportビルドに関する設定の修正

### DIFF
--- a/scripts/ubuntu_1804/Dockerfile.devel-rtm
+++ b/scripts/ubuntu_1804/Dockerfile.devel-rtm
@@ -63,7 +63,7 @@ ENV ROS_DISTRO=melodic
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list'\
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654\
  && apt-get update\
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ros-${ROS_DISTRO}-ros-base\
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ros-${ROS_DISTRO}-ros-base python-rosdep\
  && apt-get clean\
  && rm -rf /var/lib/apt/lists/*\
  && rosdep init\


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

## Description of the Change

2020年3月18日ごろから`ros-melodic-ros-base`や`ros-melodic-desktop-full`をインストールしてもrosdepが入らなくなったようなので`python-rosdep`をインストールするように変更した。rosdepが入らなくなった理由は不明。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
