### PR TITLE
pkg_install_ubuntu.shへopenjdk8のインストールを追加

### DIFF
--- a/scripts/pkg_install_ubuntu.sh
+++ b/scripts/pkg_install_ubuntu.sh
@@ -18,7 +18,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.0.07
+VERSION=2.0.0.08
 
 #
 #---------------------------------------
@@ -777,3 +777,9 @@ uninstall_result $uninstall_pkgs
 if test ! "x$err_message" = "x" ; then
   echo $err_message
 fi
+
+# install openjdk-8-jdk
+apt -y install openjdk-8-jdk
+JAVA8=`update-alternatives --list java | grep java-8`
+update-alternatives --set java ${JAVA8}
+


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #985 
## Identify the Bug

Link to #985 


## Description of the Change
- pkg_install_ubuntu.sh でのインストールオプションは何を指定してもJava8がインストールされるようにした
  - 少なくともOpenRTM2.0ではJavaの依存関係を修正するので、暫定的に必ずインストールされるようにした
- 現時点での最新版スクリプトを使ってインストールした場合、直後のJavaバージョンは11となる
```
$ sh pkg_install_ubuntu.sh --version
2.0.0.07
$ sudo sh pkg_install_ubuntu.sh -l all --yes
$ java -version
openjdk version "11.0.11" 2021-04-20
```
- 修正版スクリプトを実行すると、Java8となる
- 上記のJava11の環境で修正版スクリプトを実行してもJava8となる。この場合、インストールオプションは何を指定してもよい。ここではインストール済みのc++を指定してみる。
```
$ sh pkg_install_ubuntu.sh --version
2.0.0.08   <-- ★修正版のバージョン
$ sudo sh pkg_install_ubuntu.sh -l c++
$ java -version
openjdk version "1.8.0_292"
```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu20.04環境を新規構築してスクリプト動作を確認した
- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
