### PR TITLE
ROS2のインストールの設定でアーキテクチャの指定している箇所を削除

### DIFF
--- a/scripts/ubuntu_1804/Dockerfile.devel-rtm
+++ b/scripts/ubuntu_1804/Dockerfile.devel-rtm
@@ -52,7 +52,7 @@ ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
 RUN apt-get update\
  && apt-get install -y --no-install-recommends curl gnupg2\
  && curl http://repo.ros2.org/repos.key | apt-key add -\
- && sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main bionic main" > /etc/apt/sources.list.d/ros2-latest.list'\
+ && sh -c 'echo "deb http://repo.ros2.org/ubuntu/main bionic main" > /etc/apt/sources.list.d/ros2-latest.list'\
  && apt-get update\
  && DEBIAN_FRONTEND=noninteractive apt-get -y install ros-${ROS_DISTRO}-ros-core\
  && apt-get clean\


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change



`Dockerfile.devel-rtm`で以下のようにROS2のリポジトリの設定でアーキテクチャを指定している(`[arch=amd64,arm64]`)が、不要のため削除した。

```
echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main bionic main" > /etc/apt/sources.list.d/ros2-latest.list
```





## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
