### PR TITLE
getFileListが正常に動作しない問題の修正

### DIFF
--- a/src/lib/coil/posix/coil/File.cpp
+++ b/src/lib/coil/posix/coil/File.cpp
@@ -131,7 +131,7 @@ namespace coil
     for (int i = 0; i < files; ++i)
       {
         std::string dname = namelist[i]->d_name;
-        if (dname != "." || dname != "..") { continue; }
+        if (dname == "." || dname == "..") { continue; }
 
         std::string fullpath = dir + "/" + dname;
         struct stat stat_buf;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

coil::getFileList関数が正常に動作せず、指定フォルダ、指定拡張子のファイルのリストが取得できない。


## Description of the Change

以下のプルリクエストでネストを浅くする変更でミスがあったと推測しています。
if文の分岐が逆になってしまっているので修正しました。

- https://github.com/OpenRTM/OpenRTM-aist/pull/390


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
