### PR TITLE
Clock rewind hung bug #850 fixed (RELENG_1_2)

### DIFF
--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -34,7 +34,7 @@ namespace RTC_exp
 {
   /*!
    * @if jp
-   * @brief ¥Ç¥Õ¥©¥ë¥È¥³¥ó¥¹¥È¥é¥¯¥¿
+   * @brief ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
    * @else
    * @brief Default constructor
    * @endif
@@ -60,7 +60,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ¥Ç¥¹¥È¥é¥¯¥¿
+   * @brief ãƒ‡ã‚¹ãƒˆãƒ©ã‚¯ã‚¿
    * @else
    * @brief Destructor
    * @endif
@@ -96,7 +96,7 @@ namespace RTC_exp
    *------------------------------------------------------------*/
   /*!
    * @if jp
-   * @brief ExecutionContextÍÑ¥¢¥¯¥Æ¥£¥Ó¥Æ¥£¥¹¥ì¥Ã¥É¤òÀ¸À®¤¹¤ë
+   * @brief ExecutionContextç”¨ã‚¢ã‚¯ãƒ†ã‚£ãƒ“ãƒ†ã‚£ã‚¹ãƒ¬ãƒƒãƒ‰ã‚’ç”Ÿæˆã™ã‚‹
    * @else
    * @brief Generate internal activity thread for ExecutionContext
    * @endif
@@ -114,7 +114,7 @@ namespace RTC_exp
    *------------------------------------------------------------*/
   /*!
    * @if jp
-   * @brief ExecutionContext ÍÑ¤Î¥¹¥ì¥Ã¥É¼Â¹Ô´Ø¿ô
+   * @brief ExecutionContext ç”¨ã®ã‚¹ãƒ¬ãƒƒãƒ‰å®Ÿè¡Œé–¢æ•°
    * @else
    * @brief Thread execution function for ExecutionContext
    * @endif
@@ -175,17 +175,18 @@ namespace RTC_exp
         coil::TimeValue t1(coil::gettimeofday());
 
         coil::TimeValue period(getPeriod());
+        coil::TimeValue exectime(t1 - t0);
         if (count > 1000)
           {
             RTC_PARANOID(("Period:    %f [s]", (double)period));
-            RTC_PARANOID(("Execution: %f [s]", (double)(t1 - t0)));
-            RTC_PARANOID(("Sleep:     %f [s]", (double)(period - (t1 - t0))));
+            RTC_PARANOID(("Execution: %f [s]", (double)exectime));
+            RTC_PARANOID(("Sleep:     %f [s]", (double)(period - exectime)));
           }
         coil::TimeValue t2(coil::gettimeofday());
-        if (!m_nowait && period > (t1 - t0))
+        if (!m_nowait && 0.0 < (double)executime && (double)(period - exectime) > 0.0)
           {
             if (count > 1000) { RTC_PARANOID(("sleeping...")); }
-            coil::sleep((coil::TimeValue)(period - (t1 - t0)));
+            coil::sleep((coil::TimeValue)(period - exectime));
           }
         if (count > 1000)
           {
@@ -201,7 +202,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ExecutionContext ÍÑ¤Î¥¹¥ì¥Ã¥É¼Â¹Ô´Ø¿ô
+   * @brief ExecutionContext ç”¨ã®ã‚¹ãƒ¬ãƒƒãƒ‰å®Ÿè¡Œé–¢æ•°
    * @else
    * @brief Thread execution function for ExecutionContext
    * @endif
@@ -220,7 +221,7 @@ namespace RTC_exp
   //============================================================
   /*!
    * @if jp
-   * @brief ExecutionContext ¼Â¹Ô¾õÂÖ³ÎÇ§´Ø¿ô
+   * @brief ExecutionContext å®Ÿè¡ŒçŠ¶æ…‹ç¢ºèªé–¢æ•°
    * @else
    * @brief Check for ExecutionContext running state
    * @endif
@@ -233,7 +234,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ExecutionContext ¤Î¼Â¹Ô¤ò³«»Ï
+   * @brief ExecutionContext ã®å®Ÿè¡Œã‚’é–‹å§‹
    * @else
    * @brief Start the ExecutionContext
    * @endif
@@ -246,7 +247,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ExecutionContext ¤Î¼Â¹Ô¤òÄä»ß
+   * @brief ExecutionContext ã®å®Ÿè¡Œã‚’åœæ­¢
    * @else
    * @brief Stop the ExecutionContext
    * @endif
@@ -261,7 +262,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ExecutionContext ¤Î¼Â¹Ô¼ş´ü(Hz)¤ò¼èÆÀ¤¹¤ë
+   * @brief ExecutionContext ã®å®Ÿè¡Œå‘¨æœŸ(Hz)ã‚’å–å¾—ã™ã‚‹
    * @else
    * @brief Get execution rate(Hz) of ExecutionContext
    * @endif
@@ -274,7 +275,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ExecutionContext ¤Î¼Â¹Ô¼ş´ü(Hz)¤òÀßÄê¤¹¤ë
+   * @brief ExecutionContext ã®å®Ÿè¡Œå‘¨æœŸ(Hz)ã‚’è¨­å®šã™ã‚‹
    * @else
    * @brief Set execution rate(Hz) of ExecutionContext
    * @endif
@@ -287,7 +288,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief RT¥³¥ó¥İ¡¼¥Í¥ó¥È¤òÄÉ²Ã¤¹¤ë
+   * @brief RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’è¿½åŠ ã™ã‚‹
    * @else
    * @brief Add an RT-Component
    * @endif
@@ -301,7 +302,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ¥³¥ó¥İ¡¼¥Í¥ó¥È¤ò¥³¥ó¥İ¡¼¥Í¥ó¥È¥ê¥¹¥È¤«¤éºï½ü¤¹¤ë
+   * @brief ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’ã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆãƒªã‚¹ãƒˆã‹ã‚‰å‰Šé™¤ã™ã‚‹
    * @else
    * @brief Remove the RT-Component from participant list
    * @endif
@@ -315,7 +316,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief RT¥³¥ó¥İ¡¼¥Í¥ó¥È¤ò¥¢¥¯¥Æ¥£¥Ö²½¤¹¤ë
+   * @brief RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’ã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ã™ã‚‹
    * @else
    * @brief Activate an RT-Component
    * @endif
@@ -329,7 +330,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief RT¥³¥ó¥İ¡¼¥Í¥ó¥È¤òÈó¥¢¥¯¥Æ¥£¥Ö²½¤¹¤ë
+   * @brief RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’éã‚¢ã‚¯ãƒ†ã‚£ãƒ–åŒ–ã™ã‚‹
    * @else
    * @brief Deactivate an RT-Component
    * @endif
@@ -343,7 +344,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief RT¥³¥ó¥İ¡¼¥Í¥ó¥È¤ò¥ê¥»¥Ã¥È¤¹¤ë
+   * @brief RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã‚’ãƒªã‚»ãƒƒãƒˆã™ã‚‹
    * @else
    * @brief Reset the RT-Component
    * @endif
@@ -357,7 +358,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief RT¥³¥ó¥İ¡¼¥Í¥ó¥È¤Î¾õÂÖ¤ò¼èÆÀ¤¹¤ë
+   * @brief RTã‚³ãƒ³ãƒãƒ¼ãƒãƒ³ãƒˆã®çŠ¶æ…‹ã‚’å–å¾—ã™ã‚‹
    * @else
    * @brief Get RT-Component's state
    * @endif
@@ -372,7 +373,7 @@ namespace RTC_exp
 
   /*!
    * @if jp
-   * @brief ExecutionKind ¤ò¼èÆÀ¤¹¤ë
+   * @brief ExecutionKind ã‚’å–å¾—ã™ã‚‹
    * @else
    * @brief Get the ExecutionKind
    * @endif
@@ -388,7 +389,7 @@ namespace RTC_exp
   //------------------------------------------------------------
   /*!
    * @if jp
-   * @brief ExecutionContextProfile ¤ò¼èÆÀ¤¹¤ë
+   * @brief ExecutionContextProfile ã‚’å–å¾—ã™ã‚‹
    * @else
    * @brief Get the ExecutionContextProfile
    * @endif
@@ -631,7 +632,7 @@ extern "C"
 {
   /*!
    * @if jp
-   * @brief ECFactory¤Ø¤ÎÅĞÏ¿¤Î¤¿¤á¤Î½é´ü²½´Ø¿ô
+   * @brief ECFactoryã¸ã®ç™»éŒ²ã®ãŸã‚ã®åˆæœŸåŒ–é–¢æ•°
    * @else
    * @brief Initialization function to register to ECFactory
    * @endif

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -183,7 +183,7 @@ namespace RTC_exp
             RTC_PARANOID(("Sleep:     %f [s]", (double)(period - exectime)));
           }
         coil::TimeValue t2(coil::gettimeofday());
-        if (!m_nowait && 0.0 < (double)executime && (double)(period - exectime) > 0.0)
+        if (!m_nowait && 0.0 < (double)exectime && (double)(period - exectime) > 0.0)
           {
             if (count > 1000) { RTC_PARANOID(("sleeping...")); }
             coil::sleep((coil::TimeValue)(period - exectime));


### PR DESCRIPTION
Clock rewind causes hung and fixed it.

#850

## Identify the Bug
The default execution context has a bug that causes RTC to hang when rewinding the system clock.

## Description of the Change
If the system clock rewind detected during RTC's logic execution, skip the sleep in EC. 

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
