### PR TITLE
issue 217, double underscores '__' removed.

### DIFF
--- a/examples/HelloWorld/HelloRTWorld.h
+++ b/examples/HelloWorld/HelloRTWorld.h
@@ -7,8 +7,8 @@
  * $Id$
  */
 
-#ifndef __HELLORTWORLD_h__
-#define __HELLORTWORLD_h__
+#ifndef HELLORTWORLD_h
+#define HELLORTWORLD_h
 
 
 #include <rtm/RtcBase.h>
@@ -50,5 +50,5 @@ extern "C" {
   void HelloRTWorldDelete(RtcBase* p);
   void HelloRTWorldInit(RtcManager* manager);
 };
-#endif // __HELLORTWORLD_h__
+#endif // HELLORTWORLD_h
 

--- a/examples/HelloWorld/HelloRTWorld.h
+++ b/examples/HelloWorld/HelloRTWorld.h
@@ -7,8 +7,8 @@
  * $Id$
  */
 
-#ifndef HELLORTWORLD_h
-#define HELLORTWORLD_h
+#ifndef HELLORTWORLD_H
+#define HELLORTWORLD_H
 
 
 #include <rtm/RtcBase.h>
@@ -50,5 +50,5 @@ extern "C" {
   void HelloRTWorldDelete(RtcBase* p);
   void HelloRTWorldInit(RtcManager* manager);
 };
-#endif // HELLORTWORLD_h
+#endif // HELLORTWORLD_H
 

--- a/examples/StringIO/StringIn.h
+++ b/examples/StringIO/StringIn.h
@@ -7,8 +7,8 @@
  * $Id$
  */
 
-#ifndef __STRINGIN_h__
-#define __STRINGIN_h__
+#ifndef STRINGIN_H
+#define STRINGIN_H
 
 
 #include <rtm/RtcBase.h>
@@ -88,5 +88,5 @@ extern "C" {
   void StringInDelete(RtcBase* p);
   void StringInInit(RtcManager* manager);
 };
-#endif // __STRINGIN_h__
+#endif // STRINGIN_H
 

--- a/examples/StringIO/StringOut.h
+++ b/examples/StringIO/StringOut.h
@@ -7,8 +7,8 @@
  * $Id$
  */
 
-#ifndef __STRINGOUT_h__
-#define __STRINGOUT_h__
+#ifndef STRINGOUT_H
+#define STRINGOUT_H
 
 
 #include <rtm/RtcBase.h>
@@ -88,5 +88,5 @@ extern "C" {
   void StringOutDelete(RtcBase* p);
   void StringOutInit(RtcManager* manager);
 };
-#endif // __STRINGOUT_h__
+#endif // STRINGOUT_H
 

--- a/src/lib/coil/vxworks/coil/atomic.h
+++ b/src/lib/coil/vxworks/coil/atomic.h
@@ -31,23 +31,23 @@
 
 #include <coil/Mutex.h>
 #include <mutex>
-#define COIL_USES_ATOMIC_OP coil::Mutex __mutex;
+#define COIL_USES_ATOMIC_OP coil::Mutex mutex_;
 
 #define atomic_add(x, y)                        \
   {                                             \
-    std::lock_guard<coil::Mutex> guard(__mutex);    \
+    std::lock_guard<coil::Mutex> guard(mutex_);    \
     *x = *x + y;                                \
   }
 
 #define atomic_incr(x)                          \
   {                                             \
-    std::lock_guard<coil::Mutex> guard(__mutex);    \
+    std::lock_guard<coil::Mutex> guard(mutex_);    \
     ++(*x);                                     \
   }
 
 #define atomic_decr(x)                          \
   {                                             \
-    std::lock_guard<coil::Mutex> guard(__mutex);    \
+    std::lock_guard<coil::Mutex> guard(mutex_);    \
     --(*x);                                     \
   }
 
@@ -60,7 +60,7 @@ int exchange_add(int* x, int y, coil::Mutex* mutex)
 }
 
 #define atomic_exchange_add(x, y)               \
-  exchange_add(x, y, &__mutex)
+  exchange_add(x, y, &mutex_)
     
 #endif // COIL_HAS_ATOMIC_ADD
 #endif // COIL_ATOMIC_H

