### PR TITLE
LinuxでRTC動作中に時刻を変更するとPeriodicExecutionContextの動作が停止する問題の修正

### DIFF
--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -120,7 +120,11 @@ namespace RTC
         auto exectime = t1 - t0;
         if (exectime.count() >= 0)
           {
-            std::this_thread::sleep_for(getPeriod() - exectime);
+            auto diff = getPeriod() - exectime;
+            if (diff.count() > 0)
+              {
+                std::this_thread::sleep_for(diff);
+              }
           }
       } while (threadRunning());
 

--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -123,7 +123,13 @@ namespace RTC
             auto diff = getPeriod() - exectime;
             if (diff.count() > 0)
               {
+#ifdef _WIN32
+                std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(diff);
+                Sleep(static_cast<DWORD>(ms.count()));
+#else
                 std::this_thread::sleep_for(diff);
+
+#endif
               }
           }
       } while (threadRunning());

--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -116,7 +116,12 @@ namespace RTC
           std::lock_guard<std::mutex> guard(m_worker.mutex_);
           m_worker.ticked_ = false;
         }
-        std::this_thread::sleep_until(t0 + getPeriod());
+        auto t1 = std::chrono::high_resolution_clock::now();
+        auto exectime = t1 - t0;
+        if (exectime.count() > 0)
+          {
+            std::this_thread::sleep_for(getPeriod() - exectime);
+          }
       } while (threadRunning());
 
     return 0;

--- a/src/lib/rtm/ExtTrigExecutionContext.cpp
+++ b/src/lib/rtm/ExtTrigExecutionContext.cpp
@@ -118,7 +118,7 @@ namespace RTC
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         auto exectime = t1 - t0;
-        if (exectime.count() > 0)
+        if (exectime.count() >= 0)
           {
             std::this_thread::sleep_for(getPeriod() - exectime);
           }

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -111,7 +111,7 @@ namespace RTC_exp
         {
             auto t1 = std::chrono::high_resolution_clock::now();
             auto exectime = t1 - t0;
-            if (exectime.count() > 0)
+            if (exectime.count() >= 0)
               {
                 std::this_thread::sleep_for(getPeriod() - exectime);
               }

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -116,7 +116,13 @@ namespace RTC_exp
                 auto diff = getPeriod() - exectime;
                 if (diff.count() > 0)
                   {
+#ifdef _WIN32
+                    std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(diff);
+                    Sleep(static_cast<DWORD>(ms.count()));
+#else
                     std::this_thread::sleep_for(diff);
+
+#endif
                   }
               }
         }

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -109,7 +109,12 @@ namespace RTC_exp
 
         if (!m_nowait)
         {
-            std::this_thread::sleep_until(t0 + getPeriod());
+            auto t1 = std::chrono::high_resolution_clock::now();
+            auto exectime = t1 - t0;
+            if (exectime.count() > 0)
+              {
+                std::this_thread::sleep_for(getPeriod() - exectime);
+              }
         }
       } while (threadRunning());
     RTC_DEBUG(("Thread terminated."));

--- a/src/lib/rtm/MultilayerCompositeEC.cpp
+++ b/src/lib/rtm/MultilayerCompositeEC.cpp
@@ -113,7 +113,11 @@ namespace RTC_exp
             auto exectime = t1 - t0;
             if (exectime.count() >= 0)
               {
-                std::this_thread::sleep_for(getPeriod() - exectime);
+                auto diff = getPeriod() - exectime;
+                if (diff.count() > 0)
+                  {
+                    std::this_thread::sleep_for(diff);
+                  }
               }
         }
       } while (threadRunning());

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -84,9 +84,12 @@ namespace RTC
         auto diff = getPeriod() - exectime;
         if (diff.count() > 0)
           {
+#ifdef _WIN32
+            std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(diff);
             Sleep(static_cast<DWORD>(ms.count()));
 #else
             std::this_thread::sleep_for(diff);
+
 #endif
           }
       }

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -81,7 +81,11 @@ namespace RTC
     auto exectime = t1 - t0;
     if (exectime.count() >= 0)
       {
-        std::this_thread::sleep_for(getPeriod() - exectime);
+        auto diff = getPeriod() - exectime;
+        if (diff.count() > 0)
+          {
+            std::this_thread::sleep_for(diff);
+          }
       }
     return;
   }

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -84,7 +84,10 @@ namespace RTC
         auto diff = getPeriod() - exectime;
         if (diff.count() > 0)
           {
+            Sleep(static_cast<DWORD>(ms.count()));
+#else
             std::this_thread::sleep_for(diff);
+#endif
           }
       }
     return;

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -77,7 +77,12 @@ namespace RTC
     auto t0 = std::chrono::high_resolution_clock::now();
     ExecutionContextBase::invokeWorkerDo();
     ExecutionContextBase::invokeWorkerPostDo();
