### PR TITLE
ロードするモジュールのパスで"/"と"\\"を区別しないようにする

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -409,6 +409,7 @@ namespace coil
       "(?:"
         "^/" // UNIX absolute path
         R"(|^[a-zA-Z]{1}:\\)" // Windows absolute path
+        R"(|^[a-zA-Z]{1}:/)" // Windows absolute path
         R"(|^\\\\)" // Windows network file path
       ")"} ;
     return std::regex_search(str, path);

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -684,11 +684,21 @@ namespace RTC
     {
       std::string m_filepath;
     public:
-      explicit DllPred(const char* filepath) : m_filepath(filepath) {}
+      explicit DllPred(const char* filepath) 
+      {
+        m_filepath = coil::replaceString(filepath, "\\", "/");
+        m_filepath = coil::replaceString(m_filepath, "//", "/");
+      }
       explicit DllPred(const DLLEntity* dll)
-               : m_filepath(dll->properties["file_path"]) {}
+      {
+        m_filepath = coil::replaceString(dll->properties["file_path"], "\\", "/");
+        m_filepath = coil::replaceString(m_filepath, "//", "/");
+      }
       bool operator()(DLLEntity* dllentity)
       {
+        std::string file_path = coil::replaceString(
+          dllentity->properties.getProperty("file_path"), "\\", "/");
+        file_path = coil::replaceString(file_path, "//", "/");
         return m_filepath == dllentity->properties.getProperty("file_path");
       }
     };


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

モジュールロード時にパスの区切り文字が違う場合に、同じファイルやフォルダのパスを比較しているにもかかわらず異なるパスだと判定されることがある。

例えば、以下のパスは違うパスだと判定する。

- C:\\workspace\\test.cpp
- C:/workspace/test.cpp


また、`C:/workspace/test.cpp`は絶対パスだが、`coil::isAbsolutePath`関数で絶対パスではないと判定する。

## Description of the Change

- パスを比較する時に`\\`を`/`に変換して比較するように修正した

区切り文字を全て`/`にすることで同一の文字列になるようにした。
またOpenRTM-aist内でパスの結合は文字列を結合しているだけであり、`\\`や`/`を2回追加する場合がある。
例えば、`C:\\workspace\\`と`test.cpp`を結合する場合に、`"C:\\workspace\\"+"\\"+"test.cpp"`という処理をするため、`workspace`の後に`\\`が2回追加される。このため`\\\\`、`//`は`/`に変換するようにした。

- `coil::isAbsolutePath`関数で`C:/`から始まるパスを絶対パスだと判定するようにするように修正した



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
