### PR TITLE
create_process関数で停止する問題の修正

### DIFF
--- a/src/lib/coil/win32/coil/Process.cpp
+++ b/src/lib/coil/win32/coil/Process.cpp
@@ -138,6 +138,13 @@ namespace coil
       CloseHandle(pi.hThread);
 
 
+      DWORD size = GetFileSize(rPipe, nullptr);
+      if (size == 0)
+      {
+          return 0;
+      }
+
+
       char Buf[1025] = { 0 };
       DWORD len;
       ReadFile(rPipe, Buf, sizeof(Buf) - 1, &len, NULL);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Windows、OpenRTM-aist 1.2でのcreate_process関数で実行したプロセスの標準出力が無かった場合にReadFile関数実行時に処理が止まる。


## Description of the Change

masterブランチのProcess.cppではあらかじめ読みだした標準出力のサイズを取得して0の場合は終了する処理を入れてあるがRELENG_1_2には無かったため追加した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
