### PR TITLE
The key "manager.name" typo fixed

### DIFF
--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1254,7 +1254,7 @@ namespace RTM
         rtcd_cmd += " -o manager.is_master:NO";
         rtcd_cmd += " -o manager.corba_servant:YES";
         rtcd_cmd += " -o corba.master_manager:" + prop["corba.master_manager"];
-        rtcd_cmd += " -o manager.name:" + prop["manger.name"];
+        rtcd_cmd += " -o manager.name:" + prop["manager.name"];
         rtcd_cmd += " -o manager.instance_name:" + mgrstr;
         rtcd_cmd += " -o shutdown_auto:NO";
         rtcd_cmd += " -o manager.auto_shutdown_duration:50";


### PR DESCRIPTION
The key of property typo fixed.
prop["manger.name" -> prop["manager.name"]

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
