### PR TITLE
in.marshaling_typeとout.marshaling_typeのパラメータでのシリアライザ設定機能を削除

### DIFF
--- a/examples/Serializer/ShortToDoubleSerializer.cpp
+++ b/examples/Serializer/ShortToDoubleSerializer.cpp
@@ -37,7 +37,7 @@ extern "C"
     DLL_EXPORT void ShortToDoubleSerializerInit(RTC::Manager* /*manager*/)
     {
         //以下のファクトリはデータ型ごとに登録する必要がある
-        RTC::addSerializer<RTC::TimedDouble, ShortToDoubleSerializer>("corba:RTC/TimedShort:RTC/TimedDouble");
+        RTC::addSerializer<RTC::TimedDouble, ShortToDoubleSerializer>("cdr:RTC/TimedShort:RTC/TimedDouble");
         //addSerializer関数の第1引数で登録名を設定。以下で独自シリアライザを利用するときはこの名前を使用する。
     }
 }

--- a/examples/Serializer/rtc.serializer.conf
+++ b/examples/Serializer/rtc.serializer.conf
@@ -6,5 +6,5 @@ logger.log_level: ERROR
 manager.modules.load_path: .
 manager.modules.preload: ConsoleOutDouble, ShortToDoubleSerializer
 manager.components.precreate: ConsoleOutDouble
-manager.components.preconnect: ConsoleOutDouble0.in?port=ConsoleInShort0.out&in.marshaling_type=corba:RTC/TimedShort:RTC/TimedDouble&out.marshaling_type=corba
+manager.components.preconnect: ConsoleOutDouble0.in?port=ConsoleInShort0.out&in.marshaling_type=cdr:RTC/TimedShort:RTC/TimedDouble&out.marshaling_type=cdr
 manager.components.preactivation: ConsoleOutDouble0, ConsoleInShort0

--- a/examples/Serializer/rtc.serializer.conf
+++ b/examples/Serializer/rtc.serializer.conf
@@ -6,5 +6,5 @@ logger.log_level: ERROR
 manager.modules.load_path: .
 manager.modules.preload: ConsoleOutDouble, ShortToDoubleSerializer
 manager.components.precreate: ConsoleOutDouble
-manager.components.preconnect: ConsoleOutDouble0.in?port=ConsoleInShort0.out&in.marshaling_type=cdr:RTC/TimedShort:RTC/TimedDouble&out.marshaling_type=cdr
+manager.components.preconnect: ConsoleOutDouble0.in?port=ConsoleInShort0.out&inport.marshaling_type=cdr:RTC/TimedShort:RTC/TimedDouble&outport.marshaling_type=cdr
 manager.components.preactivation: ConsoleOutDouble0, ConsoleInShort0

--- a/src/lib/rtm/CORBA_CdrMemoryStream.h
+++ b/src/lib/rtm/CORBA_CdrMemoryStream.h
@@ -649,7 +649,7 @@ namespace RTC
 template <class DataType>
 void CdrMemoryStreamInit()
 {
-    ::RTC::addSerializer<DataType, ::RTC::CORBA_CdrSerializer<DataType>>("corba");
+    ::RTC::addSerializer<DataType, ::RTC::CORBA_CdrSerializer<DataType>>("cdr");
 }
 
 

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -129,7 +129,7 @@ namespace RTC
   {
       std::string type = info.properties.getProperty("marshaling_type", "cdr");
       std::string marshaling_type{ coil::eraseBothEndsBlank(
-        info.properties.getProperty("in.marshaling_type", type)) };
+        info.properties.getProperty("inport.marshaling_type", type)) };
       return notify(info, data, marshaling_type);
   }
 
