### PR TITLE
CMakeLists.txtのコマンド名の大文字小文字混在している箇所を一部小文字に統一、ORB_C_FLAGS_LIST変数の設定ミスを修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ set(OBSERVER_ENABLE FALSE CACHE BOOL "set OBSERVER_ENABLE")
 
 set(LOGGING_ENABLE TRUE CACHE BOOL "set LOGGING_ENABLE")
 if(NO_LOGGING)
-	SET (ORB_C_FLAGS_LIST
+	set(ORB_C_FLAGS_LIST
 		${ORB_C_FLAGS_LIST}
 		-DNO_LOGGING
 	)
@@ -197,11 +197,11 @@ endif()
 
 if(VXWORKS)
 	if("${VX_CPU_FAMILY}" STREQUAL "ppc")
-		SET (CPU_TYPE powerpc)
+		set(CPU_TYPE powerpc)
 	elseif("${VX_CPU_FAMILY}" STREQUAL "simpentium")
-		SET (CPU_TYPE simpentium)
+		set(CPU_TYPE simpentium)
 	elseif("${VX_CPU_FAMILY}" STREQUAL "simlinux")
-		SET (CPU_TYPE simlinux)
+		set(CPU_TYPE simlinux)
 	endif()
 endif(VXWORKS)
 
@@ -226,7 +226,8 @@ if(CORBA STREQUAL "ORBexpress")
 
 		set(ORB_LIBRARIES OEnames OEtcp OEmirror OEbridge OEudp OEipmc OEshrmem OEorb)
 	endif()
-	SET (ORB_C_FLAGS_LIST
+	set(ORB_C_FLAGS_LIST
+		${ORB_C_FLAGS_LIST}
 		 -DCORBA_ANY_SHARED_PTR_OPERATORS -DINCLUDE_CORBA_CORBALOC
 #		-Wpointer-arith -Wwrite-strings -Waggregate-return -Wredundant-decls -Wno-unused -Wshadow -Wundef -Wold-style-cast -fno-implement-inlines -fvolatile  -ansi -msoft-float
 	)
@@ -239,12 +240,14 @@ elseif(CORBA STREQUAL "omniORB")
 	set(CORBA_NAME "omniORB" CACHE STRING "CORBA name.")
 	if(VXWORKS)
 		if("${VX_CPU_FAMILY}" STREQUAL "ppc")
-			SET (ORB_C_FLAGS_LIST
+			set(ORB_C_FLAGS_LIST
+				${ORB_C_FLAGS_LIST}
 				-D__vxWorks__
 				-D__powerpc__
 			)
 		else()
-			SET (ORB_C_FLAGS_LIST
+			set(ORB_C_FLAGS_LIST
+				${ORB_C_FLAGS_LIST}
 				-D__vxWorks__
 				-D__x86__
 			)
@@ -272,16 +275,18 @@ elseif(CORBA STREQUAL "omniORB")
 
 	elseif(MSVC)
 		if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM")
-			SET(ARCH_NAME ARM_win32)
-			SET (ORB_C_FLAGS_LIST
+			set(ARCH_NAME ARM_win32)
+			set(ORB_C_FLAGS_LIST
+				${ORB_C_FLAGS_LIST}
 				-D__WIN32__
 				-D__arm__
 			)
 			set(ORB_LINK_DIR ${ORB_ROOT}/lib/${ARCH_NAME})
 			set(OMNIORB_BINARY_DIR ${ORB_ROOT}/bin/${ARCH_NAME})
 		else()
-			SET(ARCH_NAME x86_win32)
-			SET (ORB_C_FLAGS_LIST
+			set(ARCH_NAME x86_win32)
+			set(ORB_C_FLAGS_LIST
+				${ORB_C_FLAGS_LIST}
 				-D__WIN32__
 				-D__x86__
 			)
@@ -369,11 +374,11 @@ elseif(CORBA STREQUAL "TAO")
 	
 	if(VXWORKS)
 		if("${VX_CPU_FAMILY}" STREQUAL "ppc")
-			SET(ORB_C_FLAGS_LIST -D__powerpc__)
+			set(ORB_C_FLAGS_LIST ${ORB_C_FLAGS_LIST} -D__powerpc__)
 		else()
-			SET(ORB_C_FLAGS_LIST -D__x86__)
+			set(ORB_C_FLAGS_LIST ${ORB_C_FLAGS_LIST} -D__x86__)
 		endif()
-		SET(ORB_C_FLAGS_LIST ${ORB_C_FLAGS_LIST} -DACE_VXWORKS=0x690 -DACE_HAS_PTHREADS -DACE_HAS_AIO_CALLS -DACE_LACKS_ISBLANK)
+		set(ORB_C_FLAGS_LIST ${ORB_C_FLAGS_LIST} -DACE_VXWORKS=0x690 -DACE_HAS_PTHREADS -DACE_HAS_AIO_CALLS -DACE_LACKS_ISBLANK)
 
 		set(ORB_LINK_DIR ${ORB_ROOT}/lib)
 		set(ORB_LIBRARIES TAO_AnyTypeCode TAO_PortableServer TAO_Svc_Utils TAO_CosNaming TAO_DynamicInterface TAO_PI TAO_Utils TAO_PortableServer TAO_DiffServPolicy TAO_DynamicInterface TAO_Strategies TAO ACE)
@@ -395,7 +400,7 @@ elseif(CORBA STREQUAL "TAO")
 		set(ORB_LIBRARIES ${ORB_LIBRARIES1};${ORB_LIBRARIES2})
 
 		set(ORB_INCLUDE_DIR ${ORB_ROOT} ${ORB_ROOT}/TAO ${ORB_ROOT}/TAO/orbsvcs)
-		SET(ORB_C_FLAGS_LIST ${ORB_C_FLAGS_LIST} -DWIN32_LEAN_AND_MEAN -DWITH_ACE)
+		set(ORB_C_FLAGS_LIST ${ORB_C_FLAGS_LIST} -DWIN32_LEAN_AND_MEAN -DWITH_ACE)
 
 		set(ORB_LIBRARIES_INSTALL ${ORB_LIBRARIES1};TAO_IDL_FE;TAO_IDL_FEd;TAO_IDL_BE;TAO_IDL_BEd;)
 		set(ORB_INSTALL_DIR ${OPENRTM_VERSION}/ACE/${RTM_VC_VER}/)
@@ -521,7 +526,7 @@ if(VXWORKS)
 
 	set(ORB_LIBRARIES_PATH)
 	FOREACH(NAME ${ORB_LIBRARIES})
-		SET(ORB_LIB ORB_${NAME}_LIBRARY)
+		set(ORB_LIB ORB_${NAME}_LIBRARY)
 		LIST(APPEND ORB_LIBVARS ${ORB_LIB})
 		FIND_LIBRARY(${ORB_LIB} ${NAME}
 			PATHS ${ORB_LINK_DIR}


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- CMakeLists.txt内のコマンド名は`set`と`SET`のように大文字小文字が混在しており、可読性が悪い。CMakeは大文字小文字を区別しないため処理結果は変わらない。
- `-DNO_LOGGING`等のオプションが反映されない不具合が発生している。CMakeLists.txt内で定義している`ORB_C_FLAGS_LIST`にフラグを追加している処理を行い、設定後にビルドに反映させているが、以下のように途中で設定し直している箇所があり、最初のほうで設定している`-DNO_LOGGING`等は消えてしまう。

```
SET(ORB_C_FLAGS_LIST -D__x86__)
```


## Description of the Change

- `SET`は`set`に統一した
- `ORB_C_FLAGS_LIST `を設定しなおしている箇所を以下のように追加する形に修正した。

```
set(ORB_C_FLAGS_LIST ${ORB_C_FLAGS_LIST } -D__x86__)
```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
