### PR TITLE
fixed malformed copy constructor

### DIFF
--- a/src/lib/rtm/CorbaConsumer.h
+++ b/src/lib/rtm/CorbaConsumer.h
@@ -361,10 +361,11 @@ namespace RTC
      * @endif
      */
     CorbaConsumer(const CorbaConsumer& x)
+      : CorbaConsumerBase()
 #ifdef ORB_IS_ORBEXPRESS
-      : m_var(ObjectType::_duplicate(x.m_var.in()))
+      , m_var(ObjectType::_duplicate(x.m_var.in()))
 #else
-      : m_var(ObjectType::_duplicate(x.m_var))
+      , m_var(ObjectType::_duplicate(x.m_var))
 #endif
     {
     }


### PR DESCRIPTION
#937 
Malformed copy constructor in class RTC::CorbaConsumer fixed.

## Identify the Bug

Copy constructor of the RTC::CorbaConsumer class is malformed with respect to inheritance.

Steps to reproduce the behavior:

1. Use gcc version 9
```
$ g++ --version
g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
2. Compile client program (DAQ-Middleware) with the -Wextra option
3. See warning/error:

## Reproducibility
Systematic behavior with the -Wextra GCC option.

## Description of the Change

```
 CorbaConsumer(const CorbaConsumer& x)
     : CorbaConsumerBase()
#ifdef ORB_IS_ORBEXPRESS
     , m_var(ObjectType::_duplicate(x.m_var.in()))
#else
     , m_var(ObjectType::_duplicate(x.m_var))
#endif
   {
   }
```


## Verification 

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
