### PR TITLE
Machoのエラーを発生しないようにする

### DIFF
--- a/examples/StaticFsm/MicrowaveFsm.cpp
+++ b/examples/StaticFsm/MicrowaveFsm.cpp
@@ -8,6 +8,13 @@
 #include <iostream>
 #include "MicrowaveFsm.h"
 
+FSM_INIT_VALUE(MicrowaveFsm::Top)
+FSM_INIT_VALUE(MicrowaveFsm::Disabled)
+FSM_INIT_VALUE(MicrowaveFsm::Operational)
+FSM_INIT_VALUE(MicrowaveFsm::Idle)
+FSM_INIT_VALUE(MicrowaveFsm::Programmed)
+FSM_INIT_VALUE(MicrowaveFsm::Cooking)
+
 namespace MicrowaveFsm
 {
   //============================================================

--- a/examples/StaticFsm/MicrowaveFsm.h
+++ b/examples/StaticFsm/MicrowaveFsm.h
@@ -150,4 +150,11 @@ namespace MicrowaveFsm
 } // namespace MicrowaveFsm
 
 
+FSM_INIT_VALUE(MicrowaveFsm::Top)
+FSM_INIT_VALUE(MicrowaveFsm::Disabled)
+FSM_INIT_VALUE(MicrowaveFsm::Operational)
+FSM_INIT_VALUE(MicrowaveFsm::Idle)
+FSM_INIT_VALUE(MicrowaveFsm::Programmed)
+FSM_INIT_VALUE(MicrowaveFsm::Cooking)
+
 #endif // MICROWAVEFSM_H

--- a/examples/StaticFsm/MicrowaveFsm.h
+++ b/examples/StaticFsm/MicrowaveFsm.h
@@ -150,11 +150,4 @@ namespace MicrowaveFsm
 } // namespace MicrowaveFsm
 
 
-FSM_INIT_VALUE(MicrowaveFsm::Top)
-FSM_INIT_VALUE(MicrowaveFsm::Disabled)
-FSM_INIT_VALUE(MicrowaveFsm::Operational)
-FSM_INIT_VALUE(MicrowaveFsm::Idle)
-FSM_INIT_VALUE(MicrowaveFsm::Programmed)
-FSM_INIT_VALUE(MicrowaveFsm::Cooking)
-
 #endif // MICROWAVEFSM_H

--- a/src/lib/rtm/Macho.h
+++ b/src/lib/rtm/Macho.h
@@ -1774,8 +1774,8 @@ namespace Macho {
 	// The identifiers are consecutive integers starting from zero,
 	// which allows use as index into a vector for fast access.
 	// 'Root' always has zero as id.
-	template<class S>
-	const ID StateID<S>::value = Machine<typename S::TOP>::theStateCount++;
+	//template<class S>
+	//const ID StateID<S>::value = Machine<typename S::TOP>::theStateCount++;
 
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -227,7 +227,11 @@ namespace RTC
     }
 #if defined(__clang__)
 #pragma clang diagnostic push
+#if defined(_WIN32) || defined(_WIN64)
+#pragma clang diagnostic ignored "-Wsuggest-override"
+#else
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
 #endif
 #if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic push

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -228,6 +228,8 @@ namespace RTC
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
 #if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -242,6 +244,7 @@ namespace RTC
 #pragma GCC diagnostic pop
 #endif
 #if defined(__clang__)
+#pragma clang diagnostic pop
 #pragma clang diagnostic pop
 #endif
 

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -226,12 +226,12 @@ namespace RTC
         }
     }
 #if defined(__clang__)
-#pragma clang diagnostic push
 #if defined(_WIN32) || defined(_WIN64)
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsuggest-override"
-#else
-#pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #endif
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #endif
 #if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -247,6 +247,9 @@ namespace RTC
 #endif
 #if defined(__clang__)
 #pragma clang diagnostic pop
+#if defined(_WIN32) || defined(_WIN64)
+#pragma clang diagnostic pop
+#endif
 #endif
 
     RTObject_impl* rtComponent;

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -228,8 +228,6 @@ namespace RTC
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
 #if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -244,7 +242,6 @@ namespace RTC
 #pragma GCC diagnostic pop
 #endif
 #if defined(__clang__)
-#pragma clang diagnostic pop
 #pragma clang diagnostic pop
 #endif
 

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -98,6 +98,7 @@
     friend class ::_VS8_Bug_101615
 
 #define FSM_INIT_VALUE(S) \
+   template<> \
    const ::Macho::ID Macho::StateID<S>::value = ::Macho::Machine<typename S::TOP>::theStateCount++;
 
 namespace RTC

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -97,6 +97,9 @@
     Box & box() { return *static_cast<Box *>(_box()); }                 \
     friend class ::_VS8_Bug_101615
 
+#define FSM_INIT_VALUE(S) \
+   const ::Macho::ID Macho::StateID<S>::value = ::Macho::Machine<typename S::TOP>::theStateCount++;
+
 namespace RTC
 {
   /*!

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -228,8 +228,6 @@ namespace RTC
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Werror"
 #endif
 #if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -244,7 +242,6 @@ namespace RTC
 #pragma GCC diagnostic pop
 #endif
 #if defined(__clang__)
-#pragma clang diagnostic pop
 #pragma clang diagnostic pop
 #endif
 

--- a/src/lib/rtm/StaticFSM.h
+++ b/src/lib/rtm/StaticFSM.h
@@ -228,6 +228,8 @@ namespace RTC
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Werror"
 #endif
 #if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -242,6 +244,7 @@ namespace RTC
 #pragma GCC diagnostic pop
 #endif
 #if defined(__clang__)
+#pragma clang diagnostic pop
 #pragma clang diagnostic pop
 #endif
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Visual Studio 2019(コンパイラ：19.29.30037)でビルドすると以下のエラーが発生する。

```
重大度レベル	コード	説明	プロジェクト	ファイル	行	抑制状態
エラー	C2374	'value': 再定義されています。2 回以上初期化されています。 (ソース ファイルをコンパイルしています C:\workspace\openrtm17\examples\StaticFsm\MicrowaveFsm.cpp)	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2374	'value': 再定義されています。2 回以上初期化されています。 (ソース ファイルをコンパイルしています C:\workspace\openrtm17\examples\StaticFsm\Microwave.cpp)	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2374	'value': 再定義されています。2 回以上初期化されています。	MicrowaveComp	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	Microwave_objlib	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	MicrowaveComp	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	MicrowaveComp	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
エラー	C2734	'Macho::StateID<C>::value' : 'const' オブジェクトが 'extern' でない場合、初期化する必要があります。	MicrowaveComp	C:\workspace\openrtm17\src\lib\rtm\Macho.h	1778	
```

## Description of the Change

Macho.hで`Macho::StateID<S>::value`の初期化が2回以上実行していることからエラーが発生しているが、何故19.29.30037のコンパイラでエラーになるようになったのかよく分かっていない。

```CPP
	class StateID {
	public:
		static const ID value;
	};

	template<class S>
	const ID StateID<S>::value = Machine<typename S::TOP>::theStateCount++;
```

明示的に`const ID StateID<MicrowaveFsm::Disabled>::value = Machine<typename MicrowaveFsm::Disabled::TOP>::theStateCount++;`とヘッダーファイルに記述すればエラーは発生しない。


根本的な解決にはなっていませんが、このままAzure Pipelinesでエラーが出続けるのも問題なので、応急手当て的に上記の修正をしました。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
