### PR TITLE
RTシステムエディタでマネージャからRTCを起動しようとすると「FAILED to create of target RTC」と表示される不具合の修正

### DIFF
--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1254,7 +1254,7 @@ namespace RTM
 
         std::string lang_path_key("manager.modules.");
         lang_path_key += lang + ".load_path";
-        rtcd_cmd += " -o manager.modules.load_path:" + prop["manager.modules.load_path"] + "," + prop[rtcd_cmd_key];
+        rtcd_cmd += " -o \"manager.modules.load_path:" + prop["manager.modules.load_path"] + "," + prop[rtcd_cmd_key] + "\"";
         
         rtcd_cmd += " -o manager.is_master:NO";
         rtcd_cmd += " -o manager.corba_servant:YES";

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1251,13 +1251,17 @@ namespace RTM
             RTC_WARN(("rtcd command name not found. Default rtcd is used"));
             rtcd_cmd = "rtcd";
           }
+
+        std::string lang_path_key("manager.modules.");
+        lang_path_key += lang + ".load_path";
+        rtcd_cmd += " -o manager.modules.load_path:" + prop["manager.modules.load_path"] + "," + prop[rtcd_cmd_key];
+        
         rtcd_cmd += " -o manager.is_master:NO";
         rtcd_cmd += " -o manager.corba_servant:YES";
         rtcd_cmd += " -o corba.master_manager:" + prop["corba.master_manager"];
         rtcd_cmd += " -o manager.name:" + prop["manager.name"];
         rtcd_cmd += " -o manager.instance_name:" + mgrstr;
-        rtcd_cmd += " -o shutdown_auto:NO";
-        rtcd_cmd += " -o manager.auto_shutdown_duration:50";
+        rtcd_cmd += " -o manager.shutdown_auto:NO";
 
 
         coil::vstring slaves_names;

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1254,14 +1254,14 @@ namespace RTM
 
         std::string lang_path_key("manager.modules.");
         lang_path_key += lang + ".load_path";
-        rtcd_cmd += " -o \"manager.modules.load_path:" + prop["manager.modules.load_path"] + "," + prop[rtcd_cmd_key] + "\"";
+        rtcd_cmd += " -o \"manager.modules.load_path:" + prop["manager.modules.load_path"] + "," + prop[lang_path_key] + "\"";
         
-        rtcd_cmd += " -o manager.is_master:NO";
-        rtcd_cmd += " -o manager.corba_servant:YES";
-        rtcd_cmd += " -o corba.master_manager:" + prop["corba.master_manager"];
-        rtcd_cmd += " -o manager.name:" + prop["manager.name"];
-        rtcd_cmd += " -o manager.instance_name:" + mgrstr;
-        rtcd_cmd += " -o manager.shutdown_auto:NO";
+        rtcd_cmd += " -o \"manager.is_master:NO\"";
+        rtcd_cmd += " -o \"manager.corba_servant:YES\"";
+        rtcd_cmd += " -o \"corba.master_manager:" + prop["corba.master_manager"] + "\"";
+        rtcd_cmd += " -o \"manager.name:" + prop["manager.name"] + "\"";
+        rtcd_cmd += " -o \"manager.instance_name:" + mgrstr + "\"";
+        rtcd_cmd += " -o \"manager.shutdown_auto:NO\"";
 
 
         coil::vstring slaves_names;
@@ -1417,7 +1417,7 @@ namespace RTM
             RTC_WARN(("rtcd command name not found. Default rtcd is used."));
             rtcd_cmd = "rtcd";
           }
-        rtcd_cmd += " -o corba.master_manager:" + mgrstr;
+        rtcd_cmd += " -o \"corba.master_manager:" + mgrstr + "\"";
         rtcd_cmd += " -d ";
 
         RTC_DEBUG(("Invoking command: %s.", rtcd_cmd.c_str()));


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

RTシステムエディタでマスターマネージャを操作してRTCを起動しようとすると`FAILED to create of target RTC`と表示される。


## Description of the Change

1. `manager.shutdown_auto:NO`が`shutdown_auto:NO`となっていたため修正
2. モジュール探索パスが正常に設定されていなかったため`manager.modules.load_path`を設定するようにした。動作確認の時点ではrtcd.exeとrtc.confを配置したディレクトリで実行しておりスレーブマネージャも同じrtc.confを読み込んでいたため問題が発生しなかったみたいです。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
