### PR TITLE
通信不能のマスターマネージャ、スレーブマネージャ除外時の不具合の修正

### DIFF
--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -256,6 +256,7 @@ namespace RTM
                 m_slaves[i] = RTM::Manager::_nil();
               }
             CORBA_SeqUtil::erase(m_slaves, i); --i;
+            len = m_slaves.length();
           }
       }
     return cprof._retn();
@@ -314,6 +315,7 @@ namespace RTM
                 m_slaves[i] = RTM::Manager::_nil();
               }
             CORBA_SeqUtil::erase(m_slaves, i); --i;
+            len = m_slaves.length();
           }
       }
     return cprof._retn();
@@ -561,6 +563,7 @@ namespace RTM
             m_slaves[i] = RTM::Manager::_nil();
           }
         CORBA_SeqUtil::erase(m_slaves, i); --i;
+        len = m_slaves.length();
       }
     return crtcs._retn();
   }
@@ -615,6 +618,7 @@ namespace RTM
             m_slaves[i] = RTM::Manager::_nil();
           }
         CORBA_SeqUtil::erase(m_slaves, i); --i;
+        len = m_slaves.length();
       }
     return cprofs._retn();
   }
@@ -1256,7 +1260,7 @@ namespace RTM
                 catch (...)
                   {
                      RTC_ERROR(("A slave manager thrown exception."));
-                     CORBA_SeqUtil::erase(m_slaves, i);
+                     CORBA_SeqUtil::erase(m_slaves, i); --i;
                      RTC_ERROR(("This slave manager is removed from slave list."));
                    }
                }
@@ -1461,19 +1465,19 @@ namespace RTM
               std::lock_guard<std::mutex> guardm(m_masterMutex);
               if (m_masters.length() > 0)
                 {
-                  for (CORBA::ULong i = 0; i < m_masters.length(); i++)
+                  for (CORBA::ULong i = 0; i < m_masters.length(); ++i)
                     {
                       try
                         {
                           if (m_masters[i]->_non_existent())
                             {
-                              CORBA_SeqUtil::erase(m_masters, i);
+                              CORBA_SeqUtil::erase(m_masters, i); --i;
                             }
                         }
                       catch (...)
                         {
                           RTC_ERROR(("Unknown exception cought."));
-                          CORBA_SeqUtil::erase(m_masters, i);
+                          CORBA_SeqUtil::erase(m_masters, i); --i;
                         }
                     }
                 }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

1. マスターマネージャを起動する
2. スレーブマネージャを起動する
3. スレーブマネージャのプロセスを強制終了する
4. `get_components`関数を呼び出すと以下のエラーが発生

```
omniORB.CORBA.BAD_PARAM: CORBA.BAD_PARAM(omniORB.BAD_PARAM_IndexOutOfRange, CORBA.COMPLETED_NO)
```


## Description of the Change

for文の中で除外時にカウンタ変数を減らしているが、`len`は`m_slaves`の要素数が減少しても変化しないため除外済みの要素にアクセスしようとしてエラーになる。このため`len`に変更後の要素数を入れるように修正した。

```CPP
for (int i(0), len(m_slaves.length()); i < len; ++i)
      {
         //省略
         CORBA_SeqUtil::erase(m_slaves, i); --i;
```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