@@ -137,7 +137,7 @@ namespace RTC
   {
       std::string type = info.properties.getProperty("marshaling_type", "cdr");
       std::string marshaling_type{ coil::eraseBothEndsBlank(
-        info.properties.getProperty("out.marshaling_type", type)) };
+        info.properties.getProperty("outport.marshaling_type", type)) };
       return notify(info, data, marshaling_type);
   }
 

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -127,7 +127,7 @@ namespace RTC
 
   ConnectorListenerHolder::ReturnCode ConnectorDataListenerHolder::notifyIn(ConnectorInfo& info, ByteData& data)
   {
-      std::string type = info.properties.getProperty("marshaling_type", "corba");
+      std::string type = info.properties.getProperty("marshaling_type", "cdr");
       std::string marshaling_type{ coil::eraseBothEndsBlank(
         info.properties.getProperty("in.marshaling_type", type)) };
       return notify(info, data, marshaling_type);
@@ -135,7 +135,7 @@ namespace RTC
 
   ConnectorListenerHolder::ReturnCode ConnectorDataListenerHolder::notifyOut(ConnectorInfo& info, ByteData& data)
   {
-      std::string type = info.properties.getProperty("marshaling_type", "corba");
+      std::string type = info.properties.getProperty("marshaling_type", "cdr");
       std::string marshaling_type{ coil::eraseBothEndsBlank(
         info.properties.getProperty("out.marshaling_type", type)) };
       return notify(info, data, marshaling_type);

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1107,7 +1107,7 @@ namespace RTC
     template <class DataType>
     ReturnCode notifyIn(ConnectorInfo& info, DataType& typeddata)
     {
-        std::string type = info.properties.getProperty("marshaling_type", "corba");
+        std::string type = info.properties.getProperty("marshaling_type", "cdr");
         std::string marshaling_type{coil::eraseBothEndsBlank(
           info.properties.getProperty("in.marshaling_type", type))};
         return notify(info, typeddata, marshaling_type);
@@ -1136,7 +1136,7 @@ namespace RTC
     template <class DataType>
     ReturnCode notifyOut(ConnectorInfo& info, DataType& typeddata)
     {
-        std::string type = info.properties.getProperty("marshaling_type", "corba");
+        std::string type = info.properties.getProperty("marshaling_type", "cdr");
         std::string marshaling_type{coil::eraseBothEndsBlank(
           info.properties.getProperty("out.marshaling_type", type))};
         return notify(info, typeddata, marshaling_type);
@@ -2025,7 +2025,7 @@ namespace RTC
        */
       ReturnCode notifyIn(ConnectorInfo& info, ByteData& data) override
       {
-          std::string type = info.properties.getProperty("marshaling_type", "corba");
+          std::string type = info.properties.getProperty("marshaling_type", "cdr");
           std::string marshaling_type{ coil::eraseBothEndsBlank(
             info.properties.getProperty("in.marshaling_type", type)) };
           return notify(info, data, marshaling_type);
@@ -2053,7 +2053,7 @@ namespace RTC
        */
       ReturnCode notifyOut(ConnectorInfo& info, ByteData& data) override
       {
-          std::string type = info.properties.getProperty("marshaling_type", "corba");
+          std::string type = info.properties.getProperty("marshaling_type", "cdr");
           std::string marshaling_type{ coil::eraseBothEndsBlank(
             info.properties.getProperty("out.marshaling_type", type)) };
           return notify(info, data, marshaling_type);

--- a/src/lib/rtm/ConnectorListener.h
+++ b/src/lib/rtm/ConnectorListener.h
@@ -1109,7 +1109,7 @@ namespace RTC
     {
         std::string type = info.properties.getProperty("marshaling_type", "cdr");
         std::string marshaling_type{coil::eraseBothEndsBlank(
-          info.properties.getProperty("in.marshaling_type", type))};
+          info.properties.getProperty("inport.marshaling_type", type))};
         return notify(info, typeddata, marshaling_type);
     }
 
@@ -1138,7 +1138,7 @@ namespace RTC
     {
         std::string type = info.properties.getProperty("marshaling_type", "cdr");
         std::string marshaling_type{coil::eraseBothEndsBlank(
-          info.properties.getProperty("out.marshaling_type", type))};
+          info.properties.getProperty("outport.marshaling_type", type))};
         return notify(info, typeddata, marshaling_type);
     }
     /*!
@@ -2027,7 +2027,7 @@ namespace RTC
       {
           std::string type = info.properties.getProperty("marshaling_type", "cdr");
           std::string marshaling_type{ coil::eraseBothEndsBlank(
-            info.properties.getProperty("in.marshaling_type", type)) };
+            info.properties.getProperty("inport.marshaling_type", type)) };
           return notify(info, data, marshaling_type);
       }
 
@@ -2055,7 +2055,7 @@ namespace RTC
       {
           std::string type = info.properties.getProperty("marshaling_type", "cdr");
           std::string marshaling_type{ coil::eraseBothEndsBlank(
-            info.properties.getProperty("out.marshaling_type", type)) };
+            info.properties.getProperty("outport.marshaling_type", type)) };
           return notify(info, data, marshaling_type);
       }
 

--- a/src/lib/rtm/InPortConnector.cpp
+++ b/src/lib/rtm/InPortConnector.cpp
@@ -33,7 +33,7 @@ namespace RTC
                                    ConnectorListenersBase* listeners,
                                    CdrBufferBase* buffer)
     : rtclog("InPortConnector"), m_profile(info),
-	m_listeners(listeners), m_buffer(buffer), m_littleEndian(true), m_outPortListeners(nullptr), m_directOutPort(nullptr), m_marshaling_type("corba"), m_cdr(nullptr)
+	m_listeners(listeners), m_buffer(buffer), m_littleEndian(true), m_outPortListeners(nullptr), m_directOutPort(nullptr), m_marshaling_type("cdr"), m_cdr(nullptr)
   {
   }
 

--- a/src/lib/rtm/InPortPullConnector.cpp
+++ b/src/lib/rtm/InPortPullConnector.cpp
@@ -51,7 +51,7 @@ namespace RTC
     m_consumer->setBuffer(m_buffer);
     m_consumer->setListener(info, m_listeners);
 
-    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
     m_marshaling_type = coil::eraseBothEndsBlank(
       info.properties.getProperty("in.marshaling_type", type));
 

--- a/src/lib/rtm/InPortPullConnector.cpp
+++ b/src/lib/rtm/InPortPullConnector.cpp
@@ -51,9 +51,8 @@ namespace RTC
     m_consumer->setBuffer(m_buffer);
     m_consumer->setListener(info, m_listeners);
 
-    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
     m_marshaling_type = coil::eraseBothEndsBlank(
-      info.properties.getProperty("in.marshaling_type", type));
+      info.properties.getProperty("marshaling_type", "cdr"));
 
     onConnect();
   }

--- a/src/lib/rtm/InPortPushConnector.cpp
+++ b/src/lib/rtm/InPortPushConnector.cpp
@@ -58,9 +58,8 @@ namespace RTC
         m_sync_readwrite = true;
     }
 
-    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
     m_marshaling_type = coil::eraseBothEndsBlank(
-      info.properties.getProperty("in.marshaling_type", type));
+      info.properties.getProperty("marshaling_type", "cdr"));
 
     onConnect();
   }

--- a/src/lib/rtm/InPortPushConnector.cpp
+++ b/src/lib/rtm/InPortPushConnector.cpp
@@ -58,7 +58,7 @@ namespace RTC
         m_sync_readwrite = true;
     }
 
-    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
     m_marshaling_type = coil::eraseBothEndsBlank(
       info.properties.getProperty("in.marshaling_type", type));
 

--- a/src/lib/rtm/OutPortConnector.cpp
+++ b/src/lib/rtm/OutPortConnector.cpp
@@ -32,7 +32,7 @@ namespace RTC
   OutPortConnector::OutPortConnector(ConnectorInfo& info,
                                      ConnectorListenersBase* listeners)
     : rtclog("OutPortConnector"), m_profile(info), m_littleEndian(true),
-	m_directInPort(nullptr), m_listeners(listeners), m_directMode(false), m_marshaling_type("corba"), m_cdr(nullptr)
+	m_directInPort(nullptr), m_listeners(listeners), m_directMode(false), m_marshaling_type("cdr"), m_cdr(nullptr)
   {
   }
 

--- a/src/lib/rtm/OutPortPullConnector.cpp
+++ b/src/lib/rtm/OutPortPullConnector.cpp
@@ -59,7 +59,7 @@ namespace RTC
         m_sync_readwrite = true;
     }
 
-    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
     m_marshaling_type = coil::eraseBothEndsBlank(
       info.properties.getProperty("out.marshaling_type", type));
 

--- a/src/lib/rtm/OutPortPullConnector.cpp
+++ b/src/lib/rtm/OutPortPullConnector.cpp
@@ -59,9 +59,8 @@ namespace RTC
         m_sync_readwrite = true;
     }
 
-    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
     m_marshaling_type = coil::eraseBothEndsBlank(
-      info.properties.getProperty("out.marshaling_type", type));
+      info.properties.getProperty("marshaling_type", "cdr"));
 
     onConnect();
   }

--- a/src/lib/rtm/OutPortPushConnector.cpp
+++ b/src/lib/rtm/OutPortPushConnector.cpp
@@ -60,8 +60,7 @@ namespace RTC
     m_publisher->setBuffer(m_buffer);
     m_publisher->setListener(m_profile, m_listeners);
 
-    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
-    m_marshaling_type = coil::eraseBothEndsBlank(info.properties.getProperty("out.marshaling_type", type));
+    m_marshaling_type = coil::eraseBothEndsBlank(info.properties.getProperty("marshaling_type", "cdr"));
 
     onConnect();
   }

--- a/src/lib/rtm/OutPortPushConnector.cpp
+++ b/src/lib/rtm/OutPortPushConnector.cpp
@@ -60,7 +60,7 @@ namespace RTC
     m_publisher->setBuffer(m_buffer);
     m_publisher->setListener(m_profile, m_listeners);
 
-    std::string type{info.properties.getProperty("marshaling_type", "corba")};
+    std::string type{info.properties.getProperty("marshaling_type", "cdr")};
     m_marshaling_type = coil::eraseBothEndsBlank(info.properties.getProperty("out.marshaling_type", type));
 
     onConnect();


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

InPort、OutPortで別のシリアライザ名を指定するためにコネクタ接続時にコネクタプロファイルで`in.marshaling_type`、`out.marshaling_type`というパラメータでシリアライザを指定できるようにしていたが、そもそも`dataport.inport.***`、`dataport.outport.***`で区別できるので上記のパラメータは不要である。


## Description of the Change

- `in.marshaling_type`、`out.marshaling_type`でシリアライザを設定している箇所をすべて削除。`inport.marshaling_type`、`outport.marshaling_type`に置き換え。
- シリアライザのサンプルを修正



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
