### PR TITLE
Linuxでcoil::launch_shell関数がダブルクォーテーションを含む文字列を正常に処理できない問題の修正

### DIFF
--- a/src/lib/coil/posix/coil/Process.cpp
+++ b/src/lib/coil/posix/coil/Process.cpp
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string>
+#include <regex>
 
 
 namespace coil
@@ -55,7 +56,18 @@ namespace coil
       {
         setsid();
 
-        coil::vstring vstr(::coil::split(command, " "));
+        const std::regex base_regex("((?:[^\\s\"\\\\]|\\\\.|\"(?:\\\\.|[^\\\\\"])*(?:\"|$))+)");
+        std::sregex_iterator words_begin = std::sregex_iterator(command.begin(), command.end(), base_regex);
+        std::sregex_iterator words_end = std::sregex_iterator();
+
+        coil::vstring vstr;
+
+        for (std::sregex_iterator i = words_begin; i != words_end; ++i) {
+            std::smatch match = *i;
+            std::string match_str = replaceString(match.str(), "\"", "");
+            vstr.push_back(match_str);
+        }
+        
         Argv argv(vstr);
 
         execvp(vstr.front().c_str(), argv.get());


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#868 でrtcdコマンド実行時にコマンドライン引数を`"`で囲うように修正したが、posix用coilのlaunch_shell関数はスペースで分割して処理するようになっているため、`"`で囲うとそのまま文字の一部として`"`が含まれてしまう。

Windowsではスペースで区切るということをcoil側では行わないため問題ない。
Python版はshlex.split関数で処理しているため`"`で囲っていても正常に分割できる。

## Description of the Change

std::regexで以下のパターンの一致を繰り返した文字列をひと固まりとして分割するように変更した。

- `"`から`"`もしくは文字列終端まで(`\"(?:\\\\.|[^\\\\\"])*(?:\"|$)`)
- 空白と`"`、`\`以外の文字
- `\`+文字

`((?:[^\\s\"\\\\]|\\\\.|\"(?:\\\\.|[^\\\\\"])*(?:\"|$))+)`

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
