### PR TITLE
Pull型コネクタでInPortConsumer、OutProviderのinit関数が実行されない問題の修正

### DIFF
--- a/src/lib/rtm/InPortPullConnector.cpp
+++ b/src/lib/rtm/InPortPullConnector.cpp
@@ -48,6 +48,7 @@ namespace RTC
         throw std::bad_alloc();
       }
     m_buffer->init(info.properties.getNode("buffer"));
+    m_consumer->init(info.properties);
     m_consumer->setBuffer(m_buffer);
     m_consumer->setListener(info, m_listeners);
 

--- a/src/lib/rtm/OutPortPullConnector.cpp
+++ b/src/lib/rtm/OutPortPullConnector.cpp
@@ -50,6 +50,7 @@ namespace RTC
     if (m_provider == nullptr || m_buffer == nullptr) { throw std::bad_alloc(); }
 
     m_buffer->init(info.properties.getNode("buffer"));
+    m_provider->init(info.properties);
     m_provider->setBuffer(m_buffer);
     m_provider->setConnector(this);
     m_provider->setListener(info, m_listeners);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

データフロー型がPullの場合にInPortConsumer、OutPortProviderのinit関数が正常に実行されず、コネクタプロファイルの情報が反映されない。


## Description of the Change

InPortPullConnector、OutPortPullConnectorでInPortConsumer、OutPortProviderのinit関数を呼ぶようにしてコネクタプロファイルの情報が反映されるように修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
