### PR TITLE
Ubuntu16.04用に提供していないパッケージを一括インストールスクリプトから除外する修正

### DIFF
--- a/scripts/pkg_install_ubuntu.sh
+++ b/scripts/pkg_install_ubuntu.sh
@@ -18,7 +18,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.0.05
+VERSION=2.0.0.06
 
 #
 #---------------------------------------
@@ -98,7 +98,13 @@ openrtm_runtime="openrtm-aist openrtm-aist-example"
 omnipy="omniidl-python3"
 python_runtime="python3 python3-omniorb-omg"
 python_devel="python3-pip $cmake_tools $base_tools $omnipy $common_devel"
-openrtm_py_devel="openrtm-aist-python3-doc"
+res=`grep 16.04 /etc/lsb-release`
+if test ! "x$res" = "x" ; then
+  # 16.04
+  openrtm_py_devel=""
+else
+  openrtm_py_devel="openrtm-aist-python3-doc"
+fi
 openrtm_py_runtime="openrtm-aist-python3 openrtm-aist-python3-example"
 
 #--------------------------------------- Java


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #903 


## Description of the Change

pkg_install_ubuntu.sh の実行環境がUbuntu16.04の場合のみ、openrtm-aist-python3-doc パッケージをインストールリストから除外した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 修正したスクリプトをUbuntu16.04上で実行し、OpenRTM-aist-Python 1.2.2 のインストール処理が正常終了することを確認した。
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
