### PR TITLE
Linuxパッケージ生成時、rtm-configのprefixを「/usr」指定に変更

### DIFF
--- a/utils/rtm-config/CMakeLists.txt
+++ b/utils/rtm-config/CMakeLists.txt
@@ -35,6 +35,10 @@ string(REPLACE ";" " " LIBS "${TMPLIBS}")
 
 #------------------------------
 # Configure rtm-config
+if(BUILD_RTM_LINUX_PKGS)
+  set(CMAKE_INSTALL_PREFIX "/usr")
+endif()
+
 configure_file(
 	${CMAKE_CURRENT_SOURCE_DIR}/rtm-config.in
 	${PROJECT_BINARY_DIR}/rtm-config @ONLY)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #973 

## Identify the Bug

Link to #973 

## Description of the Change
- debパッケージ作成時のソースビルド時、cmakeオプションを下記指定した場合、
```
-DBUILD_RTM_LINUX_PKGS=ON
-DCMAKE_INSTALL_PREFIX=/tmp/rtm/install
```
- 生成されたdebパッケージでインストールした環境のrtm-config動作が以下となるようにした
```
$ rtm-config --cflags
-I/usr/include -I/usr/include/coil-2.0 -I/usr/include/openrtm-2.0 -I/usr/include/openrtm-2.0/rtm/idl
```
- cmake時にBUILD_RTM_LINUX_PKGS指定をしなかった場合、rtm-configの結果はCMAKE_INSTALL_PREFIX指定が反映される動作が変わらないようにした
```
$ rtm-config --cflags
-I/tmp/rtm/install/include -I/tmp/rtm/install/include/coil-2.0 -I/tmp/rtm/install/include/openrtm-2.0 -I/tmp/rtm/install/include/openrtm-2.0/rtm/idl
```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