--- a/src/lib/coil/win32/coil/Signal.h
+++ b/src/lib/coil/win32/coil/Signal.h
@@ -26,13 +26,14 @@
 
 namespace coil
 {
-#define _SIG_WORDS      4
-#define _SIG_MAXSIG     NSIG
+#define COIL_SIG_WORDS      4
+#define COIL_SIG_MAXSIG     NSIG
 
   extern "C" using SignalHandler = void (*)(int);
-  typedef struct __sigset {
-    unsigned int __bits[_SIG_WORDS];
-  } sigset_t;
+  struct sigset_t
+  {
+    unsigned int _bits[COIL_SIG_WORDS];
+  };
 
   /*!
    * @if jp

--- a/src/lib/rtm/ECFactory.h
+++ b/src/lib/rtm/ECFactory.h
@@ -48,10 +48,10 @@ namespace RTC
    *
    * @endif
    */
-  template <class _New>
+  template <class T_New>
   ExecutionContextBase* ECCreate()
   {
-    return new _New();
+    return new T_New();
   }
 
   /*!
@@ -73,7 +73,7 @@ namespace RTC
    *
    * @endif
    */
-  template <class _Delete>
+  template <class T_Delete>
   void ECDelete(ExecutionContextBase* ec)
   {
     delete ec;

--- a/src/lib/rtm/Factory.h
+++ b/src/lib/rtm/Factory.h
@@ -41,7 +41,7 @@ namespace RTC
    * RTコンポーネントのインスタンスを生成するためのテンプレート関数。
    * RTコンポーネント管理用マネージャから呼び出される。
    * 実際には各コンポーネントのコンストラクタが呼び出される。
-   * \<_New\>で生成対象RTコンポーネントの型を指定する。
+   * \<T_New\>で生成対象RTコンポーネントの型を指定する。
    *
    * @param manager マネージャオブジェクト
    *
@@ -53,7 +53,7 @@ namespace RTC
    * This is the template function to create RT-Component's instances.
    * This is invoked from RT-Components manager.
    * Actually, each component's constructor is invoked.
-   * Specify the type of the target RT-Components for creation by \<_New\>.
+   * Specify the type of the target RT-Components for creation by \<T_New\>.
    *
    * @param manager Manager object
    *
@@ -61,10 +61,10 @@ namespace RTC
    *
    * @endif
    */
-  template <class _New>
+  template <class T_New>
   RTObject_impl* Create(Manager* manager)
   {
-    return new _New(manager);
+    return new T_New(manager);
   }
 
   /*!
@@ -91,7 +91,7 @@ namespace RTC
    * @brief RTコンポーネント破棄用テンプレート関数
    *
    * RTコンポーネントのインスタンスを破棄するためのテンプレート関数。
-   * \<_Delete\>にて破棄対象RTコンポーネントの型を指定する。
+   * \<T_Delete\>にて破棄対象RTコンポーネントの型を指定する。
    *
    * @param rtc 破棄対象RTコンポーネントのインスタンス
    *
@@ -100,13 +100,13 @@ namespace RTC
    * @brief Template function to destroy RT-Components
    *
    * This is the template function to destroy RT-Component's instances.
-   * Specify the type of the target RT-Components for destroy by \<_Delete\>.
+   * Specify the type of the target RT-Components for destroy by \<T_Delete\>.
    *
    * @param rtc The target RT-Component's instances for destruction
    *
    * @endif
    */
-  template <class _Delete>
+  template <class T_Delete>
   void Delete(RTObject_impl* rtc)
   {
     deleteRTObject(rtc);

--- a/src/lib/rtm/Macho.h
+++ b/src/lib/rtm/Macho.h
@@ -1,5 +1,5 @@
-﻿#ifndef __MACHO_HPP__
-#define __MACHO_HPP__
+﻿#ifndef MACHO_HPP
+#define MACHO_HPP
 
 // Macho - C++ Machine Objects
 //
@@ -211,11 +211,11 @@ class TestAccess;
 ////////////////////////////////////////////////////////////////////////////////
 // Check type equality at compile time.
 template<class T, class U>
-struct __SameType {
+struct CheckSameType {
 };
 
 template<class T>
-struct __SameType<T, T> {
+struct CheckSameType<T, T> {
 	using Check = bool;
 };
 
@@ -240,7 +240,7 @@ public: \
 	/* For the user a state class "constructor" and "destructor" are its entry and exit method! */ \
 	S(::Macho::_StateInstance & instance) : ::Macho::Link<S, SUPER>(instance) { \
 		/* Compile time check: S must derive directly from Link<S, SUPER> */ \
-		using MustDeriveFromLink = ::__SameType< ::Macho::Link<S, SUPER>, LINK>::Check; \
+		using MustDeriveFromLink = ::CheckSameType< ::Macho::Link<S, SUPER>, LINK>::Check; \
 	} \
 	~S() {} \
 	static const char * _state_name() { return #S; } \
@@ -1667,7 +1667,7 @@ namespace Macho {
 
 		Machine() {
 			// Compile time check: TOP must directly derive from TopBase<TOP>
-			using MustDeriveFromTopBase = typename __SameType<TopBase<TOP>, typename TOP::SUPER>::Check;
+			using MustDeriveFromTopBase = typename CheckSameType<TopBase<TOP>, typename TOP::SUPER>::Check;
 			// suppress unused-typdefs warnig
 			static_assert(static_cast<MustDeriveFromTopBase*>(nullptr)==nullptr, "dummy");
 
@@ -1679,7 +1679,7 @@ namespace Macho {
 		// other than TOP on startup.
 		Machine(const Alias & state) {
 			// Compile time check: TOP must directly derive from TopBase<TOP>
-			using MustDeriveFromTopBase = typename __SameType<TopBase<TOP>, typename TOP::SUPER>::Check;
+			using MustDeriveFromTopBase = typename CheckSameType<TopBase<TOP>, typename TOP::SUPER>::Check;
 			// suppress unused-typdefs warnig
 			static_assert(static_cast<MustDeriveFromTopBase*>(nullptr)==nullptr, "dummy");
 
@@ -1974,4 +1974,4 @@ namespace Macho {
 } // namespace Macho
 
 
-#endif // __MACHO_HPP__
+#endif // MACHO_HPP

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -87,7 +87,7 @@
     S(::Macho::_StateInstance & instance)                               \
       : ::RTC::Link<S, SUPER>(instance)                                 \
     {                                                                   \
-      using MustDeriveFromLink = ::__SameType<::RTC::Link<S, SUPER>,    \
+      using MustDeriveFromLink = ::CheckSameType<::RTC::Link<S, SUPER>,    \
                                               LINK>::Check;             \
       static_assert(static_cast<MustDeriveFromLink*>(nullptr)==nullptr, \
                     "dummy assert for suppress warning");               \


### PR DESCRIPTION
## Identify the Bug
modified for issue #217.

## Description of the Change

double underscores '__' removed

## Verification 

コンパイルが通ることは確認したが、coil/ace ,coil/vxworks への変更が含まれる。
ただし、ace/vxworks は更新していない、環境が無いため確認不要。

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
