### PR TITLE
新規実装したネームサーバーでオブジェクトのリストが正常に取得できないバグの修正

### DIFF
--- a/utils/openrtmNames/NamingContext.cpp
+++ b/utils/openrtmNames/NamingContext.cpp
@@ -390,6 +390,7 @@ namespace RTM
 
       for (const auto& ob : m_objects) {
         all[i] = ob->get_binding();
+        i++;
       }
     }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

新規実装したopenrtmNamesでRTSystemEditorからRTCのリストを取得した場合、複数のRTCがバインドされているが1つしか取得できない問題が発生している。

## Description of the Change

list関数内でバグがあったため修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
