### PR TITLE
Ubuntu20.04用Dockerイメージdevel-rtmを生成するDockerfileを追加

### DIFF
--- a/scripts/ubuntu_2004/Dockerfile.devel-rtm
+++ b/scripts/ubuntu_2004/Dockerfile.devel-rtm
@@ -1,0 +1,91 @@
+FROM ubuntu:20.04 as fluent
+
+RUN apt update\
+ && apt install -y --no-install-recommends\
+ g++\
+ make\
+ cmake\
+ ca-certificates\
+ wget\
+ flex\
+ bison
+
+# downlaod fluent-bit.
+RUN mkdir /root/fluent-bit
+RUN wget -O - https://github.com/fluent/fluent-bit/archive/v1.3.4.tar.gz\
+ | tar xfz - -C /root/fluent-bit --strip-components 1
+
+# build fluent-bit.
+RUN cmake -DFLB_DEBUG=Off\
+ -DFLB_TRACE=Off\
+ -DFLB_JEMALLOC=On\
+ -DFLB_TLS=On\
+ -DFLB_SHARED_LIB=On\
+ -DFLB_EXAMPLES=Off\
+ -DFLB_HTTP_SERVER=On\
+ -DFLB_IN_SYSTEMD=On\
+ -DFLB_OUT_KAFKA=On\
+ -DCMAKE_BUILD_TYPE=Release\
+ -DCMAKE_INSTALL_PREFIX=/tmp/flb/install\
+ -S /root/fluent-bit\
+ -B/tmp/flb/build
+RUN cmake --build /tmp/flb/build --target install/strip -- -j$(nproc)
+
+# install header files.
+RUN mkdir -p /tmp/flb/install/include/lib/flb_libco
+RUN cp /root/fluent-bit/lib/flb_libco/libco.h /tmp/flb/install/include/lib/flb_libco
+RUN cp -r /tmp/flb/build/include/jemalloc\
+ /root/fluent-bit/lib/msgpack-*/include/*\
+ /root/fluent-bit/lib/monkey/include/monkey\
+ /root/fluent-bit/lib/mbedtls-*/include/mbedtls\
+ /tmp/flb/install/include/
+
+############################################################
+FROM ubuntu:20.04 as rtm-build
+
+ENV ROS_DISTRO=foxy
+ENV AMENT_PREFIX_PATH=/opt/ros/${ROS_DISTRO}
+ENV ROS_VERSION=2
+ENV ROS_PYTHON_VERSION=3
+ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python3.8/site-packages:${PYTHONPATH}
+ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
+RUN apt update\
+ && apt install -y --no-install-recommends curl gnupg2 lsb-release ca-certificates\
+ && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg\
+ && sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list'\
+ && apt update\
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install ros-${ROS_DISTRO}-ros-core\
+ && apt clean\
+ && rm -rf /var/lib/apt/lists/*
+
+
+ENV ROS_DISTRO=noetic
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'\
+ && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -\
+ && apt update\
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ros-${ROS_DISTRO}-ros-base python3-rosdep\
+ && apt clean\
+ && rm -rf /var/lib/apt/lists/*\
+ && rosdep init\
+ && rosdep update
+ENV CMAKE_PREFIX_PATH=/opt/ros/${ROS_DISTRO}:${CMAKE_PREFIX_PATH}
+ENV ROS_ETC_DIR=/opt/ros/${ROS_DISTRO}/etc/ros
+ENV ROS_ROOT=/opt/ros/${ROS_DISTRO}/share/ros
+ENV ROS_PACKAGE_PATH=/opt/ros/${ROS_DISTRO}/share
+ENV PYTHONPATH=/opt/ros/${ROS_DISTRO}/lib/python3.8/dist-packages:${PYTHONPATH}
+ENV PATH=/opt/ros/${ROS_DISTRO}/bin:${PATH}
+
+RUN apt update\
+ && apt install -y --no-install-recommends\
+ g++\
+ make\
+ cmake\
+ uuid-dev\
+ libboost-filesystem-dev\
+ omniorb-nameserver\
+ libomniorb4-dev\
+ omniidl\
+ && apt clean\
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fluent /tmp/flb/install /usr/local/

--- a/scripts/ubuntu_2004/Dockerfile.package
+++ b/scripts/ubuntu_2004/Dockerfile.package
@@ -1,0 +1,36 @@
+FROM openrtm/devel-rtm:ubuntu20.04
+
+RUN apt-get update\
+ && apt-get install -y --no-install-recommends\
+ doxygen\
+ graphviz\
+ build-essential\
+ debhelper\
+ devscripts\
+ fakeroot\
+ python
+
+COPY OpenRTM-aist /root/OpenRTM-aist
+RUN cmake\
+ -DSSL_ENABLE=ON\
+ -DOBSERVER_ENABLE=ON\
+ -DFLUENTBIT_ENABLE=ON\
+ -DFLUENTBIT_ROOT=/usr/local/include\
+ -DROS_ENABLE=ON\
+ -DFASTRTPS_ENABLE=ON\
+ -DROS2_ENABLE=ON\
+ -DDOCUMENTS_ENABLE=ON\
+ -DCMAKE_BUILD_TYPE=Release\
+ -DCMAKE_INSTALL_PREFIX=/tmp/rtm/install\
+ -S /root/OpenRTM-aist\
+ -B/tmp/rtm/build\
+ && cmake --build /tmp/rtm/build --target install/strip -- -j$(nproc)
+
+WORKDIR /root/OpenRTM-aist/packages/deb/
+RUN mkdir -p /root/cxx-deb-pkgs\
+ && cp /tmp/rtm/build/rules debian/\
+ && chmod 775 dpkg_build.sh\
+ && export LD_LIBRARY_PATH=/opt/ros/foxy/lib\
+ && ./dpkg_build.sh
+
+RUN cp /root/OpenRTM-aist/packages/openrtm-aist* /root/cxx-deb-pkgs/


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #957

## Description of the Change

- Dockerイメージはマルチアーキテクチャ対応でビルドし、DockerHubへアップロードした
https://hub.docker.com/repository/docker/openrtm/devel-rtm
- Ubuntu20.04用 ros-foxy-ros-core パッケージは、binary-armhf用が提供されていないため、プラットフォームはlinux/amd64とlinux/arm64のみを指定してビルドした
```
$ sudo docker buildx build --no-cache --pull -f Dockerfile.devel-rtm -t openrtm/devel-rtm:ubuntu20.04 --platform=linux/amd64,linux/arm64 --push .
```
- Dockerfile.package を使ってのdebパッケージ作成は、CMakeエラーが発生している。Ubuntu18.04では問題ない。
  - OpenRTM-aistのROSTransportとROS2Transportの各CMakeLists.txtに問題があるようで、別Issueにて対応予定。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
