### PR TITLE
FastRTPSTransportのUbuntu20.04対応

### DIFF
--- a/src/ext/transport/FastRTPS/FastRTPSManager.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSManager.cpp
@@ -105,8 +105,10 @@ namespace RTC
       if(m_xml_profile_file.empty())
       {
         eprosima::fastrtps::ParticipantAttributes PParam;
+#if (FASTRTPS_VERSION_MAJOR >= 2)
+#else
         PParam.rtps.builtin.domainId = 0;
-
+#endif
         PParam.rtps.setName("participant_openrtm");
         
         m_participant = eprosima::fastrtps::Domain::createParticipant(PParam);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROS2 foxy付属のFastRTPs(ver. 2.3.1)ではFastRTPSTransportのビルドでエラーになる。

## Description of the Change

`eprosima::fastrtps::rtps::BuiltinAttributes`の`domainId`のメンバ変数はなくなったため、バージョンで処理を分けた。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
