### PR TITLE
rtc.confから読み込んだ文字列をエスケープした状態で保持するように変更

### DIFF
--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -374,7 +374,7 @@ namespace coil
         std::string key, invalue;
         splitKeyValue(pline, key, invalue);
         setProperty(eraseBothEndsBlank(coil::unescape(std::move(key))),
-                    eraseBothEndsBlank(std::move(invalue)));
+                    eraseBothEndsBlank(coil::unescape(std::move(invalue))));
         pline.clear();
       }
   }

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1254,7 +1254,7 @@ namespace RTM
 
         std::string lang_path_key("manager.modules.");
         lang_path_key += lang + ".load_path";
-        rtcd_cmd += " -o \"manager.modules.load_path:" + prop["manager.modules.load_path"] + "," + prop[lang_path_key] + "\"";
+        rtcd_cmd += " -o \"manager.modules.load_path:" + coil::escape(prop["manager.modules.load_path"]) + "," + coil::escape(prop[lang_path_key]) + "\"";
         
         rtcd_cmd += " -o \"manager.is_master:NO\"";
         rtcd_cmd += " -o \"manager.corba_servant:YES\"";


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

## Description of the Change

svn/RELENG_1_2ブランチではrtc.confから読み込んだ文字列はエスケープした状態で保持するが、masterブランチではエスケープしない状態で保持するようになっていたため元の仕様に戻した。







## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
