### PR TITLE
RTObject.hのaddPreFsmActionListener関数の不要なスペースを削除

### DIFF
--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -4405,7 +4405,7 @@ namespace RTC
     PreFsmActionListener*
     addPreFsmActionListener(PreFsmActionListenerType listener_type,
                             Listener& obj,
-                            void (Listener:: *memfunc)(const char* state))
+                            void (Listener::*memfunc)(const char* state))
     {
       class Noname
         : public PreFsmActionListener


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Clangによる静的解析で以下のエラーが発生する。

```
D:\a\1\s\src\lib\rtm\RTObject.h(4408,45): error: '::' and '*' tokens forming pointer to member type are separated by whitespace [-Werror,-Wcompound-token-split-by-space]
                            void (Listener:: *memfunc)(const char* state))
                                          ~~^~
```


## Description of the Change


addPreFsmActionListener関数の不要なスペースを削除した。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
