### PR TITLE
Undefined Beheivor about cast from void* to function pointer solved.

### DIFF
--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -170,13 +170,9 @@ namespace RTC
         throw InvalidOperation("Invalid file name");
       }
 
-    //  if (!init_func)
-
-    ModuleInitFunc init;
-
-    init = reinterpret_cast<ModuleInitFunc>(this->symbol(name, init_func));
-
-    init(&(Manager::instance()));
+    void (*initfptr)(Manager*);
+    *reinterpret_cast<void**>(&initfptr) = this->symbol(name, init_func);
+    (*initfptr)(&(Manager::instance()));
 
     return name;
   }


### PR DESCRIPTION
## Identify the Bug

issue #116 
ModuleManager 内で 初期化関数ポインタを取得時 C++  で未定義の void* -> 関数ポインタのキャストが行われていたので修正。


## Description of the Change

see #116 

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
