### PR TITLE
環境変数ROS_MASTER_URIでros masterのアドレスを設定できるようにする

### DIFF
--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -155,11 +155,10 @@ namespace RTC
           env = coil::replaceString(env, "http://", "");
           env = coil::replaceString(env, "https://", "");
           coil::vstring envsplit = coil::split(env, ":");
-          if(m_roscorehost.empty())
-          {
-            m_roscorehost = envsplit[0];
-          }
-          if(tmp_port.empty() && envsplit.size() >= 2)
+
+          m_roscorehost = envsplit[0];
+
+          if(envsplit.size() >= 2)
           {
             tmp_port = envsplit[1];
           }

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -33,7 +33,9 @@
 #include "ROSTopicManager.h"
 
 
-
+#define ROS_MASTER_URI "ROS_MASTER_URI"
+#define ROS_DEFAULT_MASTER_ADDRESS "localhost"
+#define ROS_DEFAULT_MASTER_PORT 11311
 
 
 namespace RTC
@@ -47,7 +49,7 @@ namespace RTC
    */
   ROSInPort::ROSInPort(void)
    : m_buffer(nullptr),
-     m_roscoreport(11311)
+     m_roscoreport(ROS_DEFAULT_MASTER_PORT)
   {
     // PortProfile setting
     setInterfaceType("ros");
@@ -139,10 +141,47 @@ namespace RTC
     m_topic = "/" + m_topic;
 
 
-    m_roscorehost = prop.getProperty("ros.roscore.host", "localhost");
-    std::string tmp_port = prop.getProperty("ros.roscore.port", "11311");
-    coil::stringTo<unsigned int>(m_roscoreport, tmp_port.c_str());
-
+    m_roscorehost = prop.getProperty("ros.roscore.host");
+    std::string tmp_port = prop.getProperty("ros.roscore.port");
+    if(m_roscorehost.empty() && tmp_port.empty())
+    {
+      RTC_VERBOSE(("Get the IP address and port number of ros master from environment variable %d.", ROS_MASTER_URI));
+      std::string env;
+      if (coil::getenv(ROS_MASTER_URI, env))
+      {
+        RTC_VERBOSE(("$%d: %d", ROS_MASTER_URI, env.c_str()));
+        if(!env.empty())
+        {
+          env = coil::replaceString(env, "http://", "");
+          env = coil::replaceString(env, "https://", "");
+          coil::vstring envsplit = coil::split(env, ":");
+          if(m_roscorehost.empty())
+          {
+            m_roscorehost = envsplit[0];
+          }
+          if(tmp_port.empty() && envsplit.size() >= 2)
+          {
+            tmp_port = envsplit[1];
+          }
+        }
+      }
+    }
+    if(m_roscorehost.empty())
+    {
+      m_roscorehost = ROS_DEFAULT_MASTER_ADDRESS;
+    }
+    if(!tmp_port.empty())
+    {
+      if(!coil::stringTo<unsigned int>(m_roscoreport, tmp_port.c_str()))
+      {
+        RTC_ERROR(("%d cannot be converted to an int value", tmp_port.c_str()));
+        m_roscoreport = ROS_DEFAULT_MASTER_PORT;
+      }
+    }
+    else
+    {
+      m_roscoreport = ROS_DEFAULT_MASTER_PORT;
+    }
 
 
     RTC_VERBOSE(("topic name: %s", m_topic.c_str()));

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -145,11 +145,11 @@ namespace RTC
     std::string tmp_port = prop.getProperty("ros.roscore.port");
     if(m_roscorehost.empty() && tmp_port.empty())
     {
-      RTC_VERBOSE(("Get the IP address and port number of ros master from environment variable %d.", ROS_MASTER_URI));
+      RTC_VERBOSE(("Get the IP address and port number of ros master from environment variable %s.", ROS_MASTER_URI));
       std::string env;
       if (coil::getenv(ROS_MASTER_URI, env))
       {
-        RTC_VERBOSE(("$%d: %d", ROS_MASTER_URI, env.c_str()));
+        RTC_VERBOSE(("$%s: %s", ROS_MASTER_URI, env.c_str()));
         if(!env.empty())
         {
           env = coil::replaceString(env, "http://", "");
@@ -173,7 +173,7 @@ namespace RTC
     {
       if(!coil::stringTo<unsigned int>(m_roscoreport, tmp_port.c_str()))
       {
-        RTC_ERROR(("%d cannot be converted to an int value", tmp_port.c_str()));
+        RTC_ERROR(("%s cannot be converted to an int value", tmp_port.c_str()));
         m_roscoreport = ROS_DEFAULT_MASTER_PORT;
       }
     }

--- a/src/ext/transport/ROSTransport/ROSOutPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSOutPort.cpp
@@ -105,11 +105,10 @@ namespace RTC
           env = coil::replaceString(env, "http://", "");
           env = coil::replaceString(env, "https://", "");
           coil::vstring envsplit = coil::split(env, ":");
-          if(m_roscorehost.empty())
-          {
-            m_roscorehost = envsplit[0];
-          }
-          if(tmp_port.empty() && envsplit.size() >= 2)
+
+          m_roscorehost = envsplit[0];
+
+          if(envsplit.size() >= 2)
           {
             tmp_port = envsplit[1];
           }

--- a/src/ext/transport/ROSTransport/ROSOutPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSOutPort.cpp
@@ -95,11 +95,11 @@ namespace RTC
     std::string tmp_port = prop.getProperty("ros.roscore.port");
     if(m_roscorehost.empty() && tmp_port.empty())
     {
-      RTC_VERBOSE(("Get the IP address and port number of ros master from environment variable %d.", ROS_MASTER_URI));
+      RTC_VERBOSE(("Get the IP address and port number of ros master from environment variable %s.", ROS_MASTER_URI));
       std::string env;
       if (coil::getenv(ROS_MASTER_URI, env))
       {
-        RTC_VERBOSE(("$%d: %d", ROS_MASTER_URI, env.c_str()));
+        RTC_VERBOSE(("$%s: %s", ROS_MASTER_URI, env.c_str()));
         if(!env.empty())
         {
           env = coil::replaceString(env, "http://", "");
@@ -123,7 +123,7 @@ namespace RTC
     {
       if(!coil::stringTo<unsigned int>(m_roscoreport, tmp_port.c_str()))
       {
-        RTC_ERROR(("%d cannot be converted to an int value", tmp_port.c_str()));
+        RTC_ERROR(("%s cannot be converted to an int value", tmp_port.c_str()));
         m_roscoreport = ROS_DEFAULT_MASTER_PORT;
       }
     }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#989 


## Description of the Change

1. `ros.roscore.host`、`ros.roscore.port`のどちらも設定していない場合は環境変数`ROS_MASTER_URI`からアドレス、ポート番号を設定する。
2. `ros.roscore.host`が設定しておらず、`ros.roscore.port`を設定していない場合は、アドレスをlocalhostに設定する。
3. `ros.roscore.host`が設定してあり、`ros.roscore.port`が設定していない場合は、ポート番号は11311に設定する
4. 環境変数`ROS_MASTER_URI`からポート番号に変換を失敗した場合は、ポート番号を11311に設定する
5. 環境変数`ROS_MASTER_URI`が空、もしくは`ROS_MASTER_URI`から抽出したアドレスが空の場合はアドレスをlocalhostに設定する


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
