### PR TITLE
Windows+Python3環境でOpenRTMConfig.cmakeが生成されるように修正(1.2)

### DIFF
--- a/build/cmakeconfgen.py
+++ b/build/cmakeconfgen.py
@@ -191,7 +191,10 @@ if __name__ == '__main__':
         print("please specify vsprops file")
         sys.exit(1)
 
-    f = file(sys.argv[1], "r")
+    if sys.version_info[0] == 2:
+        f = file(sys.argv[1], "r")
+    else:
+        f = open(sys.argv[1], "r")
     text = f.read().replace("shift_jis", "utf-8")
     f.close()
 
@@ -285,6 +288,9 @@ if __name__ == '__main__':
     dict["openrtm_idlflags"] =  "-bcxx;-Wba;-nf;-Wbshortcut;-I${OPENRTM_DIR}/rtm/idl"
 
     t = yat.Template(template)
-    f = file("OpenRTMConfig.cmake", "w")
+    if sys.version_info[0] == 2:
+        f = file("OpenRTMConfig.cmake", "w")
+    else:
+        f = open("OpenRTMConfig.cmake", "w")
     f.write(t.generate(dict))
     f.close()


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #842 


## Description of the Change

- Pythonのバージョンが 2.7 でも 3.x でもOpenRTMConfig.cmakeが生成されるようにした
- 下記環境でビルド確認
  - vc2010 + Python 2.7.14
  - vc2013 + Python 3.7.7
## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
