### PR TITLE
ROSTransportで複数のsubscriberにデータを送信できない問題の修正

### DIFF
--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 set(target ROSTransport)
 
-set(srcs ROSTransport.cpp ROSTransport.h ROSInPort.cpp ROSInPort.h ROSOutPort.cpp ROSOutPort.h ROSMessageInfo.cpp ROSMessageInfo.h ROSTopicManager.cpp ROSTopicManager.h ROSSerializer.cpp ROSSerializer.h)
+set(srcs ROSTransport.cpp ROSTransport.h ROSInPort.cpp ROSInPort.h ROSOutPort.cpp ROSOutPort.h ROSMessageInfo.cpp ROSMessageInfo.h ROSTopicManager.cpp ROSTopicManager.h ROSSerializer.cpp ROSSerializer.h SubscriberLink.cpp SubscriberLink.h PublisherLink.cpp PublisherLink.h)
 
 
 if(VXWORKS AND NOT RTP)

--- a/src/ext/transport/ROSTransport/PublisherLink.cpp
+++ b/src/ext/transport/ROSTransport/PublisherLink.cpp
@@ -1,0 +1,337 @@
+﻿// -*- C++ -*-
+
+/*!
+ * @file  PublisherLink.cpp
+ * @brief PublisherLink class
+ * @date  $Date: 2021-01-08 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2021
+ *     Nobuhiko Miyamoto
+ *     Industrial Cyber-Physical Systems Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#include <xmlrpcpp/XmlRpc.h>
+#include <ros/connection_manager.h>
+#include "PublisherLink.h"
+
+
+
+namespace RTC
+{
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @endif
+   */
+  PublisherLink::PublisherLink() : m_num(0)
+  {
+  }
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @param conn ros::Connectionオブジェクト
+   * @param num コネクタのID
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @param conn 
+   * @param num 
+   *
+   * @endif
+   */
+  PublisherLink::PublisherLink(ros::ConnectionPtr conn, int num, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri)
+  : m_bytes_received(0), m_messages_received(0), m_drops(0)
+  {
+    m_conn = conn;
+    m_num = num;
+    m_caller_id = caller_id;
+    m_topic = topic;
+    m_xmlrpc_uri = xmlrpc_uri;
+  }
+  /*!
+   * @if jp
+   * @brief コピーコンストラクタ
+   *
+   * @param obj コピー元 
+   *
+   * @else
+   * @brief Copy Constructor
+   *
+   * @param obj
+   *
+   * @endif
+   */
+  PublisherLink::PublisherLink(const PublisherLink &obj)
+  {
+    m_conn = obj.m_conn;
+    m_num = obj.m_num;
+    m_caller_id = obj.m_caller_id;
+    m_topic = obj.m_topic;
+    m_xmlrpc_uri = obj.m_xmlrpc_uri;
+    m_bytes_received = obj.m_bytes_received;
+    m_messages_received = obj.m_messages_received;
+    m_drops = obj.m_drops;
+  }
+  /*!
+   * @if jp
+   * @brief デストラクタ
+   *
+   *
+   * @else
+   * @brief Destructor
+   *
+   *
+   * @endif
+   */
+  PublisherLink::~PublisherLink()
+  {
+
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionを取得
+   *
+   * @return ros::Connection
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  ros::ConnectionPtr PublisherLink::getConnection()
+  {
+    return m_conn;
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionを設定
+   *
+   * @param conn ros::Connection
+   *
+   * @else
+   * @brief 
+   *
+   * @param conn
+   *
+   * @endif
+   */
+  void PublisherLink::setConnection(ros::ConnectionPtr conn)
+  {
+    m_conn = conn;
+  }
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  int PublisherLink::getNum()
+  {
+    return m_num;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string PublisherLink::getCallerID() const
+  {
+    return m_caller_id;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string PublisherLink::getTopic() const
+  {
+    return m_topic;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string PublisherLink::getURI() const
+  {
+    return m_xmlrpc_uri;
+  }
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @param caller_id 
+   * @param topic 
+   * @param xmlrpc_uri 
+   *
+   * @else
+   * @brief 
+   *
+   * @param caller_id 
+   * @param topic 
+   * @param xmlrpc_uri 
+   *
+   * @endif
+   */
+  void PublisherLink::setInfo(const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri)
+  {
+    m_caller_id = caller_id;
+    m_topic = topic;
+    m_xmlrpc_uri = xmlrpc_uri;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @param rhs 
+   *
+   * @else
+   * @brief 
+   *
+   * @param rhs
+   *
+   * @endif
+  */
+  bool PublisherLink::operator==(const PublisherLink& rhs) const
+  {
+    if(m_caller_id == rhs.m_caller_id && m_topic == rhs.m_topic && m_xmlrpc_uri == rhs.m_xmlrpc_uri)
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+    
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタの情報を取得
+   *
+   *
+   * @param data 情報を格納する変数
+   * data[0]：コネクタID
+   * data[1]：接続先のXML-RPCサーバーのアドレス
+   * data[2]："i"
+   * data[3]：TCPROS or UDPROS
+   * data[4]：トピック名
+   * data[5]：true
+   * data[6]：接続情報
+   * 
+   * @else
+   * @brief 
+   *
+   *
+   * @param info
+   * 
+   *
+   * @endif
+   */
+  void PublisherLink::getInfo(XmlRpc::XmlRpcValue& data)
+  {
+    data[0] = m_num;
+    data[1] = m_xmlrpc_uri;
+    data[2] = std::string("i");
+    data[3] = std::string(m_conn->getTransport()->getType());
+    data[4] = m_topic;
+    data[5] = true;
+    data[6] = m_conn->getTransport()->getTransportInfo();
+  }
+
+  /*!
+   * @if jp
+   * @brief 受信データの統計情報取得
+   *
+   *
+   * @param data 受信データの統計情報
+   * 
+   * @else
+   * @brief 
+   *
+   * 
+   * @param data
+   *
+   * @endif
+   */
+  void PublisherLink::getStats(XmlRpc::XmlRpcValue& data)
+  {
+    data[0] = m_num;
+    data[1] = (int)m_bytes_received;
+    data[2] = (int)m_messages_received;
+    data[3] = (int)m_drops;
+    data[4] = 0;
+  }
+
+  /*!
+   * @if jp
+   * @brief データ受信時に受信したデータサイズを受け取る
+   *
+   *
+   * @param size データサイズ
+   * 
+   * @else
+   * @brief 
+   *
+   * 
+   * @param size
+   *
+   * @endif
+   */
+  void PublisherLink::notifyRead(const uint32_t& size)
+  {
+    m_bytes_received += size;
+    m_messages_received++;
+  }
+
+} // namespace RTC

--- a/src/ext/transport/ROSTransport/PublisherLink.h
+++ b/src/ext/transport/ROSTransport/PublisherLink.h
@@ -1,0 +1,296 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  PublisherLink.h
+ * @brief PublisherLink class
+ * @date  $Date: 2021-01-08 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2021
+ *     Nobuhiko Miyamoto
+ *     Industrial Cyber-Physical Systems Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#ifndef RTC_PUBLISHERLINK_H
+#define RTC_PUBLISHERLINK_H
+
+#include <ros/transport/transport_tcp.h>
+#include <xmlrpcpp/XmlRpc.h>
+
+
+namespace RTC
+{
+  /*!
+  * @if jp
+  * @class PublisherLink
+  * @brief PublisherLink クラス
+  *
+  * Subscriber側でPublisherとの接続情報(ros::Connection、接続先のノード名、コネクタのID)を格納するクラス
+  *
+  * @since 2.0.0
+  *
+  * @else
+  * @class PublisherLink
+  * @brief PublisherLink class
+  *
+  * 
+  *
+  * @since 2.0.0
+  *
+  * @endif
+  */
+  class PublisherLink
+  {
+  public:
+      /*!
+      * @if jp
+      * @brief コンストラクタ
+      *
+      * @else
+      * @brief Constructor
+      *
+      * @endif
+      */
+      PublisherLink(void);
+      /*!
+      * @if jp
+      * @brief コンストラクタ
+      *
+      * @param conn ros::Connection
+      * @param num コネクタのID
+      * @param caller_id 呼び出しID
+      * @param topic トピック名
+      * @param xmlrpc_uri 接続先のURI
+      *
+      * @else
+      * @brief Constructor
+      *
+      * @param conn 
+      * @param num 
+      * @param caller_id 
+      * @param topic 
+      * @param xmlrpc_uri 
+      *
+      * @endif
+      */
+      PublisherLink(ros::ConnectionPtr conn, int num, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
+      /*!
+      * @if jp
+      * @brief コピーコンストラクタ
+      *
+      * @param obj コピー元 
+      *
+      * @else
+      * @brief Copy Constructor
+      *
+      * @param obj
+      *
+      * @endif
+      */
+      PublisherLink(const PublisherLink &obj);
+      /*!
+      * @if jp
+      * @brief デストラクタ
+      *
+      *
+      * @else
+      * @brief Destructor
+      *
+      *
+      * @endif
+      */
+      ~PublisherLink();
+      /*!
+      * @if jp
+      * @brief ros::Connectionを取得
+      *
+      * @return ros::Connection
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      ros::ConnectionPtr getConnection();
+      /*!
+      * @if jp
+      * @brief ros::Connectionを設定
+      *
+      * @param conn ros::Connection
+      *
+      * @else
+      * @brief 
+      *
+      * @param conn
+      *
+      * @endif
+      */
+      void setConnection(ros::ConnectionPtr conn);
+      /*!
+      * @if jp
+      * @brief コネクタのID取得
+      *
+      * @return コネクタのID
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      int getNum();
+      /*!
+      * @if jp
+      * @brief 呼び出しID取得
+      *
+      * @return 呼び出しID
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      const std::string getCallerID() const;
+      /*!
+      * @if jp
+      * @brief トピック名取得
+      *
+      * @return トピック名
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      const std::string getTopic() const;
+      /*!
+      * @if jp
+      * @brief 接続先のURI取得
+      *
+      * @return 接続先のURI
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      const std::string getURI() const;
+      /*!
+      * @if jp
+      * @brief 呼び出しID、トピック名、接続先のURIを設定する
+      *
+      * @param caller_id 呼び出しID
+      * @param topic トピック名
+      * @param xmlrpc_uri 接続先のURI
+      *
+      * @else
+      * @brief 
+      *
+      * @param caller_id 
+      * @param topic 
+      * @param xmlrpc_uri 
+      *
+      * @endif
+      */
+      void setInfo(const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
+      /*!
+       * @if jp
+       * @brief コネクタの情報を取得
+       *
+       *
+       * @param data 情報を格納する変数
+       * data[0]：コネクタID
+       * data[1]：接続先のXML-RPCサーバーのアドレス
+       * data[2]："i"
+       * data[3]：TCPROS or UDPROS
+       * data[4]：トピック名
+       * data[5]：true
+       * data[6]：接続情報
+       * 
+       * @else
+       * @brief 
+       *
+       *
+       * @param info
+       * 
+       *
+       * @endif
+       */
+      void getInfo(XmlRpc::XmlRpcValue& data);
+      /*!
+       * @if jp
+       * @brief 受信データの統計情報取得
+       *
+       *
+       * @param data 受信データの統計情報
+       * 
+       * @else
+       * @brief 
+       *
+       * 
+       * @param data
+       *
+       * @endif
+       */
+      void getStats(XmlRpc::XmlRpcValue& data);
+      /*!
+       * @if jp
+       * @brief データ受信時に受信したデータサイズを受け取る
+       *
+       *
+       * @param size データサイズ
+       * 
+       * @else
+       * @brief 
+       *
+       * 
+       * @param size
+       *
+       * @endif
+       */
+      void notifyRead(const uint32_t& size);
+      /*!
+       * @if jp
+       * @brief 等価比較演算子
+       * 呼び出しID、トピック名、接続先のURIが一致した場合に等価と判定する
+       *
+       * @param rhs 比較対象のオブジェクト
+       *
+       * @else
+       * @brief 
+       *
+       * @param rhs
+       *
+       * @endif
+      */
+      bool operator==(const PublisherLink& rhs) const;
+  private:
+      ros::ConnectionPtr m_conn;
+      int m_num;
+      std::string m_caller_id;
+      std::string m_topic;
+      std::string m_xmlrpc_uri;
+      uint64_t m_bytes_received;
+      uint64_t m_messages_received;
+      uint64_t m_drops;
+  };  // class PublisherLink
+} // namespace RTC
+
+
+
+#endif // RTC_PUBLISHERLINK_H
+

--- a/src/ext/transport/ROSTransport/ROSInPort.h
+++ b/src/ext/transport/ROSTransport/ROSInPort.h
@@ -20,6 +20,7 @@
 #define RTC_ROSINPORT_H
 
 #include <vector>
+#include <mutex>
 #include <rtm/BufferBase.h>
 #include <rtm/InPortProvider.h>
 #include <rtm/CORBA_SeqUtil.h>
@@ -30,6 +31,7 @@
 #include <ros/transport/transport_tcp.h>
 #include <xmlrpcpp/XmlRpc.h>
 #include "ROSMessageInfo.h"
+#include "PublisherLink.h"
 
 
 namespace RTC
@@ -233,6 +235,8 @@ namespace RTC
      * @param caller_id 呼び出しID
      * @param topic トピック名
      * @param xmlrpc_uri パブリッシャーのURI
+     * 
+     * @return 
      *
      * 
      * @else
@@ -243,15 +247,248 @@ namespace RTC
      * @param topic 
      * @param xmlrpc_uri 
      * 
+     * @return 
+     * 
      * @return
      *
      * @endif
      */
-    void connectTCP(const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
+    bool connectTCP(const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
 
 
   
+    /*!
+     * @if jp
+     * @brief メッセージ型の取得
+     *
+     *
+     * @return メッセージ型
+     * 
+     * @else
+     * @brief 
+     *
+     * 
+     * @return
+     *
+     * @endif
+     */
+    const std::string& datatype() const;
+    /*!
+     * @if jp
+     * @brief トピック名の取得
+     *
+     *
+     * @return トピック名
+     * 
+     * @else
+     * @brief 
+     *
+     * 
+     * @return
+     *
+     * @endif
+     */
+    const std::string& getTopicName() const;
+    /*!
+     * @if jp
+     * @brief ノード名の取得
+     *
+     *
+     * @return ノード名
+     * 
+     * @else
+     * @brief 
+     *
+     * 
+     * @return
+     *
+     * @endif
+     */
+    const std::string& getName() const;
+    /*!
+     * @if jp
+     * @brief 受信データの統計情報取得
+     *
+     *
+     * @param data 受信データの統計情報
+     * 
+     * @else
+     * @brief 
+     *
+     * 
+     * @param data
+     *
+     * @endif
+     */
+    void getStats(XmlRpc::XmlRpcValue& result);
+    /*!
+     * @if jp
+     * @brief PublisherLinkの削除
+     *
+     *
+     * @param connection ros::Connectionオブジェクト
+     * @return true：削除成功
+     * 
+     * @else
+     * @brief 
+     *
+     * 
+     * @param connection 
+     * @return
+     *
+     * @endif
+     */
+    bool removePublisherLink(const ros::ConnectionPtr& connection);
+    
+    
+  private:
+    ByteData m_cdr;
 
+    
+    /*!
+     * @if jp
+     * @brief ON_BUFFER_WRITE のリスナへ通知する。 
+     * @param data ByteData
+     * @else
+     * @brief Notify an ON_BUFFER_WRITE event to listeners
+     * @param data ByteData
+     * @endif
+     */
+    inline void onBufferWrite(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_WRITE,
+                            m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_BUFFER_FULL のリスナへ通知する。 
+     * @param data ByteData
+     * @else
+     * @brief Notify an ON_BUFFER_FULL event to listeners
+     * @param data ByteData
+     * @endif
+     */
+    inline void onBufferFull(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_FULL,
+                            m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_BUFFER_WRITE_TIMEOUT のリスナへ通知する。 
+     * @param data ByteData
+     * @else
+     * @brief Notify an ON_BUFFER_WRITE_TIMEOUT event to listeners
+     * @param data ByteData
+     * @endif
+     */
+    inline void onBufferWriteTimeout(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_WRITE_TIMEOUT,
+                            m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_BUFFER_WRITE_OVERWRITE のリスナへ通知する。 
+     * @param data ByteData
+     * @else
+     * @brief Notify an ON_BUFFER_WRITE_OVERWRITE event to listeners
+     * @param data ByteData
+     * @endif
+     */
+    inline void onBufferWriteOverwrite(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_OVERWRITE,
+                            m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_RECEIVED のリスナへ通知する。 
+     * @param data ByteData
+     * @else
+     * @brief Notify an ON_RECEIVED event to listeners
+     * @param data ByteData
+     * @endif
+     */
+    inline void onReceived(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVED,
+                            m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_RECEIVER_FULL のリスナへ通知する。 
+     * @param data ByteData
+     * @else
+     * @brief Notify an ON_RECEIVER_FULL event to listeners
+     * @param data ByteData
+     * @endif
+     */
+    inline void onReceiverFull(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVER_FULL,
+                            m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_RECEIVER_TIMEOUT のリスナへ通知する。 
+     * @else
+     * @brief Notify an ON_RECEIVER_TIMEOUT event to listeners
+     * @endif
+     */
+    inline void onReceiverTimeout(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVER_TIMEOUT,
+                            m_profile, data);
+    }
+
+    /*!
+     * @if jp
+     * @brief ON_RECEIVER_ERRORのリスナへ通知する。 
+     * @else
+     * @Brief Notify an ON_RECEIVER_ERROR event to listeners
+     * @endif
+     */
+    inline void onReceiverError(ByteData& data)
+    {
+      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVER_ERROR,
+                            m_profile, data);
+    }
+
+  private:
+    /*!
+     * @if jp
+     * @brief リターンコード変換
+     * @else
+     * @brief Return codes conversion
+     * @endif
+     */
+    void convertReturn(BufferStatus status, ByteData& data);
+
+    CdrBufferBase* m_buffer;
+    ConnectorInfo m_profile;
+    ConnectorListenersBase* m_listeners;
+    InPortConnector* m_connector;
+
+    
+    std::string m_topic;
+    std::string m_callerid;
+    std::string m_messageType;
+    std::mutex m_mutex;
+
+    std::vector<PublisherLink> m_tcp_connecters;
+    std::mutex m_con_mutex;
+    std::string m_roscorehost;
+    unsigned int m_roscoreport;
+    std::string m_datatype;
+
+  public:
     /*!
      * @if jp
      * @brief ヘッダ情報送信時のコールバック関数
@@ -404,230 +641,19 @@ namespace RTC
 
         convertReturn(ret, m_cdr);
 
+        std::lock_guard<std::mutex> guardc(m_con_mutex);
+        for(auto & tcp_connecter : m_tcp_connecters)
+        {
+          if(tcp_connecter.getConnection() == conn)
+          {
+            tcp_connecter.notifyRead(size);
+          }
+        }
+
 
         conn->read(ROSMsglenSize, boost::bind(&ROSInPort::onMessageLength, this, _1, _2, _3, _4));
       }
     }
-    /*!
-     * @if jp
-     * @brief コネクタの情報を取得
-     *
-     *
-     * @param info 情報を格納する変数
-     * data[0]：コネクタID
-     * data[1]：接続先のXML-RPCサーバーのアドレス
-     * data[2]："i"
-     * data[3]：TCPROS or UDPROS
-     * data[4]：トピック名
-     * data[5]：true
-     * data[6]：接続情報
-     * 
-     * @else
-     * @brief 
-     *
-     *
-     * @param info
-     * 
-     *
-     * @endif
-     */
-    void getInfo(XmlRpc::XmlRpcValue& info);
-    /*!
-     * @if jp
-     * @brief メッセージ型の取得
-     *
-     *
-     * @return メッセージ型
-     * 
-     * @else
-     * @brief 
-     *
-     * 
-     * @return
-     *
-     * @endif
-     */
-    const std::string& datatype() const;
-    /*!
-     * @if jp
-     * @brief トピック名の取得
-     *
-     *
-     * @return トピック名
-     * 
-     * @else
-     * @brief 
-     *
-     * 
-     * @return
-     *
-     * @endif
-     */
-    const std::string& getTopicName() const;
-    /*!
-     * @if jp
-     * @brief ノード名の取得
-     *
-     *
-     * @return ノード名
-     * 
-     * @else
-     * @brief 
-     *
-     * 
-     * @return
-     *
-     * @endif
-     */
-    const std::string& getName() const;
-    
-    
-  private:
-    ByteData m_cdr;
-
-    
-    /*!
-     * @if jp
-     * @brief ON_BUFFER_WRITE のリスナへ通知する。 
-     * @param data ByteData
-     * @else
-     * @brief Notify an ON_BUFFER_WRITE event to listeners
-     * @param data ByteData
-     * @endif
-     */
-    inline void onBufferWrite(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_WRITE,
-                            m_profile, data);
-    }
-
-    /*!
-     * @if jp
-     * @brief ON_BUFFER_FULL のリスナへ通知する。 
-     * @param data ByteData
-     * @else
-     * @brief Notify an ON_BUFFER_FULL event to listeners
-     * @param data ByteData
-     * @endif
-     */
-    inline void onBufferFull(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_FULL,
-                            m_profile, data);
-    }
-
-    /*!
-     * @if jp
-     * @brief ON_BUFFER_WRITE_TIMEOUT のリスナへ通知する。 
-     * @param data ByteData
-     * @else
-     * @brief Notify an ON_BUFFER_WRITE_TIMEOUT event to listeners
-     * @param data ByteData
-     * @endif
-     */
-    inline void onBufferWriteTimeout(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_WRITE_TIMEOUT,
-                            m_profile, data);
-    }
-
-    /*!
-     * @if jp
-     * @brief ON_BUFFER_WRITE_OVERWRITE のリスナへ通知する。 
-     * @param data ByteData
-     * @else
-     * @brief Notify an ON_BUFFER_WRITE_OVERWRITE event to listeners
-     * @param data ByteData
-     * @endif
-     */
-    inline void onBufferWriteOverwrite(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_BUFFER_OVERWRITE,
-                            m_profile, data);
-    }
-
-    /*!
-     * @if jp
-     * @brief ON_RECEIVED のリスナへ通知する。 
-     * @param data ByteData
-     * @else
-     * @brief Notify an ON_RECEIVED event to listeners
-     * @param data ByteData
-     * @endif
-     */
-    inline void onReceived(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVED,
-                            m_profile, data);
-    }
-
-    /*!
-     * @if jp
-     * @brief ON_RECEIVER_FULL のリスナへ通知する。 
-     * @param data ByteData
-     * @else
-     * @brief Notify an ON_RECEIVER_FULL event to listeners
-     * @param data ByteData
-     * @endif
-     */
-    inline void onReceiverFull(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVER_FULL,
-                            m_profile, data);
-    }
-
-    /*!
-     * @if jp
-     * @brief ON_RECEIVER_TIMEOUT のリスナへ通知する。 
-     * @else
-     * @brief Notify an ON_RECEIVER_TIMEOUT event to listeners
-     * @endif
-     */
-    inline void onReceiverTimeout(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVER_TIMEOUT,
-                            m_profile, data);
-    }
-
-    /*!
-     * @if jp
-     * @brief ON_RECEIVER_ERRORのリスナへ通知する。 
-     * @else
-     * @Brief Notify an ON_RECEIVER_ERROR event to listeners
-     * @endif
-     */
-    inline void onReceiverError(ByteData& data)
-    {
-      m_listeners->notifyIn(ConnectorDataListenerType::ON_RECEIVER_ERROR,
-                            m_profile, data);
-    }
-
-  private:
-    /*!
-     * @if jp
-     * @brief リターンコード変換
-     * @else
-     * @brief Return codes conversion
-     * @endif
-     */
-    void convertReturn(BufferStatus status, ByteData& data);
-
-    CdrBufferBase* m_buffer;
-    ConnectorInfo m_profile;
-    ConnectorListenersBase* m_listeners;
-    InPortConnector* m_connector;
-
-    
-    std::string m_topic;
-    std::string m_callerid;
-    std::string m_messageType;
-    std::mutex m_mutex;
-
-    std::vector<ros::ConnectionPtr> m_tcp_connecters;
-    std::string m_roscorehost;
-    unsigned int m_roscoreport;
-    std::string m_datatype;
-
 
   };  // class InPortCorCdrbaProvider
 } // namespace RTC

--- a/src/ext/transport/ROSTransport/ROSInPort.h
+++ b/src/ext/transport/ROSTransport/ROSInPort.h
@@ -19,7 +19,7 @@
 #ifndef RTC_ROSINPORT_H
 #define RTC_ROSINPORT_H
 
-#include <map>
+#include <vector>
 #include <rtm/BufferBase.h>
 #include <rtm/InPortProvider.h>
 #include <rtm/CORBA_SeqUtil.h>
@@ -249,29 +249,7 @@ namespace RTC
      */
     void connectTCP(const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
 
-    /*!
-     * @if jp
-     * @brief TCPコネクタの削除
-     *
-     *
-     * @param caller_id 呼び出しID
-     * @param topic トピック名
-     * @param xmlrpc_uri パブリッシャーのURI
-     *
-     * 
-     * @else
-     * @brief 
-     *
-     *
-     * @param caller_id 
-     * @param topic 
-     * @param xmlrpc_uri 
-     * 
-     * @return
-     *
-     * @endif
-     */
-    void deleteTCPConnector(const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
+
   
 
     /*!
@@ -645,129 +623,7 @@ namespace RTC
     std::string m_messageType;
     std::mutex m_mutex;
 
-    /*!
-     * @if jp
-     * @class PublisherLink
-     * @brief PublisherLink クラス
-     *
-     * ros::Connection、コネクタのIDを格納するクラス
-     *
-     * @since 2.0.0
-     *
-     * @else
-     * @class PublisherLink
-     * @brief PublisherLink class
-     *
-     * 
-     *
-     * @since 2.0.0
-     *
-     * @endif
-     */
-    class PublisherLink
-    {
-    public:
-      /*!
-       * @if jp
-       * @brief コンストラクタ
-       *
-       * @else
-       * @brief Constructor
-       *
-       * @endif
-       */
-      PublisherLink(void);
-      /*!
-       * @if jp
-       * @brief コンストラクタ
-       *
-       * @param conn ros::Connection
-       * @param num コネクタのID
-       *
-       * @else
-       * @brief Constructor
-       *
-       * @param conn 
-       * @param num 
-       *
-       * @endif
-       */
-      PublisherLink(ros::ConnectionPtr conn, int num);
-      /*!
-       * @if jp
-       * @brief コピーコンストラクタ
-       *
-       * @param obj コピー元 
-       *
-       * @else
-       * @brief Copy Constructor
-       *
-       * @param obj
-       *
-       * @endif
-       */
-      PublisherLink(const PublisherLink &obj);
-      /*!
-       * @if jp
-       * @brief デストラクタ
-       *
-       *
-       * @else
-       * @brief Destructor
-       *
-       *
-       * @endif
-       */
-      ~PublisherLink();
-      /*!
-       * @if jp
-       * @brief ros::Connectionを取得
-       *
-       * @return ros::Connection
-       *
-       * @else
-       * @brief 
-       *
-       * @return
-       *
-       * @endif
-       */
-      ros::ConnectionPtr getConnection();
-      /*!
-       * @if jp
-       * @brief ros::Connectionを設定
-       *
-       * @param conn ros::Connection
-       *
-       * @else
-       * @brief 
-       *
-       * @param conn
-       *
-       * @endif
-       */
-      void setConnection(ros::ConnectionPtr conn);
-      /*!
-       * @if jp
-       * @brief コネクタのID取得
-       *
-       * @return コネクタのID
-       *
-       * @else
-       * @brief 
-       *
-       * @return
-       *
-       * @endif
-       */
-      int getNum();
-    private:
-      ros::ConnectionPtr m_conn;
-      int m_num;
-    };
-
-    std::map<std::string, PublisherLink> m_tcp_connecters;
-    int m_pubnum;
+    std::vector<ros::ConnectionPtr> m_tcp_connecters;
     std::string m_roscorehost;
     unsigned int m_roscoreport;
     std::string m_datatype;

--- a/src/ext/transport/ROSTransport/ROSOutPort.h
+++ b/src/ext/transport/ROSTransport/ROSOutPort.h
@@ -22,12 +22,14 @@
 
 
 #include <vector>
+#include <mutex>
 #include <rtm/InPortConsumer.h>
 #include <rtm/Manager.h>
 #include <ros/transport/transport_tcp.h>
 #include <ros/connection.h>
 #include <xmlrpcpp/XmlRpc.h>
 #include "ROSMessageInfo.h"
+#include "SubscriberLink.h"
 
 
 namespace RTC
@@ -275,54 +277,6 @@ namespace RTC
     }
 
 
-
-    /*!
-     * @if jp
-     * @brief メッセージ送信時のコールバック関数
-     *
-     *
-     * @param conn ros::Connection
-     *
-     * 
-     * @else
-     * @brief 
-     *
-     *
-     * @param conn 
-     * 
-     * @return
-     *
-     * @endif
-     */
-    void onMessageWritten(const ros::ConnectionPtr& conn)
-    {
-      (void)conn;
-      RTC_VERBOSE(("onMessageWritten()"));
-    }
-    /*!
-     * @if jp
-     * @brief コネクタの情報を取得
-     *
-     *
-     * @param info 情報を格納する変数
-     * data[0]：コネクタID
-     * data[1]：接続先のノード名
-     * data[2]："o"
-     * data[3]：TCPROS or UDPROS
-     * data[4]：トピック名
-     * data[5]：true
-     * data[6]：接続情報
-     * 
-     * @else
-     * @brief 
-     *
-     *
-     * @param info
-     * 
-     *
-     * @endif
-     */
-    void getInfo(XmlRpc::XmlRpcValue& info);
     /*!
      * @if jp
      * @brief メッセージ型の取得
@@ -371,13 +325,46 @@ namespace RTC
      * @endif
      */
     const std::string& getName() const;
+    /*!
+     * @if jp
+     * @brief 送信データの統計情報取得
+     *
+     *
+     * @param data 送信データの統計情報
+     * 
+     * @else
+     * @brief 
+     *
+     * 
+     * @param data
+     *
+     * @endif
+     */
+    void getStats(XmlRpc::XmlRpcValue& result);
+    /*!
+     * @if jp
+     * @brief SubscriberLinkの削除
+     *
+     * @param connection ros::Connectionオブジェクト
+     * @return true：削除成功
+     * 
+     * @else
+     * @brief 
+     *
+     * @param connection 
+     * @return 
+     *
+     * @endif
+     */
+    bool removeSubscriberLink(const ros::ConnectionPtr& connection);
 
   private:
 
     mutable Logger rtclog;
     bool m_start;
     coil::Properties m_properties;
-    std::vector<ros::ConnectionPtr> m_tcp_connecters;
+    std::vector<SubscriberLink> m_tcp_connecters;
+    std::mutex m_con_mutex;
     
     std::string m_topic;
     std::string m_callerid;

--- a/src/ext/transport/ROSTransport/ROSOutPort.h
+++ b/src/ext/transport/ROSTransport/ROSOutPort.h
@@ -373,6 +373,7 @@ namespace RTC
     std::string m_datatype;
     std::string m_roscorehost;
     unsigned int m_roscoreport;
+    uint64_t m_message_data_sent;
   };
 } // namespace RTC
 

--- a/src/ext/transport/ROSTransport/ROSOutPort.h
+++ b/src/ext/transport/ROSTransport/ROSOutPort.h
@@ -21,7 +21,7 @@
 
 
 
-#include <map>
+#include <vector>
 #include <rtm/InPortConsumer.h>
 #include <rtm/Manager.h>
 #include <ros/transport/transport_tcp.h>
@@ -227,28 +227,6 @@ namespace RTC
 
     /*!
      * @if jp
-     * @brief ROSTCPでパブリッシャーとサブスクライバーを接続する
-     *
-     *
-     * @param transport TransportTCP
-     *
-     * @return True：接続成功、False：接続失敗
-     * 接続済みの場合はFalse
-     * 
-     * @else
-     * @brief 
-     *
-     *
-     * @param transport 
-     * 
-     * @return
-     *
-     * @endif
-     */
-    bool connectTCP(const ros::TransportTCPPtr& transport);
-
-    /*!
-     * @if jp
      * @brief ヘッダ情報受信時のコールバック関数
      *
      *
@@ -268,70 +246,7 @@ namespace RTC
      *
      * @endif
      */
-    bool onConnectionHeaderReceived(const ros::ConnectionPtr& conn, const ros::Header& header)
-    {
-      RTC_VERBOSE(("onConnectionHeaderReceived()"));
-
-      std::string topic;
-      if (!header.getValue("topic", topic))
-      {
-        RTC_ERROR(("Topic name does not exist in header"));
-        return false;
-      }
-
-      if(m_topic != topic)
-      {
-        RTC_VERBOSE(("Topic names do not match. %s %s", m_topic.c_str(), topic.c_str()));
-        return false;
-      }
-
-      std::string client_callerid;
-      if (!header.getValue("callerid", client_callerid))
-      {
-        RTC_ERROR(("Callse id does not exist in header"));
-        return false;
-      }
-
-      for (auto & con : m_tcp_connecters)
-      {
-        if(con.second.getConnection() == conn)
-        {
-          con.second.setNoneName(client_callerid);
-        }
-        
-      }
-
-      
-
-      ROSMessageInfoBase* info = GlobalROSMessageInfoList::instance().getInfo(m_messageType);
-      
-      if(!info)
-      {
-        RTC_ERROR(("Can not find message type(%s)", m_messageType.c_str()));
-        return false;
-      }
-
-      ros::M_string m;
-      m["type"] = info->type();
-      m["md5sum"] = info->md5sum();
-      m["message_definition"] = info->message_definition();
-      m["callerid"] = m_callerid;
-      m["latching"] = "0";
-      m["topic"] = topic;
-      
-
-      RTC_VERBOSE(("TCPTransPort created"));
-      RTC_VERBOSE(("Message Type:%s", info->type().c_str()));
-      RTC_VERBOSE(("Md5sum:%s", info->md5sum().c_str()));
-      RTC_VERBOSE(("Message Definition:%s", info->message_definition().c_str()));
-      RTC_VERBOSE(("Caller ID:%s", m_callerid.c_str()));
-      RTC_VERBOSE(("Topic Name:%s", topic.c_str()));
-      RTC_VERBOSE(("TCPTransPort created"));
-
-
-      conn->writeHeader(m, boost::bind(&ROSOutPort::onHeaderWritten, this, _1));
-      return true;
-    }
+    bool onConnectionHeaderReceived(const ros::ConnectionPtr& conn, const ros::Header& header);
 
     /*!
      * @if jp
@@ -462,159 +377,7 @@ namespace RTC
     mutable Logger rtclog;
     bool m_start;
     coil::Properties m_properties;
-    int m_subnum;
-
-
-    /*!
-     * @if jp
-     * @class SubscriberLink
-     * @brief SubscriberLink クラス
-     *
-     * ros::Connection、接続先のノード名、コネクタのIDを格納するクラス
-     *
-     * @since 2.0.0
-     *
-     * @else
-     * @class SubscriberLink
-     * @brief SubscriberLink class
-     *
-     * 
-     *
-     * @since 2.0.0
-     *
-     * @endif
-     */
-    class SubscriberLink
-    {
-    public:
-      /*!
-       * @if jp
-       * @brief コンストラクタ
-       *
-       * @else
-       * @brief Constructor
-       *
-       * @endif
-       */
-      SubscriberLink();
-      /*!
-       * @if jp
-       * @brief コンストラクタ
-       *
-       * @param conn ros::Connection
-       * @param num コネクタのID
-       *
-       * @else
-       * @brief Constructor
-       *
-       * @param conn 
-       * @param num 
-       *
-       * @endif
-       */
-      SubscriberLink(ros::ConnectionPtr conn, int num);
-      /*!
-       * @if jp
-       * @brief コピーコンストラクタ
-       *
-       * @param obj コピー元 
-       *
-       * @else
-       * @brief Copy Constructor
-       *
-       * @param obj
-       *
-       * @endif
-       */
-      SubscriberLink(const SubscriberLink &obj);
-      /*!
-       * @if jp
-       * @brief デストラクタ
-       *
-       *
-       * @else
-       * @brief Destructor
-       *
-       *
-       * @endif
-       */
-      ~SubscriberLink();
-      /*!
-       * @if jp
-       * @brief 接続先のノード名を設定
-       *
-       * @param name ノード名
-       *
-       * @else
-       * @brief 
-       *
-       * @param name
-       *
-       * @endif
-       */
-      void setNoneName(std::string& name);
-      /*!
-       * @if jp
-       * @brief 接続先のノード名を取得
-       *
-       * @return ノード名
-       *
-       * @else
-       * @brief 
-       *
-       * @return
-       *
-       * @endif
-       */
-      const std::string getNodeName() const;
-      /*!
-       * @if jp
-       * @brief ros::Connectionを設定
-       *
-       * @param conn ros::Connection
-       *
-       * @else
-       * @brief 
-       *
-       * @param conn
-       *
-       * @endif
-       */
-      void setConnection(ros::ConnectionPtr conn);
-      /*!
-       * @if jp
-       * @brief ros::Connectionを取得
-       *
-       * @return ros::Connection
-       *
-       * @else
-       * @brief 
-       *
-       * @return
-       *
-       * @endif
-       */
-      ros::ConnectionPtr getConnection();
-      /*!
-       * @if jp
-       * @brief コネクタのID取得
-       *
-       * @return コネクタのID
-       *
-       * @else
-       * @brief 
-       *
-       * @return
-       *
-       * @endif
-       */
-      int getNum();
-    private:
-      std::string m_nodename;
-      ros::ConnectionPtr m_conn;
-      int m_num;
-    };
-    std::map<std::string, SubscriberLink> m_tcp_connecters;
+    std::vector<ros::ConnectionPtr> m_tcp_connecters;
     
     std::string m_topic;
     std::string m_callerid;

--- a/src/ext/transport/ROSTransport/ROSTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.cpp
@@ -56,6 +56,9 @@ namespace RTC
    * @endif
    */
   ROSTopicManager::ROSTopicManager()
+  : rtclog("ROSTopicManager"),
+    m_subnum(0),
+    m_pubnum(0)
   {
 
   }
@@ -74,6 +77,7 @@ namespace RTC
    * @endif
    */
   ROSTopicManager::ROSTopicManager(const ROSTopicManager &/*mgr*/)
+  : rtclog("ROSTopicManager")
   {
     
   }
@@ -387,88 +391,103 @@ namespace RTC
    */
   void ROSTopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
   {
-      if (params.getType() != XmlRpc::XmlRpcValue::TypeArray)
-      {
-          result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
-          return;
-      }
-      if (params.size() < 3)
-      {
-          result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
-          return;
-      }
-
-      if (params[0].getType() != XmlRpc::XmlRpcValue::TypeString)
-      {
-          result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
-          return;
-      }
-      if (params[1].getType() != XmlRpc::XmlRpcValue::TypeString)
-      {
-          result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
-          return;
-      }
-
-      std::string caller_id = params[0];
-      std::string topic = params[1];
-      
-      
-      if(m_cons.count(topic) == 0)
-      {
-        m_cons[topic] = std::vector<std::string>();
-      }
-      
-      if (params[2].getType() != XmlRpc::XmlRpcValue::TypeArray)
-      {
-      
+    if (params.getType() != XmlRpc::XmlRpcValue::TypeArray)
+    {
         result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
         return;
+    }
+    if (params.size() < 3)
+    {
+        result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
+        return;
+    }
+
+    if (params[0].getType() != XmlRpc::XmlRpcValue::TypeString)
+    {
+        result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
+        return;
+    }
+    if (params[1].getType() != XmlRpc::XmlRpcValue::TypeString)
+    {
+        result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
+        return;
+    }
+
+    std::string caller_id = params[0];
+    std::string topic = params[1];
+    
+    
+    if (params[2].getType() != XmlRpc::XmlRpcValue::TypeArray)
+    {
+    
+      result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
+      return;
+    }
+    
+    std::vector<std::string> new_ = std::vector<std::string>();
+    std::vector<std::string> old_ = m_cons[topic];
+    
+    for (int i = 0; i < params[2].size(); i++)
+    {
+      if (params[2][i].getType() != XmlRpc::XmlRpcValue::TypeString)
+      {
+          result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
+          break;
+      }
+      std::string xmlrpc_uri = params[2][i];
+      if (xmlrpc_uri.empty())
+      {
+          result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
+          break;
+      }
+      bool already_connected = false;
+      for (auto con = m_tcp_pub_connecters.begin(); con != m_tcp_pub_connecters.end(); con++)
+      {
+        if(con->getCallerID() == caller_id && con->getTopic() == topic && con->getURI() == xmlrpc_uri)
+        {
+          RTC_WARN(("%s already connected", xmlrpc_uri.c_str()));
+          if(con->getConnection()->isDropped())
+          {
+            RTC_ERROR(("delete connector: %s", xmlrpc_uri.c_str()));
+            con = m_tcp_pub_connecters.erase(con);
+          }
+          else
+          {
+            already_connected = true;
+            break;
+          }
+        }
       }
       
-      std::vector<std::string> new_ = std::vector<std::string>();
-      std::vector<std::string> old_ = m_cons[topic];
-      
-      for (int i = 0; i < params[2].size(); i++)
+      if(!already_connected)
       {
-        if (params[2][i].getType() != XmlRpc::XmlRpcValue::TypeString)
-        {
-            result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
-            return;
-        }
-        std::string xmlrpc_uri = params[2][i];
-        if (xmlrpc_uri.empty())
-        {
-            result = ros::xmlrpc::responseInt(0, ros::console::g_last_error_message, 0);
-            return;
-        }
-
         for(auto & subscriber : m_subscribers)
         {
           subscriber->connectTCP(caller_id, topic, xmlrpc_uri);
         }
-        new_.emplace_back(xmlrpc_uri);
       }
-      
-      for(auto & old_uri : old_)
+      new_.emplace_back(xmlrpc_uri);
+    }
+
+    for(auto & old_uri : old_)
+    {
+      std::vector<std::string>::iterator itr_uri = std::find(new_.begin(), new_.end(), old_uri);
+      size_t index = std::distance( new_.begin(), itr_uri );
+    
+      if (index == new_.size()) 
       {
-        std::vector<std::string>::iterator itr_uri = std::find(new_.begin(), new_.end(), old_uri);
-        size_t index = std::distance( new_.begin(), itr_uri );
-      
-        if (index == new_.size()) 
+        for (auto con = m_tcp_pub_connecters.begin(); con != m_tcp_pub_connecters.end(); con++)
         {
-          for(auto & subscriber : m_subscribers)
+          if(con->getCallerID() == caller_id && con->getTopic() == topic && con->getURI() == old_uri)
           {
-            subscriber->deleteTCPConnector(caller_id, topic, old_uri);
+            con = m_tcp_pub_connecters.erase(con);
           }
         }
       }
-
-      m_cons[topic] = new_;
-      
-      result = ros::xmlrpc::responseInt(1, "", 0);
-      
-      
-      
+    }
+    
+    result = ros::xmlrpc::responseInt(1, "", 0);
+ 
   }
 
 
@@ -619,6 +638,215 @@ namespace RTC
 
   /*!
    * @if jp
+   * @brief Publisher
+   *
+   * @return 
+   *
+   * @else
+   * @brief
+   *
+   *
+   * @return 
+   *
+   * @endif
+   */
+  std::vector<ROSTopicManager::PublisherLink> & ROSTopicManager::getPublisherLinkList()
+  {
+    return m_tcp_pub_connecters;
+  }
+  /*!
+   * @if jp
+   * @brief Subscriber
+   *
+   * @return 
+   *
+   * @else
+   * @brief
+   *
+   *
+   * @return 
+   *
+   * @endif
+   */
+  std::vector<ROSTopicManager::SubscriberLink> & ROSTopicManager::getSubscriberLinkList()
+  {
+    return m_tcp_sub_connecters;
+  }
+
+
+  /*!
+   * @if jp
+   * @brief サブスクライバーの存在確認
+   * 
+   * @param connection サブスクライバー
+   * @param caller_id サブスクライバー
+   * @param topic サブスクライバー
+   * @param xmlrpc_uri サブスクライバー
+   * @return True：存在する
+   *
+   * @else
+   * @brief 
+   *
+   * @param connection 
+   * @param caller_id 
+   * @param topic 
+   * @param xmlrpc_uri 
+   * @return 
+   * 
+   *
+   * @endif
+   */
+  bool ROSTopicManager::addPublisherLink(ros::ConnectionPtr& connection, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri)
+  {
+    m_tcp_pub_connecters.push_back(ROSTopicManager::PublisherLink(connection, m_pubnum, caller_id, topic, xmlrpc_uri));
+    m_pubnum++;
+    return true;
+  }
+  /*!
+   * @if jp
+   * @brief サブスクライバーの存在確認
+   * 
+   * @param uri サブスクライバー
+   * @return True：存在する
+   *
+   * @else
+   * @brief 
+   *
+   * @param uri 
+   * @return 
+   * 
+   *
+   * @endif
+   */
+  bool ROSTopicManager::removePublisherLink(ros::ConnectionPtr& connection)
+  {
+    for (auto con = m_tcp_pub_connecters.begin(); con != m_tcp_pub_connecters.end(); con++)
+    {
+      if(con->getConnection() == connection)
+      {
+        con->getConnection()->drop(ros::Connection::Destructing);
+        con = m_tcp_pub_connecters.erase(con);
+        return true;
+      }
+    }
+    return false;
+  }
+  /*!
+   * @if jp
+   * @brief サブスクライバーの存在確認
+   * 
+   * @param connection サブスクライバー
+   * @param caller_id サブスクライバー
+   * @param topic サブスクライバー
+   * @param xmlrpc_uri サブスクライバー
+   * @return True：存在する
+   *
+   * @else
+   * @brief 
+   *
+   * @param connection 
+   * @param caller_id 
+   * @param topic 
+   * @param xmlrpc_uri 
+   * @return 
+   * 
+   *
+   * @endif
+   */
+  bool ROSTopicManager::addSubscriberLink(ros::ConnectionPtr& connection)
+  {
+    m_tcp_sub_connecters.push_back(ROSTopicManager::SubscriberLink(connection, m_subnum));
+    m_subnum++;
+    return true;
+  }
+  /*!
+   * @if jp
+   * @brief サブスクライバーの存在確認
+   * 
+   * @param uri サブスクライバー
+   * @return True：存在する
+   *
+   * @else
+   * @brief 
+   *
+   * @param uri 
+   * @return 
+   * 
+   *
+   * @endif
+   */
+  bool ROSTopicManager::removeSubscriberLink(ros::ConnectionPtr& connection)
+  {
+    for (auto con = m_tcp_sub_connecters.begin(); con != m_tcp_sub_connecters.end(); con++)
+    {
+      if(con->getConnection() == connection)
+      {
+        con->getConnection()->drop(ros::Connection::Destructing);
+        con = m_tcp_sub_connecters.erase(con);
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+  /*!
+   * @if jp
+   * @brief サブスクライバーの存在確認
+   * 
+   * @param connection サブスクライバー
+   * @return True：存在する
+   *
+   * @else
+   * @brief 
+   *
+   * @param connection 
+   * @return 
+   * 
+   *
+   * @endif
+   */
+  ROSTopicManager::PublisherLink* ROSTopicManager::getPublisherLink(const ros::ConnectionPtr& connection)
+  {
+    for(auto & tcp_connecter : m_tcp_pub_connecters)
+    {
+      if(tcp_connecter.getConnection() == connection)
+      {
+        return &tcp_connecter;
+      }
+    }
+    return nullptr;
+  }
+  /*!
+   * @if jp
+   * @brief サブスクライバーの存在確認
+   * 
+   * @param connection サブスクライバー
+   * @return True：存在する
+   *
+   * @else
+   * @brief 
+   *
+   * @param connection 
+   * @return 
+   * 
+   *
+   * @endif
+   */
+  ROSTopicManager::SubscriberLink* ROSTopicManager::getSubscriberLink(const ros::ConnectionPtr& connection)
+  {
+    for(auto & tcp_connecter : m_tcp_sub_connecters)
+    {
+      if(tcp_connecter.getConnection() == connection)
+      {
+        return &tcp_connecter;
+      }
+    }
+    return nullptr;
+  }
+
+  /*!
+   * @if jp
    * @brief 初期化関数
    * 
    * @return インスタンス
@@ -687,6 +915,336 @@ namespace RTC
       {
           manager->shutdown();
       }
+  }
+
+    /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @endif
+   */
+  ROSTopicManager::PublisherLink::PublisherLink() : m_num(0)
+  {
+  }
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @param conn ros::Connection
+   * @param num コネクタのID
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @param conn 
+   * @param num 
+   *
+   * @endif
+   */
+  ROSTopicManager::PublisherLink::PublisherLink(ros::ConnectionPtr conn, int num, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri)
+  {
+    m_conn = conn;
+    m_num = num;
+    m_caller_id = caller_id;
+    m_topic = topic;
+    m_xmlrpc_uri = xmlrpc_uri;
+  }
+  /*!
+   * @if jp
+   * @brief コピーコンストラクタ
+   *
+   * @param obj コピー元 
+   *
+   * @else
+   * @brief Copy Constructor
+   *
+   * @param obj
+   *
+   * @endif
+   */
+  ROSTopicManager::PublisherLink::PublisherLink(const PublisherLink &obj)
+  {
+    m_conn = obj.m_conn;
+    m_num = obj.m_num;
+    m_caller_id = obj.m_caller_id;
+    m_topic = obj.m_topic;
+    m_xmlrpc_uri = obj.m_xmlrpc_uri;
+  }
+  /*!
+   * @if jp
+   * @brief デストラクタ
+   *
+   *
+   * @else
+   * @brief Destructor
+   *
+   *
+   * @endif
+   */
+  ROSTopicManager::PublisherLink::~PublisherLink()
+  {
+
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionを取得
+   *
+   * @return ros::Connection
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  ros::ConnectionPtr ROSTopicManager::PublisherLink::getConnection()
+  {
+    return m_conn;
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionを設定
+   *
+   * @param conn ros::Connection
+   *
+   * @else
+   * @brief 
+   *
+   * @param conn
+   *
+   * @endif
+   */
+  void ROSTopicManager::PublisherLink::setConnection(ros::ConnectionPtr conn)
+  {
+    m_conn = conn;
+  }
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  int ROSTopicManager::PublisherLink::getNum()
+  {
+    return m_num;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string ROSTopicManager::PublisherLink::getCallerID() const
+  {
+    return m_caller_id;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string ROSTopicManager::PublisherLink::getTopic() const
+  {
+    return m_topic;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string ROSTopicManager::PublisherLink::getURI() const
+  {
+    return m_xmlrpc_uri;
+  }
+
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @endif
+   */
+  ROSTopicManager::SubscriberLink::SubscriberLink() : m_num(0)
+  {
+  }
+
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @param conn ros::Connection
+   * @param num コネクタのID
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @param conn 
+   * @param num 
+   *
+   * @endif
+   */
+  ROSTopicManager::SubscriberLink::SubscriberLink(ros::ConnectionPtr conn, int num)
+  {
+    m_conn = conn;
+    m_num = num;
+  }
+  /*!
+   * @if jp
+   * @brief コピーコンストラクタ
+   *
+   * @param obj コピー元 
+   *
+   * @else
+   * @brief Copy Constructor
+   *
+   * @param obj
+   *
+   * @endif
+   */
+  ROSTopicManager::SubscriberLink::SubscriberLink(const SubscriberLink &obj)
+  {
+    m_conn = obj.m_conn;
+    m_nodename = obj.m_nodename;
+    m_num = obj.m_num;
+  }
+  /*!
+   * @if jp
+   * @brief デストラクタ
+   *
+   *
+   * @else
+   * @brief Destructor
+   *
+   *
+   * @endif
+   */
+  ROSTopicManager::SubscriberLink::~SubscriberLink()
+  {
+
+  }
+  /*!
+   * @if jp
+   * @brief 接続先のノード名を設定
+   *
+   * @param name ノード名
+   *
+   * @else
+   * @brief 
+   *
+   * @param name
+   *
+   * @endif
+   */
+  void ROSTopicManager::SubscriberLink::setNoneName(std::string& name)
+  {
+    m_nodename = name;
+  }
+  /*!
+   * @if jp
+   * @brief 接続先のノード名を取得
+   *
+   * @return ノード名
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string ROSTopicManager::SubscriberLink::getNodeName() const
+  {
+    return m_nodename;
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionを設定
+   *
+   * @param conn ros::Connection
+   *
+   * @else
+   * @brief 
+   *
+   * @param conn
+   *
+   * @endif
+   */
+  void ROSTopicManager::SubscriberLink::setConnection(ros::ConnectionPtr conn)
+  {
+    m_conn = conn;
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionを取得
+   *
+   * @return ros::Connection
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  ros::ConnectionPtr ROSTopicManager::SubscriberLink::getConnection()
+  {
+    return m_conn;
+  }
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  int ROSTopicManager::SubscriberLink::getNum()
+  {
+    return m_num;
   }
 }
 

--- a/src/ext/transport/ROSTransport/ROSTopicManager.h
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.h
@@ -253,6 +253,24 @@ namespace RTC
          * @endif
          */
         bool existSubscriber(ROSInPort *subscriber);
+        /*!
+         * @if jp
+         * @brief 指定トピック名のPublisherが存在するかの確認
+         * 
+         * @param topic トピック名
+         * @return True：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param topic 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        bool hasPublisher(const std::string& topic);
+
 
 
         /*!

--- a/src/ext/transport/ROSTransport/ROSTopicManager.h
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.h
@@ -21,8 +21,8 @@
 
 #include "ROSInPort.h"
 #include "ROSOutPort.h"
-#include <map>
 #include <vector>
+#include <map>
 #include <xmlrpcpp/XmlRpc.h>
 #include <ros/poll_manager.h>
 #include <ros/transport/transport_tcp.h>
@@ -251,28 +251,7 @@ namespace RTC
          * @endif
          */
         bool existSubscriber(ROSInPort *subscriber);
-        /*!
-         * @if jp
-         * @brief TCP接続受け入れ時のコールバック関数
-         * 
-         * @param transport ros::Transport
-         *
-         * @else
-         * @brief 
-         *
-         * @param transport 
-         * @return 
-         * 
-         *
-         * @endif
-         */
-        void tcprosAcceptConnection(const ros::TransportTCPPtr& transport)
-        {
-            for(auto & publisher : m_publishers) 
-            {
-                publisher->connectTCP(transport);
-            }
-        }
+
 
         /*!
          * @if jp
@@ -411,6 +390,543 @@ namespace RTC
         ros::TransportTCPPtr m_tcpserver_transport;
         ros::XMLRPCManagerPtr m_xmlrpc_manager;
         std::map<std::string, std::vector<std::string>> m_cons;
+        mutable Logger rtclog;
+        unsigned int m_subnum;
+        unsigned int m_pubnum;
+    public:
+        /*!
+        * @if jp
+        * @class PublisherLink
+        * @brief PublisherLink クラス
+        *
+        * ros::Connection、コネクタのIDを格納するクラス
+        *
+        * @since 2.0.0
+        *
+        * @else
+        * @class PublisherLink
+        * @brief PublisherLink class
+        *
+        * 
+        *
+        * @since 2.0.0
+        *
+        * @endif
+        */
+        class PublisherLink
+        {
+        public:
+            /*!
+            * @if jp
+            * @brief コンストラクタ
+            *
+            * @else
+            * @brief Constructor
+            *
+            * @endif
+            */
+            PublisherLink(void);
+            /*!
+            * @if jp
+            * @brief コンストラクタ
+            *
+            * @param conn ros::Connection
+            * @param num コネクタのID
+            *
+            * @else
+            * @brief Constructor
+            *
+            * @param conn 
+            * @param num 
+            *
+            * @endif
+            */
+            PublisherLink(ros::ConnectionPtr conn, int num, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
+            /*!
+            * @if jp
+            * @brief コピーコンストラクタ
+            *
+            * @param obj コピー元 
+            *
+            * @else
+            * @brief Copy Constructor
+            *
+            * @param obj
+            *
+            * @endif
+            */
+            PublisherLink(const PublisherLink &obj);
+            /*!
+            * @if jp
+            * @brief デストラクタ
+            *
+            *
+            * @else
+            * @brief Destructor
+            *
+            *
+            * @endif
+            */
+            ~PublisherLink();
+            /*!
+            * @if jp
+            * @brief ros::Connectionを取得
+            *
+            * @return ros::Connection
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            ros::ConnectionPtr getConnection();
+            /*!
+            * @if jp
+            * @brief ros::Connectionを設定
+            *
+            * @param conn ros::Connection
+            *
+            * @else
+            * @brief 
+            *
+            * @param conn
+            *
+            * @endif
+            */
+            void setConnection(ros::ConnectionPtr conn);
+            /*!
+            * @if jp
+            * @brief コネクタのID取得
+            *
+            * @return コネクタのID
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            int getNum();
+            /*!
+            * @if jp
+            * @brief コネクタのID取得
+            *
+            * @return コネクタのID
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            const std::string getCallerID() const;
+            /*!
+            * @if jp
+            * @brief コネクタのID取得
+            *
+            * @return コネクタのID
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            const std::string getTopic() const;
+            /*!
+            * @if jp
+            * @brief コネクタのID取得
+            *
+            * @return コネクタのID
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            const std::string getURI() const;
+        private:
+            ros::ConnectionPtr m_conn;
+            int m_num;
+            std::string m_caller_id;
+            std::string m_topic;
+            std::string m_xmlrpc_uri;
+        };
+
+        /*!
+        * @if jp
+        * @class SubscriberLink
+        * @brief SubscriberLink クラス
+        *
+        * ros::Connection、接続先のノード名、コネクタのIDを格納するクラス
+        *
+        * @since 2.0.0
+        *
+        * @else
+        * @class SubscriberLink
+        * @brief SubscriberLink class
+        *
+        * 
+        *
+        * @since 2.0.0
+        *
+        * @endif
+        */
+        class SubscriberLink
+        {
+        public:
+            /*!
+            * @if jp
+            * @brief コンストラクタ
+            *
+            * @else
+            * @brief Constructor
+            *
+            * @endif
+            */
+            SubscriberLink();
+            /*!
+            * @if jp
+            * @brief コンストラクタ
+            *
+            * @param conn ros::Connection
+            * @param num コネクタのID
+            *
+            * @else
+            * @brief Constructor
+            *
+            * @param conn 
+            * @param num 
+            *
+            * @endif
+            */
+            SubscriberLink(ros::ConnectionPtr conn, int num);
+            /*!
+            * @if jp
+            * @brief コピーコンストラクタ
+            *
+            * @param obj コピー元 
+            *
+            * @else
+            * @brief Copy Constructor
+            *
+            * @param obj
+            *
+            * @endif
+            */
+            SubscriberLink(const SubscriberLink &obj);
+            /*!
+            * @if jp
+            * @brief デストラクタ
+            *
+            *
+            * @else
+            * @brief Destructor
+            *
+            *
+            * @endif
+            */
+            ~SubscriberLink();
+            /*!
+            * @if jp
+            * @brief 接続先のノード名を設定
+            *
+            * @param name ノード名
+            *
+            * @else
+            * @brief 
+            *
+            * @param name
+            *
+            * @endif
+            */
+            void setNoneName(std::string& name);
+            /*!
+            * @if jp
+            * @brief 接続先のノード名を取得
+            *
+            * @return ノード名
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            const std::string getNodeName() const;
+            /*!
+            * @if jp
+            * @brief ros::Connectionを設定
+            *
+            * @param conn ros::Connection
+            *
+            * @else
+            * @brief 
+            *
+            * @param conn
+            *
+            * @endif
+            */
+            void setConnection(ros::ConnectionPtr conn);
+            /*!
+            * @if jp
+            * @brief ros::Connectionを取得
+            *
+            * @return ros::Connection
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            ros::ConnectionPtr getConnection();
+            /*!
+            * @if jp
+            * @brief コネクタのID取得
+            *
+            * @return コネクタのID
+            *
+            * @else
+            * @brief 
+            *
+            * @return
+            *
+            * @endif
+            */
+            int getNum();
+        private:
+            std::string m_nodename;
+            ros::ConnectionPtr m_conn;
+            int m_num;
+        };
+        std::vector<PublisherLink> m_tcp_pub_connecters;
+        std::vector<SubscriberLink> m_tcp_sub_connecters;
+        /*!
+         * @if jp
+         * @brief Publisher
+         *
+         * @return 
+         *
+         * @else
+         * @brief
+         *
+         *
+         * @return 
+         *
+         * @endif
+         */
+        std::vector<PublisherLink> & getPublisherLinkList();
+        /*!
+         * @if jp
+         * @brief Subscriber
+         *
+         * @return 
+         *
+         * @else
+         * @brief
+         *
+         *
+         * @return 
+         *
+         * @endif
+         */
+        std::vector<SubscriberLink> & getSubscriberLinkList();
+        /*!
+         * @if jp
+         * @brief サブスクライバーの存在確認
+         * 
+         * @param connection サブスクライバー
+         * @param caller_id サブスクライバー
+         * @param caller_id サブスクライバー
+         * @param xmlrpc_uri サブスクライバー
+         * @return True：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param connection 
+         * @param caller_id 
+         * @param caller_id 
+         * @param xmlrpc_uri 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        bool addPublisherLink(ros::ConnectionPtr& connection, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
+        /*!
+         * @if jp
+         * @brief サブスクライバーの存在確認
+         * 
+         * @param connection サブスクライバー
+         * @return True：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param connection 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        bool removePublisherLink(ros::ConnectionPtr& connection);
+        /*!
+         * @if jp
+         * @brief サブスクライバーの存在確認
+         * 
+         * @param connection サブスクライバー
+         * @param caller_id サブスクライバー
+         * @param caller_id サブスクライバー
+         * @param xmlrpc_uri サブスクライバー
+         * @return True：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param connection 
+         * @param caller_id 
+         * @param caller_id 
+         * @param xmlrpc_uri 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        bool addSubscriberLink(ros::ConnectionPtr& connection);
+        /*!
+         * @if jp
+         * @brief サブスクライバーの存在確認
+         * 
+         * @param connection サブスクライバー
+         * @return True：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param connection 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        bool removeSubscriberLink(ros::ConnectionPtr& connection);
+        /*!
+         * @if jp
+         * @brief サブスクライバーの存在確認
+         * 
+         * @param connection サブスクライバー
+         * @return True：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param connection 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        PublisherLink* getPublisherLink(const ros::ConnectionPtr& connection);
+        /*!
+         * @if jp
+         * @brief サブスクライバーの存在確認
+         * 
+         * @param connection サブスクライバー
+         * @return True：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param connection 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        SubscriberLink* getSubscriberLink(const ros::ConnectionPtr& connection);
+        /*!
+         * @if jp
+         * @brief TCP接続受け入れ時のコールバック関数
+         * 
+         * @param transport ros::Transport
+         *
+         * @else
+         * @brief 
+         *
+         * @param transport 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        void tcprosAcceptConnection(const ros::TransportTCPPtr& transport)
+        {
+            RTC_PARANOID(("connectTCP()"));
+
+            ros::ConnectionPtr tcp_connecter = boost::make_shared<ros::Connection>();
+            
+            addSubscriberLink(tcp_connecter);
+            tcp_connecter->initialize(transport, true, boost::bind(&ROSTopicManager::onConnectionHeaderReceived, this, _1, _2));
+            
+            if(!tcp_connecter->isDropped())
+            {
+                RTC_VERBOSE(("Connector created."));      
+                return;
+            }
+            else
+            {
+                removeSubscriberLink(tcp_connecter);
+                RTC_VERBOSE(("Connector creation failed."));
+                return;
+            }
+        }
+
+       /*!
+        * @if jp
+        * @brief ヘッダ情報受信時のコールバック関数
+        *
+        *
+        * @param conn ros::ConnectionPtr
+        * @param header ヘッダ情報
+        *
+        * @return true：問題なし、false：ヘッダが不正
+        * 
+        * @else
+        * @brief 
+        *
+        *
+        * @param conn 
+        * @param header 
+        * 
+        * @return
+        *
+        * @endif
+        */
+        bool onConnectionHeaderReceived(const ros::ConnectionPtr& conn, const ros::Header& header)
+        {
+            RTC_VERBOSE(("onConnectionHeaderReceived()"));
+
+            bool ret = false;
+            for(auto & publisher : m_publishers) 
+            {
+                if(publisher->onConnectionHeaderReceived(conn, header) == true)
+                {
+                    ret = true;
+                }
+            }
+            return ret;
+        }
     protected:
     };
 }

--- a/src/ext/transport/ROSTransport/ROSTopicManager.h
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.h
@@ -23,9 +23,11 @@
 #include "ROSOutPort.h"
 #include <vector>
 #include <map>
+#include <mutex>
 #include <xmlrpcpp/XmlRpc.h>
 #include <ros/poll_manager.h>
 #include <ros/transport/transport_tcp.h>
+
 
 namespace RTC
 {
@@ -389,333 +391,21 @@ namespace RTC
         ros::PollManagerPtr m_poll_manager;
         ros::TransportTCPPtr m_tcpserver_transport;
         ros::XMLRPCManagerPtr m_xmlrpc_manager;
-        std::map<std::string, std::vector<std::string>> m_cons;
         mutable Logger rtclog;
         unsigned int m_subnum;
         unsigned int m_pubnum;
-    public:
-        /*!
-        * @if jp
-        * @class PublisherLink
-        * @brief PublisherLink クラス
-        *
-        * ros::Connection、コネクタのIDを格納するクラス
-        *
-        * @since 2.0.0
-        *
-        * @else
-        * @class PublisherLink
-        * @brief PublisherLink class
-        *
-        * 
-        *
-        * @since 2.0.0
-        *
-        * @endif
-        */
-        class PublisherLink
-        {
-        public:
-            /*!
-            * @if jp
-            * @brief コンストラクタ
-            *
-            * @else
-            * @brief Constructor
-            *
-            * @endif
-            */
-            PublisherLink(void);
-            /*!
-            * @if jp
-            * @brief コンストラクタ
-            *
-            * @param conn ros::Connection
-            * @param num コネクタのID
-            *
-            * @else
-            * @brief Constructor
-            *
-            * @param conn 
-            * @param num 
-            *
-            * @endif
-            */
-            PublisherLink(ros::ConnectionPtr conn, int num, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
-            /*!
-            * @if jp
-            * @brief コピーコンストラクタ
-            *
-            * @param obj コピー元 
-            *
-            * @else
-            * @brief Copy Constructor
-            *
-            * @param obj
-            *
-            * @endif
-            */
-            PublisherLink(const PublisherLink &obj);
-            /*!
-            * @if jp
-            * @brief デストラクタ
-            *
-            *
-            * @else
-            * @brief Destructor
-            *
-            *
-            * @endif
-            */
-            ~PublisherLink();
-            /*!
-            * @if jp
-            * @brief ros::Connectionを取得
-            *
-            * @return ros::Connection
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            ros::ConnectionPtr getConnection();
-            /*!
-            * @if jp
-            * @brief ros::Connectionを設定
-            *
-            * @param conn ros::Connection
-            *
-            * @else
-            * @brief 
-            *
-            * @param conn
-            *
-            * @endif
-            */
-            void setConnection(ros::ConnectionPtr conn);
-            /*!
-            * @if jp
-            * @brief コネクタのID取得
-            *
-            * @return コネクタのID
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            int getNum();
-            /*!
-            * @if jp
-            * @brief コネクタのID取得
-            *
-            * @return コネクタのID
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            const std::string getCallerID() const;
-            /*!
-            * @if jp
-            * @brief コネクタのID取得
-            *
-            * @return コネクタのID
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            const std::string getTopic() const;
-            /*!
-            * @if jp
-            * @brief コネクタのID取得
-            *
-            * @return コネクタのID
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            const std::string getURI() const;
-        private:
-            ros::ConnectionPtr m_conn;
-            int m_num;
-            std::string m_caller_id;
-            std::string m_topic;
-            std::string m_xmlrpc_uri;
-        };
-
-        /*!
-        * @if jp
-        * @class SubscriberLink
-        * @brief SubscriberLink クラス
-        *
-        * ros::Connection、接続先のノード名、コネクタのIDを格納するクラス
-        *
-        * @since 2.0.0
-        *
-        * @else
-        * @class SubscriberLink
-        * @brief SubscriberLink class
-        *
-        * 
-        *
-        * @since 2.0.0
-        *
-        * @endif
-        */
-        class SubscriberLink
-        {
-        public:
-            /*!
-            * @if jp
-            * @brief コンストラクタ
-            *
-            * @else
-            * @brief Constructor
-            *
-            * @endif
-            */
-            SubscriberLink();
-            /*!
-            * @if jp
-            * @brief コンストラクタ
-            *
-            * @param conn ros::Connection
-            * @param num コネクタのID
-            *
-            * @else
-            * @brief Constructor
-            *
-            * @param conn 
-            * @param num 
-            *
-            * @endif
-            */
-            SubscriberLink(ros::ConnectionPtr conn, int num);
-            /*!
-            * @if jp
-            * @brief コピーコンストラクタ
-            *
-            * @param obj コピー元 
-            *
-            * @else
-            * @brief Copy Constructor
-            *
-            * @param obj
-            *
-            * @endif
-            */
-            SubscriberLink(const SubscriberLink &obj);
-            /*!
-            * @if jp
-            * @brief デストラクタ
-            *
-            *
-            * @else
-            * @brief Destructor
-            *
-            *
-            * @endif
-            */
-            ~SubscriberLink();
-            /*!
-            * @if jp
-            * @brief 接続先のノード名を設定
-            *
-            * @param name ノード名
-            *
-            * @else
-            * @brief 
-            *
-            * @param name
-            *
-            * @endif
-            */
-            void setNoneName(std::string& name);
-            /*!
-            * @if jp
-            * @brief 接続先のノード名を取得
-            *
-            * @return ノード名
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            const std::string getNodeName() const;
-            /*!
-            * @if jp
-            * @brief ros::Connectionを設定
-            *
-            * @param conn ros::Connection
-            *
-            * @else
-            * @brief 
-            *
-            * @param conn
-            *
-            * @endif
-            */
-            void setConnection(ros::ConnectionPtr conn);
-            /*!
-            * @if jp
-            * @brief ros::Connectionを取得
-            *
-            * @return ros::Connection
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            ros::ConnectionPtr getConnection();
-            /*!
-            * @if jp
-            * @brief コネクタのID取得
-            *
-            * @return コネクタのID
-            *
-            * @else
-            * @brief 
-            *
-            * @return
-            *
-            * @endif
-            */
-            int getNum();
-        private:
-            std::string m_nodename;
-            ros::ConnectionPtr m_conn;
-            int m_num;
-        };
+        std::mutex m_pub_mutex;
+        std::mutex m_sub_mutex;
         std::vector<PublisherLink> m_tcp_pub_connecters;
         std::vector<SubscriberLink> m_tcp_sub_connecters;
+        std::mutex m_publink_mutex;
+        std::mutex m_sublink_mutex;
+    public:
         /*!
          * @if jp
-         * @brief Publisher
+         * @brief PublisherLinkの一覧を取得する
          *
-         * @return 
+         * @return PublisherLinkの一覧
          *
          * @else
          * @brief
@@ -728,9 +418,9 @@ namespace RTC
         std::vector<PublisherLink> & getPublisherLinkList();
         /*!
          * @if jp
-         * @brief Subscriber
+         * @brief SubscriberLinkの一覧を取得する
          *
-         * @return 
+         * @return SubscriberLinkの一覧
          *
          * @else
          * @brief
@@ -743,20 +433,20 @@ namespace RTC
         std::vector<SubscriberLink> & getSubscriberLinkList();
         /*!
          * @if jp
-         * @brief サブスクライバーの存在確認
+         * @brief PublisherLinkを追加する
          * 
-         * @param connection サブスクライバー
-         * @param caller_id サブスクライバー
-         * @param caller_id サブスクライバー
-         * @param xmlrpc_uri サブスクライバー
-         * @return True：存在する
+         * @param connection ros::Connectionオブジェクト
+         * @param caller_id 呼び出しID
+         * @param topic トピック名
+         * @param xmlrpc_uri 接続先のURI
+         * @return true：追加成功
          *
          * @else
          * @brief 
          *
          * @param connection 
          * @param caller_id 
-         * @param caller_id 
+         * @param topic 
          * @param xmlrpc_uri 
          * @return 
          * 
@@ -766,10 +456,10 @@ namespace RTC
         bool addPublisherLink(ros::ConnectionPtr& connection, const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
         /*!
          * @if jp
-         * @brief サブスクライバーの存在確認
+         * @brief PublisherLinkを削除する
          * 
-         * @param connection サブスクライバー
-         * @return True：存在する
+         * @param connection ros::Connectionオブジェクト
+         * @return false：指定のPublisherLinkがリストにないため削除失敗
          *
          * @else
          * @brief 
@@ -780,16 +470,54 @@ namespace RTC
          *
          * @endif
          */
-        bool removePublisherLink(ros::ConnectionPtr& connection);
+        bool removePublisherLink(const ros::ConnectionPtr& connection);
         /*!
          * @if jp
-         * @brief サブスクライバーの存在確認
+         * @brief PublisherLinkの存在確認
          * 
-         * @param connection サブスクライバー
-         * @param caller_id サブスクライバー
-         * @param caller_id サブスクライバー
-         * @param xmlrpc_uri サブスクライバー
-         * @return True：存在する
+         * @param caller_id 呼び出しID
+         * @param topic トピック名
+         * @param xmlrpc_uri 接続先のURI
+         * @return true：存在する
+         *
+         * @else
+         * @brief 
+         *
+         * @param caller_id 
+         * @param topic 
+         * @param xmlrpc_uri 
+         * @return true：存在する
+         * 
+         *
+         * @endif
+         */
+        bool existPublisherLink(const std::string &caller_id, const std::string &topic, const std::string &xmlrpc_uri);
+        /*!
+         * @if jp
+         * @brief 指定のros::ConnectionオブジェクトのPublisherLinkを取得する
+         * 
+         * @param connection ros::Connectionオブジェクト
+         * @return PublisherLink
+         *
+         * @else
+         * @brief 
+         *
+         * @param connection 
+         * @return 
+         * 
+         *
+         * @endif
+         */
+        PublisherLink* getPublisherLink(const ros::ConnectionPtr& connection);
+        /*!
+         * @if jp
+         * @brief SubscriberLinkを追加する
+         * 
+         * @param connection ros::Connectionオブジェクト
+         * @param caller_id 呼び出しID
+         * @param topic トピック名
+         * @param xmlrpc_uri 接続先のURI
+         * @return true：存在する
          *
          * @else
          * @brief 
@@ -806,10 +534,10 @@ namespace RTC
         bool addSubscriberLink(ros::ConnectionPtr& connection);
         /*!
          * @if jp
-         * @brief サブスクライバーの存在確認
+         * @brief SubscriberLinkを削除する
          * 
-         * @param connection サブスクライバー
-         * @return True：存在する
+         * @param connection ros::Connectionオブジェクト
+         * @return false：指定のSubscriberLinkがリストにないため削除失敗
          *
          * @else
          * @brief 
@@ -820,30 +548,13 @@ namespace RTC
          *
          * @endif
          */
-        bool removeSubscriberLink(ros::ConnectionPtr& connection);
+        bool removeSubscriberLink(const ros::ConnectionPtr& connection);
         /*!
          * @if jp
-         * @brief サブスクライバーの存在確認
+         * @brief 指定のros::ConnectionオブジェクトのSubscriberLinkを取得する
          * 
-         * @param connection サブスクライバー
-         * @return True：存在する
-         *
-         * @else
-         * @brief 
-         *
-         * @param connection 
-         * @return 
-         * 
-         *
-         * @endif
-         */
-        PublisherLink* getPublisherLink(const ros::ConnectionPtr& connection);
-        /*!
-         * @if jp
-         * @brief サブスクライバーの存在確認
-         * 
-         * @param connection サブスクライバー
-         * @return True：存在する
+         * @param connection ros::Connectionオブジェクト
+         * @return SubscriberLink
          *
          * @else
          * @brief 
@@ -918,6 +629,7 @@ namespace RTC
             RTC_VERBOSE(("onConnectionHeaderReceived()"));
 
             bool ret = false;
+            std::lock_guard<std::mutex> guardp(m_pub_mutex);
             for(auto & publisher : m_publishers) 
             {
                 if(publisher->onConnectionHeaderReceived(conn, header) == true)

--- a/src/ext/transport/ROSTransport/SubscriberLink.cpp
+++ b/src/ext/transport/ROSTransport/SubscriberLink.cpp
@@ -312,9 +312,29 @@ namespace RTC
   {
     data[0] = m_num;
     data[1] = (int)m_bytes_sent;
-    data[2] = (int)m_message_data_sent;
-    data[3] = (int)m_messages_sent;
-    data[4] = 0;
+    data[2] = (int)m_messages_sent;
+    data[3] = 0;
+  }
+
+  /*!
+   * @if jp
+   * @brief 過去に送信したデータ量(byte)を設定する
+   *
+   *
+   * @param size データ量(byte)
+   * 
+   * @else
+   * @brief 
+   *
+   * 
+   * @param size
+   *
+   * @endif
+   */
+  void SubscriberLink::setStatBytes(const uint64_t size)
+  {
+    m_bytes_sent = size;
+    m_messages_sent = 1;
   }
 
   /*!

--- a/src/ext/transport/ROSTransport/SubscriberLink.cpp
+++ b/src/ext/transport/ROSTransport/SubscriberLink.cpp
@@ -1,0 +1,355 @@
+﻿// -*- C++ -*-
+
+/*!
+ * @file  SubscriberLink.cpp
+ * @brief SubscriberLink class
+ * @date  $Date: 2021-01-08 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2021
+ *     Nobuhiko Miyamoto
+ *     Industrial Cyber-Physical Systems Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#include <xmlrpcpp/XmlRpc.h>
+#include <ros/connection_manager.h>
+#include "SubscriberLink.h"
+
+
+
+namespace RTC
+{
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @endif
+   */
+  SubscriberLink::SubscriberLink() : m_num(0),
+                                     m_bytes_sent(0),
+                                     m_message_data_sent(0),
+                                     m_messages_sent(0)
+  {
+  }
+
+  /*!
+   * @if jp
+   * @brief コンストラクタ
+   *
+   * @param conn ros::Connectionオブジェクト
+   * @param num コネクタのID
+   *
+   * @else
+   * @brief Constructor
+   *
+   * @param conn 
+   * @param num 
+   *
+   * @endif
+   */
+  SubscriberLink::SubscriberLink(ros::ConnectionPtr conn, int num) : m_bytes_sent(0),
+                                                                     m_message_data_sent(0),
+                                                                     m_messages_sent(0)
+  {
+    m_conn = conn;
+    m_num = num;
+  }
+  /*!
+   * @if jp
+   * @brief コピーコンストラクタ
+   *
+   * @param obj コピー元 
+   *
+   * @else
+   * @brief Copy Constructor
+   *
+   * @param obj
+   *
+   * @endif
+   */
+  SubscriberLink::SubscriberLink(const SubscriberLink &obj)
+  {
+    m_conn = obj.m_conn;
+    m_nodename = obj.m_nodename;
+    m_num = obj.m_num;
+    m_callerid = obj.m_callerid;
+    m_topic = obj.m_topic;
+    m_bytes_sent = obj.m_bytes_sent;
+    m_message_data_sent = obj.m_message_data_sent;
+    m_messages_sent = obj.m_messages_sent;
+  }
+  /*!
+   * @if jp
+   * @brief デストラクタ
+   *
+   *
+   * @else
+   * @brief Destructor
+   *
+   *
+   * @endif
+   */
+  SubscriberLink::~SubscriberLink()
+  {
+
+  }
+  /*!
+   * @if jp
+   * @brief 接続先のノード名を設定
+   *
+   * @param name ノード名
+   *
+   * @else
+   * @brief 
+   *
+   * @param name
+   *
+   * @endif
+   */
+  void SubscriberLink::setNoneName(std::string& name)
+  {
+    m_nodename = name;
+  }
+  /*!
+   * @if jp
+   * @brief 接続先のノード名を取得
+   *
+   * @return ノード名
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string SubscriberLink::getNodeName() const
+  {
+    return m_nodename;
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionオブジェクトを設定
+   *
+   * @param conn ros::Connectionオブジェクト
+   *
+   * @else
+   * @brief 
+   *
+   * @param conn
+   *
+   * @endif
+   */
+  void SubscriberLink::setConnection(ros::ConnectionPtr conn)
+  {
+    m_conn = conn;
+  }
+  /*!
+   * @if jp
+   * @brief ros::Connectionオブジェクトを取得
+   *
+   * @return ros::Connectionオブジェクト
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  ros::ConnectionPtr SubscriberLink::getConnection()
+  {
+    return m_conn;
+  }
+  /*!
+   * @if jp
+   * @brief コネクタのID取得
+   *
+   * @return コネクタのID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  int SubscriberLink::getNum()
+  {
+    return m_num;
+  }
+
+  /*!
+  * @if jp
+  * @brief 呼び出しIDを設定
+  *
+  * @param caller_id 呼び出しID
+  *
+  * @else
+  * @brief 
+  *
+  * @param conn
+  *
+  * @endif
+  */
+  void SubscriberLink::setCallerID(const std::string &callerid)
+  {
+    m_callerid = callerid;
+  }
+  /*!
+  * @if jp
+  * @brief 呼び出しIDを取得
+  *
+  * @return 呼び出しID
+  *
+  * @else
+  * @brief 
+  *
+  * @return
+  *
+  * @endif
+  */
+  const std::string SubscriberLink::getCallerID() const
+  {
+    return m_callerid;
+  }
+
+  /*!
+   * @if jp
+   * @brief 呼び出しIDを設定
+   *
+   * @param topic 呼び出しID
+   *
+   * @else
+   * @brief 
+   *
+   * @param conn
+   *
+   * @endif
+   */
+  void SubscriberLink::setTopic(const std::string &topic)
+  {
+    m_topic = topic;
+  }
+
+  /*!
+   * @if jp
+   * @brief 呼び出しIDを取得
+   *
+   * @return 呼び出しID
+   *
+   * @else
+   * @brief 
+   *
+   * @return
+   *
+   * @endif
+   */
+  const std::string SubscriberLink::getTopic() const
+  {
+    return m_topic;
+  }
+
+  /*!
+   * @if jp
+   * @brief コネクタの情報を取得
+   *
+   *
+   * @param data 情報を格納する変数
+   * data[0]：コネクタID
+   * data[1]：接続先のノード名
+   * data[2]："o"
+   * data[3]：TCPROS or UDPROS
+   * data[4]：トピック名
+   * data[5]：true
+   * data[6]：接続情報
+   * 
+   * @else
+   * @brief 
+   *
+   *
+   * @param info
+   * 
+   *
+   * @endif
+   */
+  void SubscriberLink::getInfo(XmlRpc::XmlRpcValue& data)
+  {
+    data[0] = m_num;
+    data[1] = m_callerid;
+    data[2] = std::string("o");
+    data[3] = std::string(m_conn->getTransport()->getType());
+    data[4] = m_topic;
+    data[5] = true;
+    data[6] = m_conn->getTransport()->getTransportInfo();
+  }
+
+  /*!
+   * @if jp
+   * @brief 送信データの統計情報取得
+   *
+   *
+   * @param data 送信データの統計情報
+   * 
+   * @else
+   * @brief 
+   *
+   * 
+   * @param data
+   *
+   * @endif
+   */
+  void SubscriberLink::getStats(XmlRpc::XmlRpcValue& data)
+  {
+    data[0] = m_num;
+    data[1] = (int)m_bytes_sent;
+    data[2] = (int)m_message_data_sent;
+    data[3] = (int)m_messages_sent;
+    data[4] = 0;
+  }
+
+  /*!
+   * @if jp
+   * @brief データの送信
+   *
+   *
+   * @param buffer 送信データ
+   * @param length データ長さ
+   * @return true：送信成功
+   * 
+   * @else
+   * @brief 
+   *
+   * 
+   * @param buffer 
+   * @param length 
+   * @return 
+   *
+   * @endif
+   */
+  bool SubscriberLink::write(boost::shared_array<uint8_t>& buffer, const uint32_t &length)
+  {
+    if(!m_conn->isDropped())
+    {
+      m_conn->write(buffer, length, boost::bind(&SubscriberLink::onMessageWritten, this, _1), true);
+      m_message_data_sent += static_cast<uint64_t>(length);
+      m_bytes_sent += static_cast<uint64_t>(length);
+      m_messages_sent++;
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+} // namespace RTC

--- a/src/ext/transport/ROSTransport/SubscriberLink.h
+++ b/src/ext/transport/ROSTransport/SubscriberLink.h
@@ -266,6 +266,23 @@ namespace RTC
        * @endif
        */
       void getStats(XmlRpc::XmlRpcValue& data);
+      /*!
+       * @if jp
+       * @brief 過去に送信したデータ量(byte)を設定する
+       *
+       *
+       * @param size データ量(byte)
+       * 
+       * @else
+       * @brief 
+       *
+       * 
+       * @param size
+       *
+       * @endif
+       */
+      void setStatBytes(const uint64_t size);
+
 
       /*!
        * @if jp

--- a/src/ext/transport/ROSTransport/SubscriberLink.h
+++ b/src/ext/transport/ROSTransport/SubscriberLink.h
@@ -1,0 +1,328 @@
+﻿// -*- C++ -*-
+/*!
+ * @file  SubscriberLink.h
+ * @brief SubscriberLink class
+ * @date  $Date: 2021-01-08 03:08:03 $
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2021
+ *     Nobuhiko Miyamoto
+ *     Industrial Cyber-Physical Systems Research Center,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *
+ *     All rights reserved.
+ *
+ *
+ */
+
+#ifndef RTC_SUBSCRIBERLINK_H
+#define RTC_SUBSCRIBERLINK_H
+
+#include <ros/transport/transport_tcp.h>
+#include <xmlrpcpp/XmlRpc.h>
+#include <rtm/ByteData.h>
+
+
+namespace RTC
+{
+  /*!
+  * @if jp
+  * @class SubscriberLink
+  * @brief SubscriberLink クラス
+  *
+  * Publisher側でSubscriberとの接続情報(ros::Connection、接続先のノード名、コネクタのID)を格納するクラス
+  *
+  * @since 2.0.0
+  *
+  * @else
+  * @class SubscriberLink
+  * @brief SubscriberLink class
+  *
+  * 
+  *
+  * @since 2.0.0
+  *
+  * @endif
+  */
+  class SubscriberLink
+  {
+  public:
+      /*!
+      * @if jp
+      * @brief コンストラクタ
+      *
+      * @else
+      * @brief Constructor
+      *
+      * @endif
+      */
+      SubscriberLink();
+      /*!
+      * @if jp
+      * @brief コンストラクタ
+      *
+      * @param conn ros::Connectionオブジェクト
+      * @param num コネクタのID
+      *
+      * @else
+      * @brief Constructor
+      *
+      * @param conn 
+      * @param num 
+      *
+      * @endif
+      */
+      SubscriberLink(ros::ConnectionPtr conn, int num);
+      /*!
+      * @if jp
+      * @brief コピーコンストラクタ
+      *
+      * @param obj コピー元 
+      *
+      * @else
+      * @brief Copy Constructor
+      *
+      * @param obj
+      *
+      * @endif
+      */
+      SubscriberLink(const SubscriberLink &obj);
+      /*!
+      * @if jp
+      * @brief デストラクタ
+      *
+      *
+      * @else
+      * @brief Destructor
+      *
+      *
+      * @endif
+      */
+      ~SubscriberLink();
+      /*!
+      * @if jp
+      * @brief 接続先のノード名を設定
+      *
+      * @param name ノード名
+      *
+      * @else
+      * @brief 
+      *
+      * @param name
+      *
+      * @endif
+      */
+      void setNoneName(std::string& name);
+      /*!
+      * @if jp
+      * @brief 接続先のノード名を取得
+      *
+      * @return ノード名
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      const std::string getNodeName() const;
+      /*!
+      * @if jp
+      * @brief ros::Connectionオブジェクトを設定
+      *
+      * @param conn ros::Connectionオブジェクト
+      *
+      * @else
+      * @brief 
+      *
+      * @param conn
+      *
+      * @endif
+      */
+      void setConnection(ros::ConnectionPtr conn);
+      /*!
+      * @if jp
+      * @brief ros::Connectionオブジェクトを取得
+      *
+      * @return ros::Connectionオブジェクト
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      ros::ConnectionPtr getConnection();
+      /*!
+      * @if jp
+      * @brief コネクタのID取得
+      *
+      * @return コネクタのID
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      int getNum();
+      /*!
+      * @if jp
+      * @brief 呼び出しIDを設定
+      *
+      * @param caller_id 呼び出しID
+      *
+      * @else
+      * @brief 
+      *
+      * @param conn
+      *
+      * @endif
+      */
+      void setCallerID(const std::string &callerid);
+      /*!
+      * @if jp
+      * @brief 呼び出しIDを取得
+      *
+      * @return 呼び出しID
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      const std::string getCallerID() const;
+      /*!
+      * @if jp
+      * @brief 呼び出しIDを設定
+      *
+      * @param topic 呼び出しID
+      *
+      * @else
+      * @brief 
+      *
+      * @param conn
+      *
+      * @endif
+      */
+      void setTopic(const std::string &topic);
+      /*!
+      * @if jp
+      * @brief 呼び出しIDを取得
+      *
+      * @return 呼び出しID
+      *
+      * @else
+      * @brief 
+      *
+      * @return
+      *
+      * @endif
+      */
+      const std::string getTopic() const;
+      /*!
+       * @if jp
+       * @brief コネクタの情報を取得
+       *
+       *
+       * @param data 情報を格納する変数
+       * data[0]：コネクタID
+       * data[1]：接続先のノード名
+       * data[2]："o"
+       * data[3]：TCPROS or UDPROS
+       * data[4]：トピック名
+       * data[5]：true
+       * data[6]：接続情報
+       * 
+       * @else
+       * @brief 
+       *
+       *
+       * @param info
+       * 
+       *
+       * @endif
+       */
+      void getInfo(XmlRpc::XmlRpcValue& data);
+      /*!
+       * @if jp
+       * @brief 送信データの統計情報取得
+       *
+       *
+       * @param data 送信データの統計情報
+       * 
+       * @else
+       * @brief 
+       *
+       * 
+       * @param data
+       *
+       * @endif
+       */
+      void getStats(XmlRpc::XmlRpcValue& data);
+
+      /*!
+       * @if jp
+       * @brief データの送信
+       *
+       *
+       * @param buffer 送信データ
+       * @param length データ長さ
+       * @return true：送信成功
+       * @return true：送信成功
+       * 
+       * @else
+       * @brief 
+       *
+       * 
+       * @param buffer 
+       * @param length 
+       * @return 
+       *
+       * @endif
+       */
+      bool write(boost::shared_array<uint8_t>& buffer, const uint32_t &length);
+
+      /*!
+       * @if jp
+       * @brief メッセージ送信時のコールバック関数
+       *
+       *
+       * @param conn ros::Connectionオブジェクト
+       *
+       * 
+       * @else
+       * @brief 
+       *
+       *
+       * @param conn 
+       * 
+       * @return
+       *
+       * @endif
+       */
+      void onMessageWritten(const ros::ConnectionPtr& /*conn*/)
+      {
+      }
+  private:
+      std::string m_nodename;
+      ros::ConnectionPtr m_conn;
+      int m_num;
+      std::string m_callerid;
+      std::string m_topic;
+      uint64_t m_bytes_sent;
+      uint64_t m_message_data_sent;
+      uint64_t m_messages_sent;
+  };  // class SubscriberLink
+} // namespace RTC
+
+
+
+#endif // RTC_SUBSCRIBERLINK_H
+


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROSTransportで同一ノードの複数のSubscriberにOutPortを接続するとデータが送信できなくなる。

## Description of the Change


ROSのPublisher、Subscriberの接続時、切断時の動作概要は以下のとおりである。

- Publisherを起動後にSubscriberを起動した場合
![ROS Publisher-_Subscriber 接続](https://user-images.githubusercontent.com/6216077/104432075-fa3dac80-55cb-11eb-9ed4-e8a38d321b53.png)
- Subscriberを起動後にPublisherを起動した場合
![ROS Subscriber-_Publisher 接続](https://user-images.githubusercontent.com/6216077/104432085-fca00680-55cb-11eb-9224-606c9dac4219.png)
- Publisherを終了した場合
![ROS Publisher 切断](https://user-images.githubusercontent.com/6216077/104432068-f90c7f80-55cb-11eb-8659-dc38788d395d.png)
- Subscriberを終了した場合
![ROS Subscriber 切断](https://user-images.githubusercontent.com/6216077/104432080-fb6ed980-55cb-11eb-99da-1cf8671a33bf.png)

修正した点は以下の通り。

- 接続時のPublisher側のハンドシェイクの処理に問題があったため修正した。
- publisherUpdateでSubscriber側で正常に接続できない、削除できない不具合を修正した。

ROSノードのAPIは以下の図のとおりである。

![ros](https://user-images.githubusercontent.com/6216077/104433189-260d6200-55cd-11eb-8e7a-2ffcd6d37ec7.jpg)

C++とPythonで動作仕様が違うAPIがあるが、Pythonのほうが正しいように見えるのでROSTransportはrospyのAPIに合わせるように修正した。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
