### PR TITLE
Obsolete callback functions are replaced current function.

### DIFF
--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -19,6 +19,7 @@
 #include <rtm/RTC.h>
 #include <rtm/PeriodicECSharedComposite.h>
 #include <rtm/Manager.h>
+#include <rtm/ConfigurationListener.h>
 
 #include <algorithm>
 #include <iostream>
@@ -631,8 +632,12 @@ namespace RTC
                                m_org->getObjRef());
     bindParameter("members", m_members, "", stringToStrVec);
 
-    m_configsets.setOnSetConfigurationSet(new setCallback(m_org));
-    m_configsets.setOnAddConfigurationSet(new addCallback(m_org));
+    m_configsets.addConfigurationSetListener(
+        ConfigurationSetListenerType::ON_SET_CONFIG_SET,
+        new setCallback(m_org));
+    m_configsets.addConfigurationSetListener(
+        ConfigurationSetListenerType::ON_ADD_CONFIG_SET,
+        new addCallback(m_org));
 
     m_properties["exec_cxt.periodic.sync_transition"] = "NO";
     m_properties["exec_cxt.periodic.sync_activation"] = "NO";


### PR DESCRIPTION
## Identify the Bug

issue #734

古いコールバック関数が PeriodicECShared クラスにて使われていたので修正。
その他古いコールバック関数 (ConfigurationSet関係）についても調査し、他で使われていないことも確認。
2.0ではobsolete関数群は削除しても良いかもしれない。
コンパイルが通ることは確認。

## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
