### PR TITLE
serializer_typeをmarshaling_typesに変更

### DIFF
--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -129,12 +129,12 @@ namespace RTC
 
       CdrMemoryStreamInit<DataType>();
 
-      std::string serializer_types{coil::eraseBlank(coil::flatten(
+      std::string marshaling_types{coil::eraseBlank(coil::flatten(
         getSerializerList<DataType>()))};
 
-      RTC_DEBUG(("available serializer_types: %s", serializer_types.c_str()));
+      RTC_DEBUG(("available marshaling_types: %s", marshaling_types.c_str()));
 
-      addProperty("dataport.serializer_type", serializer_types.c_str());
+      addProperty("dataport.marshaling_types", marshaling_types.c_str());
     }
 
     /*!

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -117,12 +117,12 @@ namespace RTC
 
       CdrMemoryStreamInit<DataType>();
 
-      std::string serializer_types{coil::eraseBlank(coil::flatten(
+      std::string marshaling_types{coil::eraseBlank(coil::flatten(
         getSerializerList<DataType>()))};
 
-      RTC_DEBUG(("available serializer_types: %s", serializer_types.c_str()));
+      RTC_DEBUG(("available marshaling_types: %s", marshaling_types.c_str()));
 
-      addProperty("dataport.serializer_type", serializer_types.c_str());
+      addProperty("dataport.marshaling_types", marshaling_types.c_str());
     }
 
     /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug


## Description of the Change

ポートプロファイルにはシリアライザ一覧を`serializer_type`という名前で格納していたが、これがコネクタ接続時の`marshaling_type`と紛らわしいため、ポートプロファイルのシリアライザ一覧のキーを`marshaling_types`に変更した。

ポートプロファイルのプロパティを出力すると以下のようになる。

```
- port
  - port_type: DataInPort
- dataport
  - data_type: IDL:RTC/TimedDouble:1.0
  - marshaling_types: corba, corba:RTC/TimedShort:RTC/TimedDouble
  - subscription_type: Any
  - dataflow_type: push, pull, duplex
  - interface_type: corba_cdr, csp_channel, data_service, direct, shared_memory
- data_type: IDL:RTC/TimedDouble:1.0
```

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
