### PR TITLE
fsm4rtc_observer/ComponentObserverConsumer.hの記述ミスの修正

### DIFF
--- a/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
+++ b/src/ext/sdo/fsm4rtc_observer/ComponentObserverConsumer.h
@@ -215,7 +215,7 @@ namespace RTC
           "EC_STATUS",
           "PORT_PROFILE",
           "CONFIGURATION",
-          "RTC_HEARTBEAT"
+          "RTC_HEARTBEAT",
           "EC_HEARTBEAT",
           "FSM_PROFILE",
           "FSM_STATUS",

--- a/src/lib/rtm/RTObject.h
+++ b/src/lib/rtm/RTObject.h
@@ -4405,7 +4405,7 @@ namespace RTC
     PreFsmActionListener*
     addPreFsmActionListener(PreFsmActionListenerType listener_type,
                             Listener& obj,
-                            void (Listener:: *memfunc)(const char* state))
+                            void (Listener::*memfunc)(const char* state))
     {
       class Noname
         : public PreFsmActionListener


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Clangでの静的解析時に以下のエラーが発生する。


```
D:\a\1\s\src\ext\sdo\fsm4rtc_observer\ComponentObserverConsumer.h(219,11): error: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma? [-Werror,-Wstring-concatenation]
          "EC_HEARTBEAT",
          ^
D:\a\1\s\src\ext\sdo\fsm4rtc_observer\ComponentObserverConsumer.h(218,11): note: place parentheses around the string literal to silence warning
          "RTC_HEARTBEAT"
```


## Description of the Change

"RTC_HEARTBEAT"の後のコンマが抜けていたため修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
