### PR TITLE
独自シリアライザのサンプル追加

### DIFF
--- a/examples/Serializer/CMakeLists.txt
+++ b/examples/Serializer/CMakeLists.txt
@@ -19,7 +19,9 @@ set(SerializerList ShortToDoubleSerializer
 		   LongToDoubleDeserializer
 		   TestSerializer
 		   ShortToShortSerializer
-		   DouboleToDoubleDeserializer)
+		   DouboleToDoubleDeserializer
+		   TestSerializer2
+		   TestSerializer3)
 
 
 foreach(target ${SerializerList})

--- a/examples/Serializer/CMakeLists.txt
+++ b/examples/Serializer/CMakeLists.txt
@@ -17,7 +17,9 @@ set(SerializerList ShortToDoubleSerializer
 		   ShortToDoubleDeserializer
 		   ShortToLongSerializer
 		   LongToDoubleDeserializer
-		   TestSerializer)
+		   TestSerializer
+		   ShortToShortSerializer
+		   DouboleToDoubleDeserializer)
 
 
 foreach(target ${SerializerList})
@@ -59,3 +61,4 @@ install(FILES rtc_in_serializer.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMP
 install(FILES rtc_inout_serializer.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMPONENT examples)
 install(FILES rtc_out_serializer.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMPONENT examples)
 install(FILES rtc_original_serializer.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMPONENT examples)
+install(FILES rtc_all_serializer.conf DESTINATION ${INSTALL_RTM_EXAMPLE_DIR} COMPONENT examples)

--- a/examples/Serializer/DouboleToDoubleDeserializer.cpp
+++ b/examples/Serializer/DouboleToDoubleDeserializer.cpp
@@ -1,0 +1,39 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  DouboleToDoubleDeserializer.cpp
+ * @brief Convert short to double
+ * $Date: 2019-06-25 07:33:08 $
+ *
+ * $Id$
+ */
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/ByteDataStreamBase.h>
+#include <rtm/CORBA_CdrMemoryStream.h>
+#include <coil/Factory.h>
+#include <rtm/Manager.h>
+
+//以下はシリアライザの実装
+class DouboleToDoubleDeserializer : public RTC::CORBA_CdrSerializer<RTC::TimedDouble>
+{
+public:
+    DouboleToDoubleDeserializer() = default;
+
+    bool deserialize(RTC::TimedDouble& data) override
+    {
+        bool ret = m_cdr.deserializeCDR(data);
+        return ret;
+    }
+private:
+};
+
+extern "C"
+{
+    //以下はモジュールロード時に呼び出される関数
+    DLL_EXPORT void DouboleToDoubleDeserializerInit(RTC::Manager* /*manager*/)
+    {
+        //以下のファクトリはデータ型ごとに登録する必要がある
+        RTC::addSerializer<RTC::TimedDouble, DouboleToDoubleDeserializer>("cdr:RTC/TimedDouble");
+        //addSerializer関数の第1引数で登録名を設定。独自シリアライザを利用するときはこの名前を使用する。
+    }
+}

--- a/examples/Serializer/ShortToShortSerializer.cpp
+++ b/examples/Serializer/ShortToShortSerializer.cpp
@@ -1,0 +1,38 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  ShortToShortSerializer.cpp
+ * @brief Convert short to double
+ * $Date: 2020-04-01 07:33:08 $
+ *
+ * $Id$
+ */
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/ByteDataStreamBase.h>
+#include <rtm/CORBA_CdrMemoryStream.h>
+#include <coil/Factory.h>
+#include <rtm/Manager.h>
+
+//以下はシリアライザの実装
+class ShortToShortSerializer : public RTC::CORBA_CdrSerializer<RTC::TimedShort>
+{
+public:
+    ShortToShortSerializer() = default;
+
+    bool serialize(const RTC::TimedShort& data) override
+    {
+        return m_cdr.serializeCDR(data);
+    }
+private:
+};
+
+extern "C"
+{
+    //以下はモジュールロード時に呼び出される関数
+    DLL_EXPORT void ShortToShortSerializerInit(RTC::Manager* /*manager*/)
+    {
+        //以下のファクトリはデータ型ごとに登録する必要がある
+        RTC::addSerializer<RTC::TimedShort, ShortToShortSerializer>("cdr:RTC/TimedShort");
+        //addSerializer関数の第1引数で登録名を設定。独自シリアライザを利用するときはこの名前を使用する。
+    }
+}

--- a/examples/Serializer/TestSerializer2.cpp
+++ b/examples/Serializer/TestSerializer2.cpp
@@ -1,0 +1,80 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  TestSerializer2.cpp
+ * @brief Sample Serializer
+ * $Date: 2020-04-01 07:33:08 $
+ *
+ * $Id$
+ */
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/ByteDataStreamBase.h>
+#include <rtm/CORBA_CdrMemoryStream.h>
+#include <coil/Factory.h>
+#include <rtm/Manager.h>
+
+//以下はシリアライザの実装
+class TestSerializer2Short : public RTC::CORBA_CdrSerializer<RTC::TimedShort>
+{
+public:
+    TestSerializer2Short() = default;
+
+    bool serialize(const RTC::TimedShort& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        tmp_data.tm.sec = data.tm.sec;
+        tmp_data.tm.nsec = data.tm.nsec;
+        tmp_data.data = static_cast<CORBA::Float>(data.data);
+        return m_cdr.serializeCDR(tmp_data);
+    }
+
+    bool deserialize(RTC::TimedShort& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        bool ret = m_cdr.deserializeCDR(tmp_data);
+        data.tm.sec = tmp_data.tm.sec;
+        data.tm.nsec = tmp_data.tm.nsec;
+        data.data = static_cast<CORBA::Short>(tmp_data.data);
+        return ret;
+    }
+private:
+};
+
+
+class TestSerializer2Double : public RTC::CORBA_CdrSerializer<RTC::TimedDouble>
+{
+public:
+    TestSerializer2Double() = default;
+
+    bool serialize(const RTC::TimedDouble& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        tmp_data.tm.sec = data.tm.sec;
+        tmp_data.tm.nsec = data.tm.nsec;
+        tmp_data.data = static_cast<CORBA::Float>(data.data);
+        return m_cdr.serializeCDR(tmp_data);
+    }
+
+    bool deserialize(RTC::TimedDouble& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        bool ret = m_cdr.deserializeCDR(tmp_data);
+        data.tm.sec = tmp_data.tm.sec;
+        data.tm.nsec = tmp_data.tm.nsec;
+        data.data = static_cast<CORBA::Double>(tmp_data.data);
+        return ret;
+    }
+private:
+};
+
+extern "C"
+{
+    //以下はモジュールロード時に呼び出される関数
+    DLL_EXPORT void TestSerializer2Init(RTC::Manager* /*manager*/)
+    {
+        //以下のファクトリはデータ型ごとに登録する必要がある
+        RTC::addSerializer<RTC::TimedShort, TestSerializer2Short>("test:dummydata2");
+        RTC::addSerializer<RTC::TimedDouble, TestSerializer2Double>("test:dummydata2");
+        //addSerializer関数の第1引数で登録名を設定。独自シリアライザを利用するときはこの名前を使用する。
+    }
+}

--- a/examples/Serializer/TestSerializer3.cpp
+++ b/examples/Serializer/TestSerializer3.cpp
@@ -1,0 +1,80 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  TestSerializer3.cpp
+ * @brief Sample Serializer
+ * $Date: 2020-04-01 07:33:08 $
+ *
+ * $Id$
+ */
+
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/ByteDataStreamBase.h>
+#include <rtm/CORBA_CdrMemoryStream.h>
+#include <coil/Factory.h>
+#include <rtm/Manager.h>
+
+//以下はシリアライザの実装
+class TestSerializer3Short : public RTC::CORBA_CdrSerializer<RTC::TimedShort>
+{
+public:
+    TestSerializer3Short() = default;
+
+    bool serialize(const RTC::TimedShort& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        tmp_data.tm.sec = data.tm.sec;
+        tmp_data.tm.nsec = data.tm.nsec;
+        tmp_data.data = static_cast<CORBA::Float>(data.data);
+        return m_cdr.serializeCDR(tmp_data);
+    }
+
+    bool deserialize(RTC::TimedShort& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        bool ret = m_cdr.deserializeCDR(tmp_data);
+        data.tm.sec = tmp_data.tm.sec;
+        data.tm.nsec = tmp_data.tm.nsec;
+        data.data = static_cast<CORBA::Short>(tmp_data.data);
+        return ret;
+    }
+private:
+};
+
+
+class TestSerializer3Double : public RTC::CORBA_CdrSerializer<RTC::TimedDouble>
+{
+public:
+    TestSerializer3Double() = default;
+
+    bool serialize(const RTC::TimedDouble& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        tmp_data.tm.sec = data.tm.sec;
+        tmp_data.tm.nsec = data.tm.nsec;
+        tmp_data.data = static_cast<CORBA::Float>(data.data);
+        return m_cdr.serializeCDR(tmp_data);
+    }
+
+    bool deserialize(RTC::TimedDouble& data) override
+    {
+        RTC::TimedFloat tmp_data;
+        bool ret = m_cdr.deserializeCDR(tmp_data);
+        data.tm.sec = tmp_data.tm.sec;
+        data.tm.nsec = tmp_data.tm.nsec;
+        data.data = static_cast<CORBA::Double>(tmp_data.data);
+        return ret;
+    }
+private:
+};
+
+extern "C"
+{
+    //以下はモジュールロード時に呼び出される関数
+    DLL_EXPORT void TestSerializer3Init(RTC::Manager* /*manager*/)
+    {
+        //以下のファクトリはデータ型ごとに登録する必要がある
+        RTC::addSerializer<RTC::TimedShort, TestSerializer3Short>("test3:dummydata2");
+        RTC::addSerializer<RTC::TimedDouble, TestSerializer3Double>("test3:dummydata2");
+        //addSerializer関数の第1引数で登録名を設定。独自シリアライザを利用するときはこの名前を使用する。
+    }
+}

--- a/examples/Serializer/rtc_all_serializer.conf
+++ b/examples/Serializer/rtc_all_serializer.conf
@@ -4,7 +4,7 @@ logger.enable: YES
 logger.file_name: stdout
 logger.log_level: ERROR
 manager.modules.load_path: .
-manager.modules.preload: ConsoleOutDouble, DouboleToDoubleDeserializer, LongToDoubleDeserializer, ShortToDoubleDeserializer, ShortToDoubleSerializer, ShortToLongSerializer, ShortToShortSerializer 
+manager.modules.preload: ConsoleOutDouble, DouboleToDoubleDeserializer, LongToDoubleDeserializer, ShortToDoubleDeserializer, ShortToDoubleSerializer, ShortToLongSerializer, ShortToShortSerializer, TestSerializer, TestSerializer2, TestSerializer3
 manager.components.precreate: ConsoleOutDouble
 #manager.components.preconnect: ConsoleOutDouble0.in?port=ConsoleInShort0.out&outport.marshaling_type=cdr:RTC/TimedDouble:RTC/TimedShort&inport.marshaling_type=cdr
 #manager.components.preactivation: ConsoleOutDouble0, ConsoleInShort0

--- a/examples/Serializer/rtc_all_serializer.conf
+++ b/examples/Serializer/rtc_all_serializer.conf
@@ -4,7 +4,7 @@ logger.enable: YES
 logger.file_name: stdout
 logger.log_level: ERROR
 manager.modules.load_path: .
-manager.modules.preload: ConsoleOutDouble, ShortToDoubleSerializer, DouboleToDoubleDeserializer
+manager.modules.preload: ConsoleOutDouble, DouboleToDoubleDeserializer, LongToDoubleDeserializer, ShortToDoubleDeserializer, ShortToDoubleSerializer, ShortToLongSerializer, ShortToShortSerializer 
 manager.components.precreate: ConsoleOutDouble
 #manager.components.preconnect: ConsoleOutDouble0.in?port=ConsoleInShort0.out&outport.marshaling_type=cdr:RTC/TimedDouble:RTC/TimedShort&inport.marshaling_type=cdr
 #manager.components.preactivation: ConsoleOutDouble0, ConsoleInShort0

--- a/examples/Serializer/rtc_in_serializer.conf
+++ b/examples/Serializer/rtc_in_serializer.conf
@@ -4,7 +4,7 @@ logger.enable: YES
 logger.file_name: stdout
 logger.log_level: ERROR
 manager.modules.load_path: .
-manager.modules.preload: ConsoleOutDouble, ShortToDoubleDeserializer
+manager.modules.preload: ConsoleOutDouble, ShortToDoubleDeserializer, ShortToShortSerializer
 manager.components.precreate: ConsoleOutDouble
 #manager.components.preconnect: ConsoleOutDouble0.in?port=ConsoleInShort0.out&inport.marshaling_type=cdr:RTC/TimedShort:RTC/TimedDouble&outport.marshaling_type=cdr
 #manager.components.preactivation: ConsoleOutDouble0, ConsoleInShort0


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

## Description of the Change

以下のissue対応のためにさらに独自シリアライザのサンプルプログラムを追加。

- https://github.com/OpenRTM/OpenRTP-aist/issues/295

以下の2種類のシリアライザをさらに追加。

- `ShortToShortSerializer`

| シリアライザの名前| 説明 |
----|---- 
| cdr:RTC/TimedShort | OutPort側でTimedShort型のデータをそのまま符号化するシリアライザ(issueの(B-1)動作確認用)|


- `DouboleToDoubleDeserializer`

| シリアライザの名前| 説明 |
----|---- 
| cdr:RTC/TimedDouble | InPort側でTimedDouble型のデータをそのまま復号するシリアライザ(issueの(C-1)動作確認用)|


- `TestSerializer2`

| シリアライザの名前| 説明 |
----|---- 
| test:dummydata2 | InPort側ではTimedFloat型のデータをTimedDouble型に変換する。OutPort側ではTimedShort型のデータをTimedFloat型に変換する。|




- `TestSerializer3`

| シリアライザの名前| 説明 |
----|---- 
| test3:dummydata2 | InPort側ではTimedFloat型のデータをTimedDouble型に変換する。OutPort側ではTimedShort型のデータをTimedFloat型に変換する。|




以下の設定ファイルを変更した。

- `rtc_in_serializer.conf`

`ShortToDoubleDeserializer`と`ShortToShortSerializer`をロードする。
ポートプロファイルから取得できる`dataport.marshaling_types`の値は以下のようになる。

| RTCの名前 | ポート名 | データ型 | dataport.marshaling_types|
----|----|----|----
| ConsoleInShort0 | out | IDL:RTC/TimedShort:1.0 | cdr,**cdr:RTC/TimedShort** |
| ConsoleOutDouble0 | in | IDL:RTC/TimedDouble:1.0 | cdr,cdr:RTC/TimedShort:RTC/TimedDouble |

- `rtc_out_serializer.conf`

`ShortToDoubleSerializer`と`DouboleToDoubleDeserializer`をロードする。
ポートプロファイルから取得できる`dataport.marshaling_types`の値は以下のようになる。

| RTCの名前 | ポート名 | データ型 | dataport.marshaling_types|
----|----|----|----
| ConsoleInShort0 | out | IDL:RTC/TimedShort:1.0 | cdr,cdr:RTC/TimedDouble:RTC/TimedShort |
| ConsoleOutDouble0 | in | IDL:RTC/TimedDouble:1.0 | cdr,**cdr:RTC/TimedDouble** |


以下の設定ファイルを新たに追加した。

- `rtc_all_serializer.conf`

サンプルのシリアライザ、デシリアライザを全てロードする。
ポートプロファイルから取得できる`dataport.marshaling_types`の値は以下のようになる。

| RTCの名前 | ポート名 | データ型 | dataport.marshaling_types|
----|----|----|----
| ConsoleInShort0 | out | IDL:RTC/TimedShort:1.0 | cdr,cdr:RTC/TimedDouble:RTC/TimedShort,cdr:RTC/TimedLong:RTC/TimedShort,cdr:RTC/TimedShort,test3:dummydata2,test:dummydata,test:dummydata2 |
| ConsoleOutDouble0 | in | IDL:RTC/TimedDouble:1.0 |  cdr,cdr:RTC/TimedDouble,cdr:RTC/TimedLong:RTC/TimedDouble,cdr:RTC/TimedShort:RTC/TimedDouble,test3:dummydata2,test:dummydata,test:dummydata2 |

動作確認に必要なファイル一式は以下にアップロードした。

- [serializer_sample_ver2.zip](https://github.com/OpenRTM/OpenRTM-aist/files/4441616/serializer_sample_ver2.zip)



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
