### PR TITLE
configure.ac for omniidl in ubuntu 20.04

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -445,6 +445,7 @@ if test "x$with_rtorb" != "x" ; then
 fi
 if test "x$orb_to_use" = "x" ; then
 	orb_to_use=omniORB
+	with_omniorb=/usr
 fi
 
 echo 'ORB: '$orb_to_use


### PR DESCRIPTION
Ubuntu20.04では /bin->/usr/bin がシンボリックリンクで構成されており、/bin/omniidl を起動すると .so モジュールがないとエラーが出てomniidlが正しく起動できない。

configure.ac で オプション指定しない場合、omniidl などのコマンドを $with_omniorb/bin から探そうとするため、$with_omniorb にデフォルト値で /usr を代入しておく。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