-    std::this_thread::sleep_until(t0 + getPeriod());
+    auto t1 = std::chrono::high_resolution_clock::now();
+    auto exectime = t1 - t0;
+    if (exectime.count() > 0)
+      {
+        std::this_thread::sleep_for(getPeriod() - exectime);
+      }
     return;
   }
 

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -79,7 +79,7 @@ namespace RTC
     ExecutionContextBase::invokeWorkerPostDo();
     auto t1 = std::chrono::high_resolution_clock::now();
     auto exectime = t1 - t0;
-    if (exectime.count() > 0)
+    if (exectime.count() >= 0)
       {
         std::this_thread::sleep_for(getPeriod() - exectime);
       }

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -170,7 +170,11 @@ namespace RTC_exp
             auto exectime = t1 - t0;
             if (exectime.count() >= 0)
               {
-                std::this_thread::sleep_for(getPeriod() - exectime);
+                auto diff = getPeriod() - exectime;
+                if (diff.count() > 0)
+                  {
+                    std::this_thread::sleep_for(diff);
+                  }
               }
           }
       } while (threadRunning());

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -173,7 +173,13 @@ namespace RTC_exp
                 auto diff = getPeriod() - exectime;
                 if (diff.count() > 0)
                   {
+#ifdef _WIN32
+                    std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(diff);
+                    Sleep(static_cast<DWORD>(ms.count()));
+#else
                     std::this_thread::sleep_for(diff);
+
+#endif
                   }
               }
           }

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -168,7 +168,7 @@ namespace RTC_exp
           {
             auto t1 = std::chrono::high_resolution_clock::now();
             auto exectime = t1 - t0;
-            if (exectime.count() > 0)
+            if (exectime.count() >= 0)
               {
                 std::this_thread::sleep_for(getPeriod() - exectime);
               }

--- a/src/lib/rtm/PeriodicExecutionContext.cpp
+++ b/src/lib/rtm/PeriodicExecutionContext.cpp
@@ -166,7 +166,12 @@ namespace RTC_exp
         ExecutionContextBase::invokeWorkerPostDo();
         if (!m_nowait)
           {
-            std::this_thread::sleep_until(t0 + getPeriod());
+            auto t1 = std::chrono::high_resolution_clock::now();
+            auto exectime = t1 - t0;
+            if (exectime.count() > 0)
+              {
+                std::this_thread::sleep_for(getPeriod() - exectime);
+              }
           }
       } while (threadRunning());
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

WindowsとUbuntuでは`std::chrono::high_resolution_clock::now()`の動作が異なっている。
Visual Studioの場合は`std::chrono::high_resolution_clock::now()`はQueryPerformanceCounterによりOSが起動してからの時間を取得している。取得できる時間はOSを起動してから単調増加するため時刻変更の影響はない。

一方、Ubuntu 18.04で確認したところ`std::chrono::high_resolution_clock::now()`で取得できる時間はUNIX時間となっているため、dateコマンドなどで時刻を変更すると影響が出る。

`std::chrono::steady_clock::now()`で時間を取得した場合はどの環境でもある時点からの単調増加な経過時間を取得するため時刻変更による問題はなくなる。
Windowsの場合は`high_resolution_clock`と`steady_clock`は中身が全く同じであり、Ubuntu 18.04の場合については`high_resolution_clock`と`steady_clock`で精度が同じであるため`steady_clock`を使うようにしても動作に影響はないが、他のコンパイラ、環境の場合にどうなるかは分からない。


## Description of the Change

現在時刻を取得して時間が巻き戻っていたらsleepしないように修正した。
sleep_until関数を実行していた箇所を以下のように現在時刻の取得、比較、sleep_for関数の実行を行うように変更した。

```CPP
        auto t1 = std::chrono::high_resolution_clock::now();
        auto exectime = t1 - t0;
        if (exectime.count() > 0)
          {
            std::this_thread::sleep_for(getPeriod() - exectime);
          }
```

`std::this_thread::sleep_until`関数は内部で現在の時間を取得して差し引いた値を`std::this_thread::sleep_for`関数に入力しているだけのため動作に悪影響が出ることはない。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
