### PR TITLE
ROSTransport、ROS2Transportを同時にビルドする場合の対応、Ubuntu 20.04への対応

### DIFF
--- a/src/ext/transport/ROS2Transport/CMakeLists.txt
+++ b/src/ext/transport/ROS2Transport/CMakeLists.txt
@@ -5,10 +5,6 @@ project (ROS2Transport
 	LANGUAGES C CXX)
 
 
-if(NOT CMAKE_CXX_STANDARD)
-	set(CMAKE_CXX_STANDARD 14)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
@@ -21,6 +17,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(fastcdr REQUIRED)
 find_package(fastrtps REQUIRED)
+
 
 
 
@@ -54,14 +51,34 @@ if(VXWORKS AND NOT RTP)
 		PUBLIC ${sensor_msgs_INCLUDE_DIRS})
 	target_link_libraries(${target} ${libs})
 
+
+	target_compile_definitions(${target} PRIVATE STD_MSGS_VERSION_MAJOR=${std_msgs_VERSION_MAJOR} 
+								GEOMETORY_MSGS_VERSION_MAJOR=${geometry_msgs_VERSION_MAJOR} 
+								SENSOR_MSGS_VERSION_MAJOR=${sensor_msgs_VERSION_MAJOR} 
+								STD_MSGS_VERSION_MINOR=${std_msgs_VERSION_MINOR} 
+								GEOMETORY_MSGS_VERSION_MINOR=${geometry_msgs_VERSION_MINOR} 
+								SENSOR_MSGS_VERSION_MINOR==${sensor_msgs_VERSION_MINOR})
+	if(${rclcpp_VERSION_MAJOR} GREATER 1)
+		set_target_properties(${target} PROPERTIES
+			POSITION_INDEPENDENT_CODE ON
+			CXX_STANDARD 14
+			CXX_EXTENSIONS OFF
+			CXX_STANDARD_REQUIRED ON
+		)
+	endif()
+
 	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
 				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
 				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
 				COMPONENT ext)
 else()
-set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${DATATYPE_FACTORIES} FastRTPSTransport ${rclcpp_LIBRARIES} ${std_msgs_LIBRARIES} ${geometry_msgs_LIBRARIES} ${sensor_msgs_LIBRARIES} fastcdr fastrtps)
-
-
+	set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${DATATYPE_FACTORIES} FastRTPSTransport 
+		${rclcpp_LIBRARIES} ${std_msgs_LIBRARIES} ${geometry_msgs_LIBRARIES} ${sensor_msgs_LIBRARIES} 
+		${std_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp} 
+		${geometry_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp} 
+		${sensor_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp}
+		${std_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp}
+		fastcdr fastrtps)
 	add_library(${target} SHARED ${srcs})
 	openrtm_common_set_compile_props(${target})
 	openrtm_include_rtm(${target})
@@ -69,11 +86,25 @@ set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${DATATYPE_FACTORIES} FastRTPSTran
 	target_include_directories(${target}
 		PRIVATE ${PROJECT_SOURCE_DIR}/..)
 	target_include_directories(${target} SYSTEM
-		PUBLIC ${rclcpp_INCLUDE_DIRS}
-		PUBLIC ${std_msgs_INCLUDE_DIRS}
-		PUBLIC ${geometry_msgs_INCLUDE_DIRS}
-		PUBLIC ${sensor_msgs_INCLUDE_DIRS})
+					PUBLIC ${rclcpp_INCLUDE_DIRS}
+					PUBLIC ${std_msgs_INCLUDE_DIRS}
+					PUBLIC ${geometry_msgs_INCLUDE_DIRS}
+					PUBLIC ${sensor_msgs_INCLUDE_DIRS})
 	target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION})
+	target_compile_definitions(${target} PRIVATE STD_MSGS_VERSION_MAJOR=${std_msgs_VERSION_MAJOR} 
+								GEOMETORY_MSGS_VERSION_MAJOR=${geometry_msgs_VERSION_MAJOR} 
+								SENSOR_MSGS_VERSION_MAJOR=${sensor_msgs_VERSION_MAJOR} 
+								STD_MSGS_VERSION_MINOR=${std_msgs_VERSION_MINOR} 
+								GEOMETORY_MSGS_VERSION_MINOR=${geometry_msgs_VERSION_MINOR} 
+								SENSOR_MSGS_VERSION_MINOR==${sensor_msgs_VERSION_MINOR})
+	if(${rclcpp_VERSION_MAJOR} GREATER 1)
+		set_target_properties(${target} PROPERTIES
+			POSITION_INDEPENDENT_CODE ON
+			CXX_STANDARD 14
+			CXX_EXTENSIONS OFF
+			CXX_STANDARD_REQUIRED ON
+		)
+	endif()
 	set_target_properties(${target} PROPERTIES PREFIX "")
 
 

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.h
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.h
@@ -25,6 +25,35 @@
 #include <rmw_fastrtps_cpp/TypeSupport.hpp>
 #include <fastcdr/FastBuffer.h>
 #include <fastcdr/Cdr.h>
