### PR TITLE
RTCの設定ファイルの指定する際にインスタンス名が正しく設定されていない問題の修正

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2214,6 +2214,8 @@ std::vector<coil::Properties> Manager::getLoadableModules()
   void Manager::configureComponent(RTObject_impl* comp,
                                    const coil::Properties& prop)
   {
+    comp->setProperties(prop);
+
     std::string category(comp->getCategory());
     std::string type_name(comp->getTypeName());
     std::string inst_name(comp->getInstanceName());
@@ -2279,7 +2281,6 @@ std::vector<coil::Properties> Manager::getLoadableModules()
           }
       }
     // Merge Properties. type_prop is merged properties
-    comp->setProperties(prop);
     type_prop << name_prop;
     type_prop["config_file"]
       = coil::flatten(coil::unique_sv(std::move(config_fname)));


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#948 


## Description of the Change

ファイルを読み込む時点で時点でインスタンス名が設定されていないことが問題のため修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
