### PR TITLE
AsyncInvokerがcore dumpする問題の修正

### DIFF
--- a/src/lib/coil/CMakeLists.txt
+++ b/src/lib/coil/CMakeLists.txt
@@ -60,6 +60,7 @@ set(coil_headers
 )
 
 set(coil_srcs
+	common/coil/Async.cpp
 	common/coil/ClockManager.cpp
 	common/coil/PeriodicTask.cpp
 	common/coil/Properties.cpp

--- a/src/lib/coil/common/coil/Async.cpp
+++ b/src/lib/coil/common/coil/Async.cpp
@@ -6,6 +6,7 @@
  * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
  *
  * Copyright (C) 2021
+ *     Software Platform Research Team,
  *     Industrial Cyber-Physical Systems Research Center,
  *     Intelligent Systems Research Institute,
  *     National Institute of

--- a/src/lib/coil/common/coil/Async.cpp
+++ b/src/lib/coil/common/coil/Async.cpp
@@ -23,5 +23,57 @@ namespace coil
 {
   DeleteAsyncThread* DeleteAsyncThread::delasync = nullptr;
   std::mutex DeleteAsyncThread::mutex;
+
+  DeleteAsyncThread::DeleteAsyncThread()
+  {
+	  m_task.setTask([this] { svc(); });
+	  m_task.setPeriod(std::chrono::seconds(1));
+  }
+
+  DeleteAsyncThread::~DeleteAsyncThread()
+  {
+
+  }
+
+  void DeleteAsyncThread::activate()
+  {
+      m_task.suspend();
+      m_task.activate();
+      m_task.suspend();
+  }
+
+  int DeleteAsyncThread::svc()
+  {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      std::lock_guard<std::mutex> guard(m_mutex);
+
+      std::vector<Async*>::iterator thread = m_threads.begin();
+      while (thread != m_threads.end())
+      {
+          (*thread)->exit();
+          thread = m_threads.erase(thread);
+      }
+
+      return 0;
+  }
+
+  void DeleteAsyncThread::add(Async* thread)
+  {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      m_threads.push_back(thread);
+      m_task.signal();
+  }
+
+  DeleteAsyncThread* DeleteAsyncThread::instance()
+  {
+      std::lock_guard<std::mutex> guard(mutex);
+      if (delasync == nullptr)
+      {
+          delasync = new DeleteAsyncThread();
+          delasync->activate();
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      return delasync;
+  }
 }
 

--- a/src/lib/coil/common/coil/Async.cpp
+++ b/src/lib/coil/common/coil/Async.cpp
@@ -1,0 +1,26 @@
+﻿// -*- C++ -*-
+/*!
+ * @file Async.cpp
+ * @brief Asynchronous function invocation helper class
+ * @date $Date$
+ * @author Nobuhiko Miyamoto <n-miyamoto@aist.go.jp>
+ *
+ * Copyright (C) 2021
+ *     Industrial Cyber-Physical Systems Research Center,
+ *     Intelligent Systems Research Institute,
+ *     National Institute of
+ *         Advanced Industrial Science and Technology (AIST), Japan
+ *     All rights reserved.
+ *
+ * $Id$
+ *
+ */
+
+#include <coil/Async.h>
+
+namespace coil
+{
+  DeleteAsyncThread* DeleteAsyncThread::delasync = nullptr;
+  std::mutex DeleteAsyncThread::mutex;
+}
+

--- a/src/lib/coil/common/coil/Async.h
+++ b/src/lib/coil/common/coil/Async.h
@@ -20,6 +20,7 @@
 #define COIL_ASYNC_H
 
 #include <coil/Task.h>
+#include <coil/PeriodicTask.h>
 #include <mutex>
 #include <iostream>
 #include <utility>
@@ -114,6 +115,167 @@ namespace coil
      * @endif
      */
     virtual bool finished() = 0;
+    /*!
+     * @if jp
+     *
+     * @brief インスタンス削除
+     *
+     * 非同期処理の終了待ち、インスタンスの削除等を行うための仮想関数
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * 
+     *
+     * @endif
+     */
+    virtual void exit() = 0;
+  };
+
+  /*!
+   * @if jp
+   *
+   * @class DeleteAsyncThread
+   * @brief DeleteAsyncThread クラス
+   *
+   * @else
+   *
+   * @class DeleteAsyncThread
+   * @brief DeleteAsyncThread class
+   *
+   * @endif
+   */
+  class DeleteAsyncThread
+  {
+  public:
+    /*!
+     * @if jp
+     *
+     * @brief コンストラクタ
+     *
+     * コンストラクタ。
+     *
+     * @else
+     *
+     * @brief Constructor
+     *
+     * Constructor
+     *
+     * @endif
+     */
+    DeleteAsyncThread(){
+      m_task.setTask([this]{ svc(); });
+      m_task.setPeriod(std::chrono::seconds(1));
+    };
+    /*!
+     * @if jp
+     *
+     * @brief デストラクタ
+     *
+     * デストラクタ。
+     *
+     * @else
+     *
+     * @brief Destructor
+     *
+     * Destructor
+     *
+     * @endif
+     */
+    ~DeleteAsyncThread() {};
+    /*!
+     * @if jp
+     * @brief スレッドを生成する
+     *
+     *
+     * @else
+     * @brief Create a thread
+     *
+     *
+     * @endif
+     */
+    void activate()
+    {
+      m_task.suspend();
+      m_task.activate();
+      m_task.suspend();
+    }
+
+    /*!
+     * @if jp
+     * @brief スレッド実行関数
+     *
+     *
+     * @else
+     * @brief Thread execution function
+     *
+     *
+     * @endif
+     */
+    int svc()
+    {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      std::lock_guard<std::mutex> guard(m_mutex);
+
+      std::vector<Async*>::iterator thread = m_threads.begin();
+      while (thread != m_threads.end())
+      {
+        (*thread)->exit();
+        thread = m_threads.erase(thread);
+      }
+
+      return 0;
+    }
+    /*!
+     * @if jp
+     * @brief 終了処理を行うAsyncオブジェクトの追加
+     *
+     * @param thread Asyncオブジェクト
+     *
+     * @else
+     * @brief 
+     *
+     * @param thread Async Object
+     *
+     * @endif
+     */
+    void add(Async *thread)
+    {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      m_threads.push_back(thread);
+      m_task.signal();
+    }
+
+    static DeleteAsyncThread* delasync;
+    static std::mutex mutex;
+
+    /*!
+     * @if jp
+     * @brief Async処理スレッドのインスタンスの取得
+     *
+     *
+     * @else
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    static DeleteAsyncThread* instance()
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      if(delasync == nullptr)
+      {
+        delasync = new DeleteAsyncThread();
+        delasync->activate();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      return delasync;
+    }    
+  private:
+    std::vector<Async*> m_threads;
+    std::mutex m_mutex;
+    PeriodicTask m_task;
   };
 
   /*!
@@ -214,7 +376,7 @@ namespace coil
      *
      * @brief 非同期処理終了
      *
-     * 非同期処理を終了し、インスタンスを削除する。
+     * 非同期処理を終了し、インスタンスを削除するスレッドにシグナルを送る。
      *
      * @else
      *
@@ -227,7 +389,27 @@ namespace coil
     void finalize() override
     {
       Task::finalize();
-      if (m_autodelete) delete this;
+      if (m_autodelete) DeleteAsyncThread::instance()->add(this);
+    }
+    /*!
+     * @if jp
+     *
+     * @brief インスタンス削除
+     *
+     * 非同期処理の終了待ちを行い、インスタンスを削除する。
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * 
+     *
+     * @endif
+     */
+    void exit() override
+    {
+      Task::wait();
+      delete this;
     }
 
     /*!
@@ -433,7 +615,27 @@ namespace coil
     void finalize() override
     {
       Task::finalize();
-      if (m_autodelete) delete this;
+      if (m_autodelete) DeleteAsyncThread::instance()->add(this);
+    }
+    /*!
+     * @if jp
+     *
+     * @brief インスタンス削除
+     *
+     * 非同期処理の終了待ちを行い、インスタンスを削除する。
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * 
+     *
+     * @endif
+     */
+    void exit() override
+    {
+      Task::wait();
+      delete this;
     }
   private:
     Object* m_obj;

--- a/src/lib/coil/common/coil/Async.h
+++ b/src/lib/coil/common/coil/Async.h
@@ -164,10 +164,7 @@ namespace coil
      *
      * @endif
      */
-    DeleteAsyncThread(){
-      m_task.setTask([this]{ svc(); });
-      m_task.setPeriod(std::chrono::seconds(1));
-    };
+    DeleteAsyncThread();
     /*!
      * @if jp
      *
@@ -183,7 +180,7 @@ namespace coil
      *
      * @endif
      */
-    ~DeleteAsyncThread() {};
+    ~DeleteAsyncThread();
     /*!
      * @if jp
      * @brief スレッドを生成する
@@ -195,12 +192,7 @@ namespace coil
      *
      * @endif
      */
-    void activate()
-    {
-      m_task.suspend();
-      m_task.activate();
-      m_task.suspend();
-    }
+    void activate();
 
     /*!
      * @if jp
@@ -213,20 +205,8 @@ namespace coil
      *
      * @endif
      */
-    int svc()
-    {
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-      std::lock_guard<std::mutex> guard(m_mutex);
+    int svc();
 
-      std::vector<Async*>::iterator thread = m_threads.begin();
-      while (thread != m_threads.end())
-      {
-        (*thread)->exit();
-        thread = m_threads.erase(thread);
-      }
-
-      return 0;
-    }
     /*!
      * @if jp
      * @brief 終了処理を行うAsyncオブジェクトの追加
@@ -240,12 +220,7 @@ namespace coil
      *
      * @endif
      */
-    void add(Async *thread)
-    {
-      std::lock_guard<std::mutex> guard(m_mutex);
-      m_threads.push_back(thread);
-      m_task.signal();
-    }
+    void add(Async* thread);
 
     static DeleteAsyncThread* delasync;
     static std::mutex mutex;
@@ -261,17 +236,7 @@ namespace coil
      *
      * @endif
      */
-    static DeleteAsyncThread* instance()
-    {
-      std::lock_guard<std::mutex> guard(mutex);
-      if(delasync == nullptr)
-      {
-        delasync = new DeleteAsyncThread();
-        delasync->activate();
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
-      return delasync;
-    }    
+    static DeleteAsyncThread* instance();
   private:
     std::vector<Async*> m_threads;
     std::mutex m_mutex;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- #978 

coil::Async_tクラスのメンバ変数にstd::threadオブジェクト(m_thread)があって、m_threadと対応するスレッド内でcoil::Async_tオブジェクトをdeleteしようとした結果、スレッドが終了しないうちにm_threadも削除しようとするためこういうことが起こるのだと思います。
2.0からスレッドにstd::threadを使うようになったため動作が変わったのだと思いますが、1.2以前は偶然動いていただけだと推測しているので対処は困難です。



## Description of the Change

正しい対処法かどうかは分かりませんが、オブジェクトをdeleteするスレッド(DeleteAsyncThreadクラス)を生成(static変数で定義しているため、1つだけ生成できる)して、AsyncオブジェクトはDeleteAsyncThreadオブジェクトにadd関数で自身のオブジェクトを追加して終了関数を呼び出してもらうように動作を変更しました。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
