### PR TITLE
DEBIAN_FRONTENDは環境変数ではなく変数で定義する

### DIFF
--- a/scripts/code_analysis/Dockerfile
+++ b/scripts/code_analysis/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 ARG CLANG_VAR=9
 
 RUN apt-get update\
- && apt-get install -y --no-install-recommends\
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends\
  clang-${CLANG_VAR}\
  ninja-build\
  cmake\

--- a/scripts/ubuntu_2004/Dockerfile
+++ b/scripts/ubuntu_2004/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update\
- && apt-get install -y --no-install-recommends\
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends\
  g++\
  make\
  cmake\


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Dockerfileの以下の箇所で`DEBIAN_FRONTEND`という環境変数を定義しているが、定義が必要なのはapt-get実行時みであり、それ以降は定義する必要はない。

https://github.com/OpenRTM/OpenRTM-aist/blob/e92ad8f887efb8b2692e6b105c746eecb53d0f92/scripts/ubuntu_2004/Dockerfile#L3

またcode_analysisのdockerfileもUbuntu 20.04を使用しているが、こちらにDEBIAN_FRONTENDが定義されていないため処理が途中で止まる。

## Description of the Change


`DEBIAN_FRONTEND`はapt-getの前で変数として定義した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
