### PR TITLE
Fluent BitプラグインのWindows対応

### DIFF
--- a/src/ext/logger/CMakeLists.txt
+++ b/src/ext/logger/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required (VERSION 3.5.1)
 
-if(UNIX)
-	set(FLUENTBIT_ENABLE FALSE CACHE BOOL "set FLUENTBIT_ENABLE")
-	if(FLUENTBIT_ENABLE)
-		add_subdirectory(fluentbit_stream)
-	endif(FLUENTBIT_ENABLE)
-endif(UNIX)
+
+set(FLUENTBIT_ENABLE FALSE CACHE BOOL "set FLUENTBIT_ENABLE")
+if(FLUENTBIT_ENABLE)
+	add_subdirectory(fluentbit_stream)
+endif(FLUENTBIT_ENABLE)
+
 

--- a/src/ext/logger/fluentbit_stream/CMakeLists.txt
+++ b/src/ext/logger/fluentbit_stream/CMakeLists.txt
@@ -28,6 +28,7 @@ add_definitions(${ORB_C_FLAGS_LIST})
 add_definitions(${COIL_C_FLAGS_LIST})
 if(WIN32)
 	add_definitions(-DRTM_SKEL_IMPORT_SYMBOL)
+	add_definitions(-DFLB_SYSTEM_WINDOWS)
 endif()
 add_definitions(-Dtypeof=decltype)
 

--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -171,10 +171,13 @@ namespace RTC
     const std::string& manager_name = conf["manager.instance_name"];
     for(auto & flb : m_flbIn)
       {
-
+#if defined (WIN32)
+        n = sprintf_s(tmp, sizeof(tmp) - 1,
+                     R"([%lld, {"time":"%s","name":"%s","level":"%s","pid":"%s","host":"%s","manager":"%s","message": "%s"}])", time(nullptr), date.c_str(), name.c_str(), Logger::getLevelString(level).c_str(), pid.c_str(), host_name.c_str(), manager_name.c_str(), mes);
+#else
         n = snprintf(tmp, sizeof(tmp) - 1,
                      R"([%ld, {"time":"%s","name":"%s","level":"%s","pid":"%s","host":"%s","manager":"%s","message": "%s"}])", time(nullptr), date.c_str(), name.c_str(), Logger::getLevelString(level).c_str(), pid.c_str(), host_name.c_str(), manager_name.c_str(), mes);
-
+#endif
         flb_lib_push(s_flbContext, flb, tmp, n);
       }
     return n;

--- a/src/ext/logger/fluentbit_stream/FluentBit.h
+++ b/src/ext/logger/fluentbit_stream/FluentBit.h
@@ -21,8 +21,14 @@
 #include <string>
 #include <fstream>
 #include <iostream>
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#pragma warning(push)
+#pragma warning( disable : 4100 4245 4189 4805 4200 4505 )
+#endif
 #include <fluent-bit.h>
-
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#pragma warning(pop)
+#endif
 #include <coil/stringutil.h>
 #include <rtm/LogstreamBase.h>
 

--- a/src/lib/rtm/SystemLogger.h
+++ b/src/lib/rtm/SystemLogger.h
@@ -497,9 +497,22 @@ namespace RTC
     std::string m_name = "unknown";
     std::string m_dateFormat = "%b %d %H:%M:%S.%Q";
     coil::IClock* m_clock{&coil::ClockManager::instance().getClock("system")};
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#ifdef LIBRARY_EXPORTS
+    static __declspec(dllexport) const char* const m_levelString[];
+    static __declspec(dllexport) const char* const m_levelOutputString[];
+    static __declspec(dllexport) const char* const m_levelColor[];
+#else
+    static __declspec(dllimport) const char* const m_levelString[];
+    static __declspec(dllimport) const char* const m_levelOutputString[];
+    static __declspec(dllimport) const char* const m_levelColor[];
+#endif
+#else
     static const char* const m_levelString[];
     static const char* const m_levelOutputString[];
     static const char* const m_levelColor[];
+#endif
     bool m_msEnable{false};
     bool m_usEnable{false};
   };


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Fluent BitプラグインをWindowsに対応させる。


## Description of the Change

