### PR TITLE
parseArg function added to coil::stringutils

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -434,7 +434,7 @@ namespace coil
    * @brief Parse string as argument list
    * @endif
    */
-  vstring parse_args(const std::string &args)
+  vstring parseArgs(const std::string &args)
   {
     bool inArg(false);    // -> " " or "\t"
     bool inEscape(false); // -> "\"

--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -451,17 +451,17 @@ namespace coil
             if (inEscape || inDquote || inSquote)
               {
                 anArg.push_back(args[i]);
-                goto CONTINUE;
+                continue;
               }
             // skip spaces between args
-            if (!inArg) { goto CONTINUE; }
+            if (!inArg) { continue; }
             // end of arg
             if (inArg)
               {
                 ret.push_back(anArg);
                 anArg.clear();
                 inArg = false; // exit arg
-                goto CONTINUE;
+                continue;
               }
           }
         inArg = true;
@@ -470,7 +470,7 @@ namespace coil
           {
             if (inEscape) { anArg.push_back(args[i]); }
             inEscape = !inEscape;
-            goto CONTINUE;
+            continue;
           }
 
         if (args[i] == '\"')
@@ -480,17 +480,17 @@ namespace coil
                 inEscape = false;
                 if (inSquote) { anArg.push_back('\\'); }
                 anArg.push_back(args[i]);
-                goto CONTINUE;
+                continue;
               }
             // (") in S-quote is stored in arg
             if (inSquote)
               {
                 anArg.push_back(args[i]);
-                goto CONTINUE;
+                continue;
               }
             // inDquote: enter(false->true), exit(true->false)
             inDquote = !inDquote;
-            goto CONTINUE;
+            continue;
           }
 
         if (args[i] == '\'')
@@ -500,17 +500,17 @@ namespace coil
                 inEscape = false;
                 if (inDquote) { anArg.push_back('\\'); }
                 anArg.push_back(args[i]);
-                goto CONTINUE;
+                continue;
               }
             // (') in S-quote is stored in arg
             if (inDquote)
               {
                 anArg.push_back(args[i]);
-                goto CONTINUE;
+                continue;
               }
             // inSquote: enter(false->true), exit(true->false)
             inSquote = !inSquote;
-            goto CONTINUE;
+            continue;
           }
 
         // here arg[i] != (' ') or (\t) or (") or (')
@@ -520,20 +520,7 @@ namespace coil
             if (inDquote || inSquote) { anArg.push_back('\\'); }
           }
         anArg.push_back(args[i]);
-        goto CONTINUE;
-
-      CONTINUE:
-        if (false)
-          {
-            std::cout << "args[" << i << "] = " << args[i];
-            std::cout << "\t anArg = " << anArg;
-            std::cout << "\t\t";
-            std::cout << "\tARG:" << inArg ? "T" : "F";
-            std::cout << "\tESC:" << inEscape ? "T" : "F";
-            std::cout << "\t'\"':" << inDquote ? "T" : "F";
-            std::cout << "\t'\'':" << inSquote ? "T" : "F";
-            std::cout << std::endl;
-          }
+        continue;
       }
     ret.push_back(anArg);
     return ret;

--- a/src/lib/coil/common/coil/stringutil.h
+++ b/src/lib/coil/common/coil/stringutil.h
@@ -599,6 +599,28 @@ namespace coil
 
   /*!
    * @if jp
+   * @brief 文字列を引数として解釈する
+   *
+   * 引数で指定された文字列を引数リストとして返す。
+   *
+   * @param args 引数文字列
+   * @return 分割された引数の文字列リスト
+   *
+   * @else
+   * @brief Parse string as argument list
+   *
+   * Given string is parsed as arguments, and split it and return as a
+   * list of args.
+   *
+   * @param args argument string
+   * @return Splitted argument list
+   *
+   * @endif
+   */
+  vstring parseArgs(const std::string &args);
+
+  /*!
+   * @if jp
    * @brief 与えられたオブジェクトをstd::stringに変換
    *
    * 引数で指定されたオブジェクトを文字列に変換する。

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1497,22 +1497,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
     // Initialize ORB
     try
       {
-        std::string opt = createORBOptions();
-        std::vector<std::string> args;
-        coil::vstring opts = coil::split(opt, "\"");
-        for(size_t i=0;i < opts.size();i++)
-          {
-            if (i % 2 == 0)
-              {
-                coil::vstring olist{
-                  coil::split(coil::eraseBothEndsBlank(opts[i]), " ")};
-                std::move(olist.begin(), olist.end(), std::back_inserter(args));
-              }
-            else
-              {
-                args.emplace_back(opts[i]);
-              }
-          }
+        const std::string opt = createORBOptions();
+        coil::vstring args{ coil::parseArgs(opt) };
         // TAO's ORB_init needs argv[0] as command name.
         args.insert(args.begin(), "manager");
         m_argv = coil::Argv(args);


### PR DESCRIPTION
## Identify the Bug

issue #880

rtc.conf等の引数をパースする関数を追加。ダブル・シングルクオートで引数をまとめることができる。

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