+
+#if (STD_MSGS_VERSION_MAJOR >= 2)
+#include <std_msgs/msg/detail/float32__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/float64__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int16__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int32__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int64__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int8__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/string__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int16__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int32__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int64__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int8__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/float32_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/float64_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int16_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int32_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int64_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/int8_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int16_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int32_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int64_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/u_int8_multi_array__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <std_msgs/msg/detail/string__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <geometry_msgs/msg/detail/point_stamped__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <geometry_msgs/msg/detail/quaternion_stamped__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <geometry_msgs/msg/detail/vector3_stamped__rosidl_typesupport_fastrtps_cpp.hpp>
+#include <sensor_msgs/msg/detail/image__rosidl_typesupport_fastrtps_cpp.hpp>
+#else
 #include <std_msgs/msg/float32__rosidl_typesupport_fastrtps_cpp.hpp>
 #include <std_msgs/msg/float64__rosidl_typesupport_fastrtps_cpp.hpp>
 #include <std_msgs/msg/int16__rosidl_typesupport_fastrtps_cpp.hpp>
@@ -51,6 +80,7 @@
 #include <geometry_msgs/msg/quaternion_stamped__rosidl_typesupport_fastrtps_cpp.hpp>
 #include <geometry_msgs/msg/vector3_stamped__rosidl_typesupport_fastrtps_cpp.hpp>
 #include <sensor_msgs/msg/image__rosidl_typesupport_fastrtps_cpp.hpp>
+#endif
 
 
 namespace RTC

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -22,13 +22,18 @@ if(UNIX)
 	endif()
 endif()
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(roscpp roscpp)
 
-find_package(catkin REQUIRED COMPONENTS
-	roscpp
-)
+if(NOT roscpp_FOUND)
+	message(FATAL_ERROR "can not find roscpp.")
+endif()
 
 
-find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
+find_package(Boost 1.69 COMPONENTS chrono filesystem system)
+if(NOT Boost_FOUND)
+	find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
+endif()
 
 link_directories(${ORB_LINK_DIR})
 add_definitions(${ORB_C_FLAGS_LIST})
@@ -53,10 +58,9 @@ if(VXWORKS AND NOT RTP)
 	openrtm_set_link_props_shared(${target})
 	openrtm_include_rtm(${target})
 	target_include_directories(${target} SYSTEM
-	  PRIVATE ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros
-	  PRIVATE${catkin_INCLUDE_DIRS}
+	  PRIVATE${roscpp_INCLUDE_DIRS}
 	  PRIVATE${Boost_INCLUDE_DIRS})
-	target_link_libraries(${target} ${libs} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+	target_link_libraries(${target} ${libs} ${roscpp_LINK_LIBRARIES} ${Boost_LIBRARIES})
 	
 	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
 				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
@@ -70,10 +74,9 @@ else()
 	openrtm_include_rtm(${target})
 	openrtm_set_link_props_shared(${target})
 	target_include_directories(${target} SYSTEM
-		PRIVATE ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros
-		PRIVATE ${catkin_INCLUDE_DIRS}
+		PRIVATE ${roscpp_INCLUDE_DIRS}
 		PRIVATE ${Boost_INCLUDE_DIRS})
-	target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+	target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} ${roscpp_LINK_LIBRARIES} ${Boost_LIBRARIES})
 	set_target_properties(${target} PROPERTIES PREFIX "")
 
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- Ubuntu 20.04でROS2Transportがビルドエラーになる。
- ROSTransport、ROS2Transportを同時にビルドするとエラーになる・



## Description of the Change


- ROS2をリンクした場合、Ubuntu20.04ではC++14でないとエラーになるため修正
- ROS2の`ament_cmake_export_libraries-extras.cmake`の仕様が以前と変わっており、dashingではCMake実行時に以下の変数にライブラリ名を設定していたが、これがfoxyでは無くなっている。このため`geometry_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp`、`sensor_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp`、`std_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp`をリンクライブラリに追加。

| 変数名 | ライブラリ名 |
| ------------- | ------------- |
| std_msgs_LIBRARIES | libstd_msgs__rosidl_typesupport_fastrtps_cpp.so  |
| geometry_msgs_LIBRARIES  | libgeometry_msgs__rosidl_typesupport_fastrtps_cpp.so  |
| sensor_msgs_LIBRARIES | libsensor_msgs__rosidl_typesupport_fastrtps_cpp.so  |

- dashingとfoxyでstd_msgs、geometry_msgs、sensor_msgs関連のヘッダーファイルの配置が換わっている。C++ソースコード内でROS2のバージョンを判別する方法は調べた限りでは存在しないため、CMake実行時にバージョン判定して定数を定義した。
- catkinをfind_packageで読み込むとROSTransport、ROS2Transportを同時にビルドするときにエラーになるようなのでroscppを探すように変更した。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