- Fluent Bitのビルド、インストールについて
Fluent Bitの以下のファイルについては編集が必要である。

  - include\fluent-bit\flb_input.h
  - include\fluent-bit\flb_output.h
  - lib\monkey\include\monkey\mk_core\external\winuio.h
  - lib\monkey\include\monkey\mk_core\mk_dep_unistd.h

以下のリポジトリに修正をコミットしたのでこれを使用する。

```
git clone https://github.com/Nobu19800/fluent-bit
```

CMakeのコマンドは以下の通り。Windowsでは`FLB_TLS`と`FLB_HTTP_SERVER`は強制的に有効、`FLB_IN_SYSTEMD`と`FLB_OUT_KAFKA`は強制的に無効になるため削除。

```
cmake -DFLB_RELEASE=On -DFLB_TRACE=Off -DFLB_SHARED_LIB=On -DFLB_EXAMPLES=Off  -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/workspace/fluent-bit/build/install .. -DOPENSSL_ROOT_DIR=C:/workspace/OpenSSL/build
```

また、cmake実行前にBison/Flexの実行ファイルのパスを設定しておく必要がある。

- https://sourceforge.net/projects/winflexbison/

```
set PATH=C:\workspace\win_flex_bison-2.5.24;%PATH%
````

インストール時にコピーするファイルは以下の通り。

```ps
$FLUENTBIT_SOURCE_DIR = "C:\workspace\fluent-bit"
$FLUENTBIT_BUILD_DIR = "C:\workspace\fluent-bit\build"
$FLUENTBIT_INSTALL_DIR = "C:\workspace\fluent-bit\build\install"

Copy-Item $FLUENTBIT_SOURCE_DIR\lib\monkey\include\monkey\mk_core\external -destination $FLUENTBIT_INSTALL_DIR\include\monkey\mk_core -recurs
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\monkey\mk_core\deps\libevent\include\event.h $FLUENTBIT_INSTALL_DIR\include
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\monkey\mk_core\deps\libevent\include\evutil.h $FLUENTBIT_INSTALL_DIR\include
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\monkey\mk_core\deps\libevent\include\event2 -destination $FLUENTBIT_INSTALL_DIR\include -recurs
Copy-Item $FLUENTBIT_BUILD_DIR\lib\monkey\mk_core\deps\libevent\include\event2\event-config.h $FLUENTBIT_INSTALL_DIR\include\event2
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\msgpack-*\include\msgpack.h $FLUENTBIT_INSTALL_DIR\include
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\msgpack-*\include\msgpack -destination $FLUENTBIT_INSTALL_DIR\include -recurs
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\mbedtls-*\include\mbedtls -destination $FLUENTBIT_INSTALL_DIR\include -recurs
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\c-ares-*\include\*.h $FLUENTBIT_INSTALL_DIR\include
Copy-Item $FLUENTBIT_BUILD_DIR\lib\c-ares-*\ares_build.h $FLUENTBIT_INSTALL_DIR\include
Copy-Item $FLUENTBIT_BUILD_DIR\lib\c-ares-*\ares_config.h $FLUENTBIT_INSTALL_DIR\include
Copy-Item $FLUENTBIT_BUILD_DIR\lib\c-ares-*\ares_config.h $FLUENTBIT_INSTALL_DIR\include
New-Item $FLUENTBIT_INSTALL_DIR\lib\fluent-bit -ItemType Directory
Copy-Item $FLUENTBIT_BUILD_DIR\library\Release\fluent-bit.lib $FLUENTBIT_INSTALL_DIR\lib\fluent-bit
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\cmetrics\include\cmetrics -destination $FLUENTBIT_INSTALL_DIR\include -recurs
Copy-Item $FLUENTBIT_SOURCE_DIR\lib\cmetrics\include\prometheus_remote_write -destination $FLUENTBIT_INSTALL_DIR\include -recurs
```



- OpenRTM-aist Fluent Bitプラグインのビルドについて

Visual Studio 2019以外では試していないので他でビルドできるかは確認が必要。

Visual Studioのビルドでは`FLB_SYSTEM_WINDOWS`のフラグが必要のためこの修正を行った。



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
