### PR TITLE
周期関数呼び出しTimerに追加した関数がすぐに呼び出される問題の修正

### DIFF
--- a/src/lib/coil/common/coil/Timer.h
+++ b/src/lib/coil/common/coil/Timer.h
@@ -111,7 +111,7 @@ namespace coil
      */
     PeriodicFunction(std::function<void(void)> fn,
                      std::chrono::nanoseconds period)
-      : m_fn(std::move(fn)), m_remains(0), m_period(period) {}
+      : m_fn(std::move(fn)), m_remains(period), m_period(period) {}
 
     /*!
      * @if jp

--- a/src/lib/coil/common/coil/Timer.h
+++ b/src/lib/coil/common/coil/Timer.h
@@ -110,7 +110,7 @@ namespace coil
      * @endif
      */
     PeriodicFunction(std::function<void(void)> fn,
-                     std::chrono::nanoseconds period)
+                     std::chrono::nanoseconds period) noexcept
       : m_fn(std::move(fn)), m_remains(period), m_period(period) {}
 
     /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

周期的に関数を呼び出すタイマ(`coil::Timer<coil::PeriodicFunction>`)に関数、実行周期を設定すると、最初にtick関数を呼び出したときに設定した実行周期に関わらず1度実行してしまう。
例えば、`manager.auto_shutdown_duration`で設定した時間が100秒だとしても、タイマのループが始まった時に必ず実行する。

## Description of the Change

PeriodicFunctionクラスのtick関数では、関数を呼ぶ度に`m_remains`に保持した時間から`interval`を引いて0以下になった時に関数を呼んでいるが、`m_remains`の初期値が0のため最初は必ず実行する。
このため`m_remains`の初期値を実行周期に設定するようにした。



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
