### PR TITLE
コネクタ接続時に指定のシリアライザが使用不可の場合にエラーにする

### DIFF
--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -504,6 +504,11 @@ namespace RTC
     RTC_DEBUG(("ConnectorProfile::properties are as follows."));
     RTC_DEBUG_STR((prop));
 
+    if (!isExistingMarshalingType(prop))
+    {
+        return RTC::RTC_ERROR;
+    }
+
     /*
      * ここで, ConnectorProfile からの properties がマージされたため、
      * prop["dataflow_type"]: データフロータイプ
@@ -583,6 +588,11 @@ namespace RTC
         return RTC::UNSUPPORTED;
       }
     RTC_TRACE(("endian: %s", littleEndian ? "little" : "big"));
+
+    if (!isExistingMarshalingType(prop))
+    {
+        return RTC::RTC_ERROR;
+    }
 
     /*
      * ここで, ConnectorProfile からの properties がマージされたため、

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -543,6 +543,11 @@ namespace RTC
     RTC_DEBUG(("ConnectorProfile::properties are as follows."));
     RTC_PARANOID_STR((prop));
 
+    if (!isExistingMarshalingType(prop))
+    {
+        return RTC::RTC_ERROR;
+    }
+
     /*
      * ここで, ConnectorProfile からの properties がマージされたため、
      * prop["dataflow_type"]: データフロータイプ
@@ -620,6 +625,11 @@ namespace RTC
         return RTC::UNSUPPORTED;
       }
     RTC_TRACE(("endian: %s", m_littleEndian ? "little":"big"));
+
+    if (!isExistingMarshalingType(prop))
+    {
+        return RTC::RTC_ERROR;
+    }
 
     /*
      * ここで, ConnectorProfile からの properties がマージされたため、

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -994,9 +994,9 @@ namespace RTC
   * @return ポートのポインタ
   *
   * @else
-  * @brief
+  * @brief Getting direct communication object
   *
-  * @return
+  * @return a pointer to the port
   *
   * @endif
   */
@@ -1011,16 +1011,15 @@ namespace RTC
    *
    * @brief 指定のシリアライザが使用可能かを判定する
    *
-   *
    * @param con_prop コネクタプロファイルのプロパティ
    * @return true：利用可能、false：利用不可
    *
    * @else
    *
-   * @brief
+   * @brief Whether the specified serializer can be used
    *
-   * @param con_prop
-   * @return
+   * @param con_prop Properties of ConnectorProfile
+   * @return ture: avaiable, false: un-available
    *
    * @endif
    */

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -1005,4 +1005,44 @@ namespace RTC
 	  return m_directport;
   }
 
+
+  /*!
+   * @if jp
+   *
+   * @brief 指定のシリアライザが使用可能かを判定する
+   *
+   *
+   * @param con_prop コネクタプロファイルのプロパティ
+   * @return true：利用可能、false：利用不可
+   *
+   * @else
+   *
+   * @brief
+   *
+   * @param con_prop
+   * @return
+   *
+   * @endif
+   */
+  bool PortBase::isExistingMarshalingType(coil::Properties& con_prop)
+  {
+      std::string marshaling_type{ coil::eraseBothEndsBlank(con_prop.getProperty("marshaling_type", "cdr")) };
+
+      Properties prop;
+      NVUtil::copyToProperties(prop, m_profile.properties);
+      coil::vstring enabledSerializerTypes{coil::split(prop["dataport.marshaling_types"], ",", true) };
+
+
+
+      coil::vstring::iterator it = std::find(enabledSerializerTypes.begin(), enabledSerializerTypes.end(), marshaling_type);
+      size_t index = std::distance(enabledSerializerTypes.begin(), it);
+      if (index == enabledSerializerTypes.size())
+      {
+          RTC_ERROR(("%s is illegal marshaling type.", marshaling_type.c_str()));
+          return false;
+      }
+      return true;
+
+  }
+
 } // namespace RTC

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -2051,6 +2051,25 @@ namespace RTC
     }
 
   protected:
+  /*!
+   * @if jp
+   *
+   * @brief 指定のシリアライザが使用可能かを判定する
+   *
+   *
+   * @param con_prop コネクタプロファイルのプロパティ
+   * @return true：利用可能、false：利用不可
+   *
+   * @else
+   *
+   * @brief 
+   *
+   * @param con_prop 
+   * @return 
+   *
+   * @endif
+   */
+    bool isExistingMarshalingType(coil::Properties& con_prop);
     /*!
      * @if jp
      * @brief ロガーストリーム

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -2062,10 +2062,10 @@ namespace RTC
    *
    * @else
    *
-   * @brief 
+   * @brief Whether the specified serializer can be used
    *
-   * @param con_prop 
-   * @return 
+   * @param con_prop Properties of Connectorprofile
+   * @return ture: avialable, false: un-available
    *
    * @endif
    */


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

現状、コネクタ接続時にファクトリに登録されていないシリアライザを指定した場合でも接続処理を続行する。


## Description of the Change

ポートプロファイルの`dataport.marshaling_types`で取得できるシリアライザの一覧に存在しないシリアライザを指定した場合はエラーにしてコネクタを切断するように変更した。
指定のシリアライザが使用可能かを判定する`isExistingMarshalingType`関数をPortBaseクラス追加した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
