### PR TITLE
rtm-skelwrapper python3 support (RELENG_1_2) #856

### DIFF
--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- python -*-
 # -*- coding: utf-8 -*-
 #


### PR DESCRIPTION
## Identify the Bug

#856

## Description of the Change

The shebang was changed to python3

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
