### PR TITLE
GitHub Actionsでのビルド対象からUbuntu16.04を外す

### DIFF
--- a/.github/workflows/openrtm_linux.yml
+++ b/.github/workflows/openrtm_linux.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu_1604, ubuntu_1804, ubuntu_2004, debian_10, code_analysis]
+        os: [ubuntu_1804, ubuntu_2004, debian_10, code_analysis]
     steps:
     - uses: actions/checkout@v1
     - name: Build OpenRTM


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Description of the Change

- OpenRTM-aist 2.0 のサポート対象からUbuntu16.04は除外したので、GitHub Actionsの定義も同様にする
- GitHub Actions でのUbuntu16.04サポートも、2021/09/20 で終了している

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
