### PR TITLE
ROSTransportのWindows対応のための修正

### DIFF
--- a/src/ext/local_service/nameservice_file/CMakeLists.txt
+++ b/src/ext/local_service/nameservice_file/CMakeLists.txt
@@ -10,6 +10,9 @@ add_definitions(${ORB_C_FLAGS_LIST})
 add_definitions(${COIL_C_FLAGS_LIST})
 if(WIN32)
 	add_definitions(-DRTM_SKEL_IMPORT_SYMBOL)
+	if(ROS_ENABLE)
+		add_definitions(-D_RTLDLL -DBOOST_ALL_DYN_LINK)
+	endif()
 endif()
 
 

--- a/src/ext/transport/FastRTPS/CORBACdrData.cpp
+++ b/src/ext/transport/FastRTPS/CORBACdrData.cpp
@@ -106,5 +106,4 @@ bool RTC::CORBACdrData::isKeyDefined()
 
 void RTC::CORBACdrData::serializeKey(eprosima::fastcdr::Cdr &/*scdr*/) const
 {
-	 
 }

--- a/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.cpp
+++ b/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.cpp
@@ -126,7 +126,7 @@ namespace RTC
     bool CORBACdrDataPubSubType::deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload, void* data)
     {
 
-        RTC::ByteData* p_type = (RTC::ByteData*) data; 	//Convert DATA to pointer of your type
+        RTC::ByteData* p_type = (RTC::ByteData*) data; //Convert DATA to pointer of your type
         eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->length); // Object that manages the raw buffer.
         eprosima::fastcdr::Cdr::Endianness endian;
         if (m_endian)
@@ -196,19 +196,19 @@ namespace RTC
         {
             return false;
         }
-        eprosima::fastcdr::FastBuffer fastbuffer((char*)m_keyBuffer,CORBACdrData::getKeyMaxCdrSerializedSize()); 	// Object that manages the raw buffer.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS); 	// Object that serializes the data.
+        eprosima::fastcdr::FastBuffer fastbuffer((char*)m_keyBuffer,CORBACdrData::getKeyMaxCdrSerializedSize()); // Object that manages the raw buffer.
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS); // Object that serializes the data.
         
-        if(CORBACdrData::getKeyMaxCdrSerializedSize()>16)	{
+        if(CORBACdrData::getKeyMaxCdrSerializedSize()>16){
             m_md5.init();
             m_md5.update(m_keyBuffer,(unsigned int)ser.getSerializedDataLength());
             m_md5.finalize();
-            for(uint8_t i = 0;i<16;++i)    	{
+            for(uint8_t i = 0;i<16;++i)    {
                 handle->value[i] = m_md5.digest[i];
             }
         }
         else    {
-            for(uint8_t i = 0;i<16;++i)    	{
+            for(uint8_t i = 0;i<16;++i)    {
                 handle->value[i] = m_keyBuffer[i];
             }
         }

--- a/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.h
+++ b/src/ext/transport/FastRTPS/CORBACdrDataPubSubTypes.h
@@ -37,23 +37,23 @@ namespace RTC
     public:
         using type = CORBACdrData;
 
-    	CORBACdrDataPubSubType();
-    	~CORBACdrDataPubSubType() override;
+        CORBACdrDataPubSubType();
+        ~CORBACdrDataPubSubType() override;
         void init(std::string name, bool header_enable);
         void setEndian(bool endian);
-    	bool serialize(void *data, eprosima::fastrtps::rtps::SerializedPayload_t *payload) override;
-    	bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t *payload, void *data) override;
+        bool serialize(void *data, eprosima::fastrtps::rtps::SerializedPayload_t *payload) override;
+        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t *payload, void *data) override;
         std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
 #if (FASTRTPS_VERSION_MAJOR <= 1) && (FASTRTPS_VERSION_MINOR <= 6)
-    	bool getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t *ihandle) override;
+        bool getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t *ihandle) override;
 #else
         bool getKey(void *data, eprosima::fastrtps::rtps::InstanceHandle_t *ihandle, bool force_md5) override;
 #endif
-    	void* createData() override;
-    	void deleteData(void * data) override;
+        void* createData() override;
+        void deleteData(void * data) override;
     private:
-    	MD5 m_md5;
-    	unsigned char* m_keyBuffer;
+        MD5 m_md5;
+        unsigned char* m_keyBuffer;
         bool m_endian;
         bool m_header_enable;
     };

--- a/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
+++ b/src/ext/transport/FastRTPS/FastRTPSInPort.cpp
@@ -360,7 +360,7 @@ namespace RTC
   void FastRTPSInPort::SubListener::onNewDataMessage(eprosima::fastrtps::Subscriber* sub)
   {
     RTC_PARANOID(("onNewDataMessage()"));
-		
+
     RTC_PARANOID(("takeNextData"));
     if(sub->takeNextData(&m_data, &m_info))
     {

--- a/src/ext/transport/FastRTPS/FastRTPSManager.h
+++ b/src/ext/transport/FastRTPS/FastRTPSManager.h
@@ -230,7 +230,7 @@ namespace RTC
     private:
         static FastRTPSManager* manager;
         static std::mutex mutex;
-	    eprosima::fastrtps::Participant *m_participant;
+        eprosima::fastrtps::Participant *m_participant;
         std::string m_xml_profile_file;
     protected:
     };

--- a/src/ext/transport/OpenSplice/CORBACdrDataDcps_impl.cpp
+++ b/src/ext/transport/OpenSplice/CORBACdrDataDcps_impl.cpp
@@ -554,7 +554,7 @@ OpenRTM_OpenSplice::CORBACdrDataDataReader_impl::dataSeqGetBuffer (
     DDS::ULong index)
 {
     OpenRTM_OpenSplice::CORBACdrDataSeq *data_seq = reinterpret_cast<OpenRTM_OpenSplice::CORBACdrDataSeq *>(received_data);
-	return &((*data_seq)[index]);
+    return &((*data_seq)[index]);
 }
 
 void

--- a/src/ext/transport/OpenSplice/OpenSpliceOutPort_Impl.cpp
+++ b/src/ext/transport/OpenSplice/OpenSpliceOutPort_Impl.cpp
@@ -313,7 +313,7 @@ namespace RTC
             return false;
         }
 
-       	m_listener = new PubListener();
+        m_listener = new PubListener();
 
         DDS::DataWriter_var writer = topicmgr.createWriter(m_topic, m_listener.in());
 

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -100,3 +100,11 @@ endif(VXWORKS)
 
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/devel/include/ros)
+
+set(INSTALL_ROSTRANSPORT_DIR ${INSTALL_RTM_EXT_DIR}/transport)
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/rtc.ros.conf.in ${PROJECT_BINARY_DIR}/rtc.ros.conf @ONLY)
+install(
+	FILES ${PROJECT_BINARY_DIR}/rtc.ros.conf
+	DESTINATION ${INSTALL_RTM_ETC_DIR}/transport
+	COMPONENT ext)

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -22,8 +22,13 @@ if(UNIX)
 	endif()
 endif()
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(roscpp roscpp)
+if(WIN32)
+	find_package(roscpp REQUIRED
+	)
+else()
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(roscpp roscpp)
+endif()
 
 if(NOT roscpp_FOUND)
 	message(FATAL_ERROR "can not find roscpp.")
@@ -32,8 +37,13 @@ endif()
 
 find_package(Boost 1.69 COMPONENTS chrono filesystem system)
 if(NOT Boost_FOUND)
-	find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
+	if(WIN32)
+		find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system thread)
+	else()
+		find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
+	endif()
 endif()
+
 
 link_directories(${ORB_LINK_DIR})
 add_definitions(${ORB_C_FLAGS_LIST})
@@ -42,6 +52,10 @@ if(WIN32)
 	add_definitions(-DRTM_SKEL_IMPORT_SYMBOL)
 	add_definitions(-DNOGDI)
 	add_definitions(-DTRANSPORT_PLUGIN)
+	add_definitions(-D_RTLDLL)
+	add_definitions(-DBOOST_ALL_DYN_LINK)
+
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/install_manifest.txt.in ${PROJECT_BINARY_DIR}/install_manifest.txt @ONLY)
 endif()
 
 
@@ -76,7 +90,11 @@ else()
 	target_include_directories(${target} SYSTEM
 		PRIVATE ${roscpp_INCLUDE_DIRS}
 		PRIVATE ${Boost_INCLUDE_DIRS})
-	target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} ${roscpp_LINK_LIBRARIES} ${Boost_LIBRARIES})
+	if(WIN32)
+		target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} ${roscpp_LIBRARIES} ${Boost_LIBRARIES})
+	else()
+		target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} ${roscpp_LINK_LIBRARIES} ${Boost_LIBRARIES})
+	endif()
 	set_target_properties(${target} PROPERTIES PREFIX "")
 
 

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -49,6 +49,7 @@ namespace RTC
    */
   ROSInPort::ROSInPort(void)
    : m_buffer(nullptr),
+     m_tcp_nodelay(true),
      m_roscoreport(ROS_DEFAULT_MASTER_PORT)
   {
     // PortProfile setting
@@ -141,6 +142,9 @@ namespace RTC
     m_topic = "/" + m_topic;
 
 
+    m_tcp_nodelay = coil::toBool(prop["ros.tcp_nodelay"], "YES", "NO", true);
+
+
     m_roscorehost = prop.getProperty("ros.roscore.host");
     std::string tmp_port = prop.getProperty("ros.roscore.port");
     if(m_roscorehost.empty() && tmp_port.empty())
@@ -221,7 +225,7 @@ namespace RTC
     if(!info)
     {
       RTC_ERROR(("Can not find message type(%s)", m_messageType.c_str()));
-      return;
+      throw;
     }
 
     request[0] = m_callerid;
@@ -237,7 +241,7 @@ namespace RTC
     if(!b)
     {
       RTC_ERROR(("XML-RCP Error"));
-      return;
+      throw;
     }
     
 
@@ -402,7 +406,14 @@ namespace RTC
       header["md5sum"] = info->md5sum();
       header["callerid"] = m_callerid;
       header["type"] = info->type();
-      header["tcp_nodelay"] = "1";
+      if(m_tcp_nodelay)
+      {
+        header["tcp_nodelay"] = "1";
+      }
+      else
+      {
+        header["tcp_nodelay"] = "0";
+      }
 
       RTC_VERBOSE(("writeHeader()"));
       RTC_VERBOSE(("Message Type:%s", info->type().c_str()));

--- a/src/ext/transport/ROSTransport/ROSInPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSInPort.cpp
@@ -27,10 +27,15 @@
 #include <ros/network.h>
 #include <ros/poll_manager.h>
 #include <ros/connection_manager.h>
-#include <coil/OS.h>
-#include <coil/stringutil.h>
 #include "ROSInPort.h"
 #include "ROSTopicManager.h"
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#ifdef getpid
+#undef getpid
+#endif
+#endif
+#include <coil/OS.h>
+#include <coil/stringutil.h>
 
 
 #define ROS_MASTER_URI "ROS_MASTER_URI"

--- a/src/ext/transport/ROSTransport/ROSInPort.h
+++ b/src/ext/transport/ROSTransport/ROSInPort.h
@@ -481,6 +481,7 @@ namespace RTC
     std::string m_callerid;
     std::string m_messageType;
     std::mutex m_mutex;
+    bool m_tcp_nodelay;
 
     std::vector<PublisherLink> m_tcp_connecters;
     std::mutex m_con_mutex;

--- a/src/ext/transport/ROSTransport/ROSOutPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSOutPort.cpp
@@ -167,7 +167,7 @@ namespace RTC
     if(!info)
     {
       RTC_ERROR(("Can not find message type(%s)", m_messageType.c_str()));
-      return;
+      throw;
     }
 
 
@@ -182,6 +182,7 @@ namespace RTC
     if(!b)
     {
       RTC_ERROR(("XML-RCP Error"));
+      throw;
     }
   }
 

--- a/src/ext/transport/ROSTransport/ROSOutPort.cpp
+++ b/src/ext/transport/ROSTransport/ROSOutPort.cpp
@@ -22,10 +22,15 @@
 #include <chrono>
 #include <rtm/NVUtil.h>
 #include <ros/xmlrpc_manager.h>
-#include <coil/OS.h>
-#include <coil/stringutil.h>
 #include "ROSOutPort.h"
 #include "ROSTopicManager.h"
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#ifdef getpid
+#undef getpid
+#endif
+#endif
+#include <coil/OS.h>
+#include <coil/stringutil.h>
 
 #define ROS_MASTER_URI "ROS_MASTER_URI"
 #define ROS_DEFAULT_MASTER_ADDRESS "localhost"

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -18,6 +18,8 @@
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #include <WinSock2.h>
+#pragma warning(push)
+#pragma warning( disable : 4267 )
 #endif
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
@@ -51,6 +53,10 @@
 #include <sensor_msgs/Image.h>
 #include "ROSSerializer.h"
 #include "ROSMessageInfo.h"
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#pragma warning(pop)
+#endif
 
 
 namespace RTC

--- a/src/ext/transport/ROSTransport/ROSTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.cpp
@@ -25,6 +25,11 @@
 #include <xmlrpcpp/XmlRpcSocket.h>
 #include <ros/connection.h>
 #include <ros/connection_manager.h>
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#ifdef getpid
+#undef getpid
+#endif
+#endif
 #include <coil/OS.h>
 
 
@@ -35,6 +40,10 @@ namespace ros
     void init(const M_string& remappings);
   }
 }
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+std::string ros::console::g_last_error_message = "Unknown Error";
+#endif
 
 
 namespace RTC

--- a/src/ext/transport/ROSTransport/ROSTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.cpp
@@ -41,7 +41,7 @@ namespace RTC
 {
   ROSTopicManager* ROSTopicManager::manager = nullptr;
   std::mutex ROSTopicManager::mutex;
-
+  std::once_flag ROSTopicManager::m_once;
 
   /*!
    * @if jp
@@ -1060,12 +1060,10 @@ namespace RTC
    */
   ROSTopicManager* ROSTopicManager::init()
   {
-    std::lock_guard<std::mutex> guard(mutex);
-    if (!manager)
-    {
+    std::call_once(m_once, [] {
       manager = new ROSTopicManager();
       manager->start();
-    }
+    });
     return manager;
   }
 
@@ -1085,12 +1083,10 @@ namespace RTC
    */
   ROSTopicManager& ROSTopicManager::instance()
   {
-    std::lock_guard<std::mutex> guard(mutex);
-    if (!manager)
-    {
+    std::call_once(m_once, [] {
       manager = new ROSTopicManager();
       manager->start();
-    }
+    });
     return *manager;
   }
 

--- a/src/ext/transport/ROSTransport/ROSTopicManager.h
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.h
@@ -418,6 +418,7 @@ namespace RTC
         std::vector<SubscriberLink> m_tcp_sub_connecters;
         std::mutex m_publink_mutex;
         std::mutex m_sublink_mutex;
+        static std::once_flag m_once;
     public:
         /*!
          * @if jp

--- a/src/ext/transport/ROSTransport/ROSTransport.cpp
+++ b/src/ext/transport/ROSTransport/ROSTransport.cpp
@@ -28,6 +28,48 @@
 
 namespace ROSRTM
 {
+  static const char* const ros_sub_option[] =
+  {
+    "topic.__value__", "chatter",
+    "topic.__widget__", "text",
+    "topic.__constraint__", "none",
+    "roscore.host.__value__", "",
+    "roscore.host.__widget__", "text",
+    "roscore.host.__constraint__", "none",
+    "roscore.port.__value__", "",
+    "roscore.port.__widget__", "text",
+    "roscore.port.__constraint__", "none",
+    "node.name.__value__", "",
+    "node.name.__widget__", "text",
+    "node.name.__constraint__", "none",
+    "node.anonymous.__value__", "NO",
+    "node.anonymous.__widget__", "radio",
+    "node.anonymous.__constraint__", "(YES, NO)",
+    "tcp_nodelay.__value__", "YES",
+    "tcp_nodelay.__widget__", "radio",
+    "tcp_nodelay.__constraint__", "(YES, NO)",
+    ""
+  };
+
+  static const char* const ros_pub_option[] =
+  {
+    "topic.__value__", "chatter",
+    "topic.__widget__", "text",
+    "topic.__constraint__", "none",
+    "roscore.host.__value__", "",
+    "roscore.host.__widget__", "text",
+    "roscore.host.__constraint__", "none",
+    "roscore.port.__value__", "",
+    "roscore.port.__widget__", "text",
+    "roscore.port.__constraint__", "none",
+    "node.name.__value__", "",
+    "node.name.__widget__", "text",
+    "node.name.__constraint__", "none",
+    "node.anonymous.__value__", "NO",
+    "node.anonymous.__widget__", "radio",
+    "node.anonymous.__constraint__", "(YES, NO)",
+    ""
+  };
 
   ManagerActionListener::ManagerActionListener()
   {
@@ -70,21 +112,25 @@ extern "C"
   {
     (void)manager;
     {
+      coil::Properties prop(ROSRTM::ros_sub_option);
       RTC::InPortProviderFactory& factory(RTC::InPortProviderFactory::instance());
       factory.addFactory("ros",
                         ::coil::Creator< ::RTC::InPortProvider,
                                           ::RTC::ROSInPort>,
                         ::coil::Destructor< ::RTC::InPortProvider,
-                                            ::RTC::ROSInPort>);
+                                            ::RTC::ROSInPort>,
+                        prop);
     }
 
     {
+      coil::Properties prop(ROSRTM::ros_pub_option);
       RTC::InPortConsumerFactory& factory(RTC::InPortConsumerFactory::instance());
       factory.addFactory("ros",
                         ::coil::Creator< ::RTC::InPortConsumer,
                                           ::RTC::ROSOutPort>,
                         ::coil::Destructor< ::RTC::InPortConsumer,
-                                            ::RTC::ROSOutPort>);
+                                            ::RTC::ROSOutPort>,
+                        prop);
     }
     ROSSerializerInit(manager);
 

--- a/src/ext/transport/ROSTransport/rtc.ros.conf.in
+++ b/src/ext/transport/ROSTransport/rtc.ros.conf.in
@@ -1,0 +1,9 @@
+logger.enable: YES
+logger.log_level: DEBUG
+#logger.file_name: stdout
+
+manager.modules.load_path: @CMAKE_INSTALL_PREFIX@/@INSTALL_ROSTRANSPORT_DIR@
+manager.preload.modules: ROSTransport@CMAKE_SHARED_LIBRARY_SUFFIX@
+
+manager.components.preactivation: ConsoleOut0, ConsoleIn0
+manager.components.preconnect: ConsoleOut0.in?interface_type=ros&marshaling_type=ros:std_msgs/Float32&ros.node.name=ConsoleOut0, ConsoleIn0.out?interface_type=ros&marshaling_type=ros:std_msgs/Float32&ros.node.name=ConsoleIn0

--- a/src/lib/coil/common/coil/Async.cpp
+++ b/src/lib/coil/common/coil/Async.cpp
@@ -34,8 +34,8 @@ namespace coil
 
   DeleteAsyncThread::DeleteAsyncThread()
   {
-	  m_task.setTask([this] { svc(); });
-	  m_task.setPeriod(std::chrono::seconds(1));
+      m_task.setTask([this] { svc(); });
+      m_task.setPeriod(std::chrono::seconds(1));
   }
 
   DeleteAsyncThread::~DeleteAsyncThread()

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -610,7 +610,7 @@ namespace coil
     class FactoryEntry
     {
     public:
-      FactoryEntry() = default;
+      FactoryEntry();
 
       /*!
        * @if jp
@@ -646,6 +646,14 @@ namespace coil
     ObjectMap m_objects;
     std::mutex m_mutex;
   };
+
+  template <
+    class AbstractClass,
+    typename Identifier,
+    typename Compare,
+    typename Creator,
+    typename Destructor>
+    Factory<AbstractClass, Identifier, Compare, Creator, Destructor>::FactoryEntry::FactoryEntry() = default;
 
   /*!
    * @if jp

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -651,12 +651,12 @@ namespace coil
 
 
   template <
-      class AbstractClass,
-      typename Identifier = std::string,
-      typename Compare = std::less<Identifier>,
-      typename Creator = AbstractClass *(*)(),
-      typename Destructor = void (*)(AbstractClass *&)>
-  Factory<AbstractClass,>::FactoryEntry::~FactoryEntry() = default;
+    class AbstractClass,
+    typename Identifier,
+    typename Compare,
+    typename Creator,
+    typename Destructor>
+    Factory<AbstractClass, Identifier, Compare, Creator, Destructor>::FactoryEntry::~FactoryEntry() = default;
 
   /*!
    * @if jp

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -610,7 +610,7 @@ namespace coil
     class FactoryEntry
     {
     public:
-      FactoryEntry();
+      FactoryEntry() = default;
 
       /*!
        * @if jp
@@ -633,10 +633,12 @@ namespace coil
        *
        * @endif
        */
-      FactoryEntry(Identifier id, Creator creator, Destructor destructor, Properties prop)
+      FactoryEntry(Identifier id, Creator creator, Destructor destructor, const Properties &prop)
           : id_(std::move(id)), creator_(creator), destructor_(destructor), prop_(prop)
       {
       }
+
+      ~FactoryEntry();
       std::string id_;
       Creator creator_;
       Destructor destructor_;
@@ -647,13 +649,14 @@ namespace coil
     std::mutex m_mutex;
   };
 
+
   template <
-    class AbstractClass,
-    typename Identifier,
-    typename Compare,
-    typename Creator,
-    typename Destructor>
-    Factory<AbstractClass, Identifier, Compare, Creator, Destructor>::FactoryEntry::FactoryEntry() = default;
+      class AbstractClass,
+      typename Identifier = std::string,
+      typename Compare = std::less<Identifier>,
+      typename Creator = AbstractClass *(*)(),
+      typename Destructor = void (*)(AbstractClass *&)>
+  Factory<AbstractClass,>::FactoryEntry::~FactoryEntry() = default;
 
   /*!
    * @if jp

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -21,6 +21,7 @@
 #define COIL_FACTORY_H
 
 #include <coil/Singleton.h>
+#include <coil/Properties.h>
 
 #include <cassert>
 #include <cstdint>
@@ -59,7 +60,7 @@
 
 namespace coil
 {
-/*!
+  /*!
    * @if jp
    *
    * @brief reutrn codes of Factory class.
@@ -70,17 +71,17 @@ namespace coil
    *
    * @endif
    */
-enum class FactoryReturn : uint8_t
-{
-  OK,
-  FACTORY_ERROR,
-  ALREADY_EXISTS,
-  NOT_FOUND,
-  INVALID_ARG,
-  UNKNOWN_ERROR
-};
+  enum class FactoryReturn : uint8_t
+  {
+    OK,
+    FACTORY_ERROR,
+    ALREADY_EXISTS,
+    NOT_FOUND,
+    INVALID_ARG,
+    UNKNOWN_ERROR
+  };
 
-/*!
+  /*!
    * @if jp
    *
    * @brief Creator テンプレート
@@ -91,13 +92,13 @@ enum class FactoryReturn : uint8_t
    *
    * @endif
    */
-template <class AbstractClass, class ConcreteClass>
-AbstractClass *Creator()
-{
-  return new ConcreteClass();
-}
+  template <class AbstractClass, class ConcreteClass>
+  AbstractClass *Creator()
+  {
+    return new ConcreteClass();
+  }
 
-/*!
+  /*!
    * @if jp
    *
    * @brief Destructor テンプレート
@@ -108,23 +109,23 @@ AbstractClass *Creator()
    *
    * @endif
    */
-template <class AbstractClass, class ConcreteClass>
-void Destructor(AbstractClass *&obj)
-{
-  if (obj == nullptr)
+  template <class AbstractClass, class ConcreteClass>
+  void Destructor(AbstractClass *&obj)
   {
-    return;
+    if (obj == nullptr)
+    {
+      return;
+    }
+    ConcreteClass *tmp = dynamic_cast<ConcreteClass *>(obj);
+    if (tmp == nullptr)
+    {
+      return;
+    }
+    delete obj;
+    obj = nullptr;
   }
-  ConcreteClass *tmp = dynamic_cast<ConcreteClass *>(obj);
-  if (tmp == nullptr)
-  {
-    return;
-  }
-  delete obj;
-  obj = nullptr;
-}
 
-/*!
+  /*!
    * @if jp
    *
    * @class Factory
@@ -137,23 +138,23 @@ void Destructor(AbstractClass *&obj)
    *
    * @endif
    */
-template <
-    class AbstractClass,
-    typename Identifier = std::string,
-    typename Compare = std::less<Identifier>,
-    typename Creator = AbstractClass *(*)(),
-    typename Destructor = void (*)(AbstractClass *&)>
-class Factory
-{
-  class FactoryEntry;
+  template <
+      class AbstractClass,
+      typename Identifier = std::string,
+      typename Compare = std::less<Identifier>,
+      typename Creator = AbstractClass *(*)(),
+      typename Destructor = void (*)(AbstractClass *&)>
+  class Factory
+  {
+    class FactoryEntry;
 
-public:
-  using FactoryMap = std::map<Identifier, FactoryEntry>;
-  using FactoryMapIt = typename FactoryMap::iterator;
-  using ObjectMap = std::map<AbstractClass *, FactoryEntry>;
-  using ObjectMapIt = typename ObjectMap::iterator;
+  public:
+    using FactoryMap = std::map<Identifier, FactoryEntry>;
+    using FactoryMapIt = typename FactoryMap::iterator;
+    using ObjectMap = std::map<AbstractClass *, FactoryEntry>;
+    using ObjectMapIt = typename ObjectMap::iterator;
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief ファクトリー有無チェック
@@ -176,13 +177,13 @@ public:
      *
      * @endif
      */
-  bool hasFactory(const Identifier &id)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    return static_cast<bool>(m_creators.count(id) != 0);
-  }
+    bool hasFactory(const Identifier &id)
+    {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      return static_cast<bool>(m_creators.count(id) != 0);
+    }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief ファクトリーIDリスト取得
@@ -201,24 +202,56 @@ public:
      *
      * @endif
      */
-  std::vector<Identifier> getIdentifiers()
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    std::vector<Identifier> idlist;
-    idlist.reserve(m_creators.size());
-
-    FactoryMapIt it(m_creators.begin());
-    FactoryMapIt it_end(m_creators.end());
-
-    while (it != it_end)
+    std::vector<Identifier> getIdentifiers()
     {
-      idlist.emplace_back(it->first);
-      ++it;
-    }
-    return idlist;
-  }
+      std::lock_guard<std::mutex> guard(m_mutex);
+      std::vector<Identifier> idlist;
+      idlist.reserve(m_creators.size());
 
-  /*!
+      FactoryMapIt it(m_creators.begin());
+      FactoryMapIt it_end(m_creators.end());
+
+      while (it != it_end)
+      {
+        idlist.emplace_back(it->first);
+        ++it;
+      }
+      return idlist;
+    }
+
+    /*!
+     * @if jp
+     *
+     * @brief 指定IDのファクトリのプロパティを取得する
+     *
+     * プロパティにはオブジェクトの設定に必要なパラメータ
+     * の情報を格納している
+     *
+     * @return プロパティ
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * 
+     *
+     * @return 
+     *
+     * @endif
+     */
+    Properties getProperties(const Identifier &id)
+    {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      FactoryMap::iterator it = m_creators.find(id);
+      if (it != m_creators.end())
+      {
+        return m_creators[id].prop_;
+      }
+    
+      return Properties();
+    }
+
+    /*!
      * @if jp
      *
      * @brief ファクトリー登録
@@ -228,6 +261,7 @@ public:
      * @param id ファクトリーID
      * @param creator クリエータ用ファンクタ
      * @param destructor デストラクタ用ファンクタ
+     * @param prop 設定に必要な各種パラメータの情報
      *
      * @return OK: 正常終了
      *         ALREADY_EXISTS: 登録済み
@@ -242,6 +276,7 @@ public:
      * @param id Factory ID.
      * @param creator Functor for creator.
      * @param destructor Functor for destructor.
+     * @param prop 
      *
      * @return OK: Successful
      *         ALREADY_EXISTS: already exists.
@@ -249,25 +284,26 @@ public:
      *
      * @endif
      */
-  FactoryReturn addFactory(const Identifier &id,
-                           Creator creator,
-                           Destructor destructor)
-  {
-    if (creator == nullptr || destructor == nullptr)
+    FactoryReturn addFactory(const Identifier &id,
+                             Creator creator,
+                             Destructor destructor,
+                             Properties prop = Properties())
     {
-      return FactoryReturn::INVALID_ARG;
+      if (creator == nullptr || destructor == nullptr)
+      {
+        return FactoryReturn::INVALID_ARG;
+      }
+      std::lock_guard<std::mutex> guard(m_mutex);
+      if (m_creators.count(id) != 0)
+      {
+        return FactoryReturn::ALREADY_EXISTS;
+      }
+      FactoryEntry f(id, creator, destructor, prop);
+      m_creators[id] = f;
+      return FactoryReturn::OK;
     }
-    std::lock_guard<std::mutex> guard(m_mutex);
-    if (m_creators.count(id) != 0)
-    {
-      return FactoryReturn::ALREADY_EXISTS;
-    }
-    FactoryEntry f(id, creator, destructor);
-    m_creators[id] = f;
-    return FactoryReturn::OK;
-  }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief ファクトリー削除
@@ -292,18 +328,18 @@ public:
      *
      * @endif
      */
-  FactoryReturn removeFactory(const Identifier &id)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    if (m_creators.count(id) == 0)
+    FactoryReturn removeFactory(const Identifier &id)
     {
-      return FactoryReturn::NOT_FOUND;
+      std::lock_guard<std::mutex> guard(m_mutex);
+      if (m_creators.count(id) == 0)
+      {
+        return FactoryReturn::NOT_FOUND;
+      }
+      m_creators.erase(id);
+      return FactoryReturn::OK;
     }
-    m_creators.erase(id);
-    return FactoryReturn::OK;
-  }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief ファクトリーオブジェクト生成
@@ -326,20 +362,20 @@ public:
      *
      * @endif
      */
-  AbstractClass *createObject(const Identifier &id)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    if (m_creators.count(id) == 0)
+    AbstractClass *createObject(const Identifier &id)
     {
-      return nullptr;
+      std::lock_guard<std::mutex> guard(m_mutex);
+      if (m_creators.count(id) == 0)
+      {
+        return nullptr;
+      }
+      AbstractClass *obj = m_creators[id].creator_();
+      assert(m_objects.count(obj) == 0);
+      m_objects[obj] = m_creators[id];
+      return obj;
     }
-    AbstractClass *obj = m_creators[id].creator_();
-    assert(m_objects.count(obj) == 0);
-    m_objects[obj] = m_creators[id];
-    return obj;
-  }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief ファクトリーオブジェクト削除
@@ -360,19 +396,19 @@ public:
      *
      * @endif
      */
-  FactoryReturn deleteObject(const Identifier &id, AbstractClass *&obj)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    if (m_creators.count(id) == 0)
+    FactoryReturn deleteObject(const Identifier &id, AbstractClass *&obj)
     {
-      return deleteObject(obj);
+      std::lock_guard<std::mutex> guard(m_mutex);
+      if (m_creators.count(id) == 0)
+      {
+        return deleteObject(obj);
+      }
+      m_creators[id].destructor_(obj);
+      m_objects.erase(obj);
+      return FactoryReturn::OK;
     }
-    m_creators[id].destructor_(obj);
-    m_objects.erase(obj);
-    return FactoryReturn::OK;
-  }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief ファクトリーオブジェクト削除
@@ -391,20 +427,20 @@ public:
      *
      * @endif
      */
-  FactoryReturn deleteObject(AbstractClass *&obj)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    if (m_objects.count(obj) == 0)
+    FactoryReturn deleteObject(AbstractClass *&obj)
     {
-      return FactoryReturn::NOT_FOUND;
+      std::lock_guard<std::mutex> guard(m_mutex);
+      if (m_objects.count(obj) == 0)
+      {
+        return FactoryReturn::NOT_FOUND;
+      }
+      AbstractClass *tmp(obj);
+      m_objects[obj].destructor_(obj);
+      m_objects.erase(tmp);
+      return FactoryReturn::OK;
     }
-    AbstractClass *tmp(obj);
-    m_objects[obj].destructor_(obj);
-    m_objects.erase(tmp);
-    return FactoryReturn::OK;
-  }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief 生成済みオブジェクトリストの取得
@@ -423,18 +459,18 @@ public:
      *
      * @endif
      */
-  std::vector<AbstractClass *> createdObjects()
-  {
-    std::vector<AbstractClass *> objects;
-    std::lock_guard<std::mutex> guard(m_mutex);
-    for (ObjectMapIt it(m_objects.begin()); it != m_objects.end(); ++it)
+    std::vector<AbstractClass *> createdObjects()
     {
-      objects.emplace_back(it->first);
+      std::vector<AbstractClass *> objects;
+      std::lock_guard<std::mutex> guard(m_mutex);
+      for (ObjectMapIt it(m_objects.begin()); it != m_objects.end(); ++it)
+      {
+        objects.emplace_back(it->first);
+      }
+      return objects;
     }
-    return objects;
-  }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief オブジェクトがこのファクトリの生成物かどうか調べる
@@ -455,13 +491,13 @@ public:
      *
      * @endif
      */
-  bool isProducerOf(AbstractClass *obj)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    return m_objects.count(obj) != 0;
-  }
+    bool isProducerOf(AbstractClass *obj)
+    {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      return m_objects.count(obj) != 0;
+    }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief オブジェクトからクラス識別子(ID)を取得する
@@ -484,18 +520,18 @@ public:
      *                     OK: normal return
      * @endif
      */
-  FactoryReturn objectToIdentifier(AbstractClass *obj, Identifier &id)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    if (m_objects.count(obj) == 0)
+    FactoryReturn objectToIdentifier(AbstractClass *obj, Identifier &id)
     {
-      return FactoryReturn::NOT_FOUND;
+      std::lock_guard<std::mutex> guard(m_mutex);
+      if (m_objects.count(obj) == 0)
+      {
+        return FactoryReturn::NOT_FOUND;
+      }
+      id = m_objects[obj].id_;
+      return FactoryReturn::OK;
     }
-    id = m_objects[obj].id_;
-    return FactoryReturn::OK;
-  }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief オブジェクトのコンストラクタを取得する
@@ -520,13 +556,13 @@ public:
      *
      * @endif
      */
-  Creator objectToCreator(AbstractClass *obj)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    return m_objects[obj].creator_;
-  }
+    Creator objectToCreator(AbstractClass *obj)
+    {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      return m_objects[obj].creator_;
+    }
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief オブジェクトのデストラクタを取得する
@@ -551,14 +587,14 @@ public:
      *
      * @endif
      */
-  Destructor objectToDestructor(AbstractClass *obj)
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    return m_objects[obj].destructor_;
-  }
+    Destructor objectToDestructor(AbstractClass *obj)
+    {
+      std::lock_guard<std::mutex> guard(m_mutex);
+      return m_objects[obj].destructor_;
+    }
 
-private:
-  /*!
+  private:
+    /*!
      * @if jp
      *
      * @class FactoryEntry
@@ -571,12 +607,12 @@ private:
      *
      * @endif
      */
-  class FactoryEntry
-  {
-  public:
-    FactoryEntry() = default;
+    class FactoryEntry
+    {
+    public:
+      FactoryEntry() = default;
 
-    /*!
+      /*!
        * @if jp
        *
        * @brief コンストラクタ
@@ -597,20 +633,21 @@ private:
        *
        * @endif
        */
-    FactoryEntry(Identifier id, Creator creator, Destructor destructor)
-        : id_(std::move(id)), creator_(creator), destructor_(destructor)
-    {
-    }
-    std::string id_;
-    Creator creator_;
-    Destructor destructor_;
+      FactoryEntry(Identifier id, Creator creator, Destructor destructor, Properties prop= Properties())
+          : id_(std::move(id)), creator_(creator), destructor_(destructor), prop_(prop)
+      {
+      }
+      std::string id_;
+      Creator creator_;
+      Destructor destructor_;
+      Properties prop_;
+    };
+    FactoryMap m_creators;
+    ObjectMap m_objects;
+    std::mutex m_mutex;
   };
-  FactoryMap m_creators;
-  ObjectMap m_objects;
-  std::mutex m_mutex;
-};
 
-/*!
+  /*!
    * @if jp
    *
    * @class GlobalFactory
@@ -623,33 +660,33 @@ private:
    *
    * @endif
    */
-template <
-    class AbstractClass,
-    typename Identifier = std::string,
-    typename Compare = std::less<Identifier>,
-    typename Creator = AbstractClass *(*)(),
-    typename Destructor = void (*)(AbstractClass *&)>
-class GlobalFactory
-    : public Factory<AbstractClass, Identifier, Compare, Creator, Destructor>
-{
-public:
-  // A helper class to call SingletonClass-destructor.
-  struct Container
+  template <
+      class AbstractClass,
+      typename Identifier = std::string,
+      typename Compare = std::less<Identifier>,
+      typename Creator = AbstractClass *(*)(),
+      typename Destructor = void (*)(AbstractClass *&)>
+  class GlobalFactory
+      : public Factory<AbstractClass, Identifier, Compare, Creator, Destructor>
   {
-    GlobalFactory *x;
-    ~Container() { delete x; }
-  };
+  public:
+    // A helper class to call SingletonClass-destructor.
+    struct Container
+    {
+      GlobalFactory *x;
+      ~Container() { delete x; }
+    };
 
-  static GlobalFactory &instance()
-  {
-    std::call_once(m_once, [] {
-      m_instance.x = new GlobalFactory();
-    });
-    return *m_instance.x;
-  }
+    static GlobalFactory &instance()
+    {
+      std::call_once(m_once, [] {
+        m_instance.x = new GlobalFactory();
+      });
+      return *m_instance.x;
+    }
 
-private:
-  /*!
+  private:
+    /*!
      * @if jp
      *
      * @brief コンストラクタ
@@ -664,9 +701,9 @@ private:
      *
      * @endif
      */
-  GlobalFactory() = default;
+    GlobalFactory() = default;
 
-  /*!
+    /*!
      * @if jp
      *
      * @brief デストラクタ
@@ -681,34 +718,34 @@ private:
      *
      * @endif
      */
-  ~GlobalFactory() = default;
+    ~GlobalFactory() = default;
 
-  GlobalFactory(const GlobalFactory &x) = delete;
-  GlobalFactory &operator=(const GlobalFactory &x) = delete;
+    GlobalFactory(const GlobalFactory &x) = delete;
+    GlobalFactory &operator=(const GlobalFactory &x) = delete;
 
-  /*!
+    /*!
      * @if jp
      * @brief 排他制御オブジェクト
      * @else
      * @brief Mutual exclusion object
      * @endif
      */
-  static std::once_flag m_once;
-  /*!
+    static std::once_flag m_once;
+    /*!
      * @if jp
      * @brief SingletonClass オブジェクト
      * @else
      * @brief SingletonClass object
      * @endif
      */
-  static Container m_instance;
-};
-template <class AbstractClass, typename Identifier, typename Compare, typename Creator, typename Destructor>
-typename GlobalFactory<AbstractClass, Identifier, Compare, Creator, Destructor>::Container
-    GlobalFactory<AbstractClass, Identifier, Compare, Creator, Destructor>::m_instance;
+    static Container m_instance;
+  };
+  template <class AbstractClass, typename Identifier, typename Compare, typename Creator, typename Destructor>
+  typename GlobalFactory<AbstractClass, Identifier, Compare, Creator, Destructor>::Container
+      GlobalFactory<AbstractClass, Identifier, Compare, Creator, Destructor>::m_instance;
 
-template <class AbstractClass, typename Identifier, typename Compare, typename Creator, typename Destructor>
-std::once_flag GlobalFactory<AbstractClass, Identifier, Compare, Creator, Destructor>::m_once;
+  template <class AbstractClass, typename Identifier, typename Compare, typename Creator, typename Destructor>
+  std::once_flag GlobalFactory<AbstractClass, Identifier, Compare, Creator, Destructor>::m_once;
 
 } // namespace coil
 

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -242,7 +242,7 @@ namespace coil
     Properties getProperties(const Identifier &id)
     {
       std::lock_guard<std::mutex> guard(m_mutex);
-      FactoryMap::iterator it = m_creators.find(id);
+      FactoryMapIt it = m_creators.find(id);
       if (it != m_creators.end())
       {
         return m_creators[id].prop_;

--- a/src/lib/coil/common/coil/Factory.h
+++ b/src/lib/coil/common/coil/Factory.h
@@ -633,7 +633,7 @@ namespace coil
        *
        * @endif
        */
-      FactoryEntry(Identifier id, Creator creator, Destructor destructor, Properties prop= Properties())
+      FactoryEntry(Identifier id, Creator creator, Destructor destructor, Properties prop)
           : id_(std::move(id)), creator_(creator), destructor_(destructor), prop_(prop)
       {
       }

--- a/src/lib/coil/posix/coil/SharedMemory.cpp
+++ b/src/lib/coil/posix/coil/SharedMemory.cpp
@@ -157,7 +157,7 @@ namespace coil
   int SharedMemory::open(std::string shm_address, unsigned long long memory_size)
   {
     m_shm_address = std::move(shm_address);
-	m_memory_size = memory_size;
+    m_memory_size = memory_size;
 
 
     m_fd = shm_open(m_shm_address.c_str(), O_RDWR|O_CREAT, 0);
@@ -199,14 +199,14 @@ namespace coil
    */
   int SharedMemory::write(const char *data, const unsigned long long pos, const unsigned long long size)
   {
-	  if (!created())
-	  {
-		  return -1;
-	  }
+    if (!created())
+    {
+      return -1;
+    }
 
-	  memcpy(&m_shm[pos],&data[0],static_cast<size_t>(size));
+    memcpy(&m_shm[pos],&data[0],static_cast<size_t>(size));
     
-	  return 0;
+    return 0;
   }
 
   /*!
@@ -232,14 +232,14 @@ namespace coil
    */
   int SharedMemory::read(char* data, const unsigned long long pos, const unsigned long long size)
   {
-	  if (!created())
-	  {
-		  return -1;
-	  }
+    if (!created())
+    {
+      return -1;
+    }
 
-	  memcpy(&data[0],&m_shm[pos],static_cast<size_t>(size));
+    memcpy(&data[0],&m_shm[pos],static_cast<size_t>(size));
 
-	  return 0;
+    return 0;
   }
 
   /*!
@@ -266,11 +266,11 @@ namespace coil
     
     if (created())
     {
-	::close(m_fd);
+        ::close(m_fd);
     }
     else
     {
-	return -1;
+        return -1;
     }
     return 0;
 
@@ -296,7 +296,7 @@ namespace coil
    */
   unsigned long long SharedMemory::get_size()
   {
-	return m_memory_size;
+    return m_memory_size;
   }
   /*!
    * @if jp
@@ -319,7 +319,7 @@ namespace coil
    */
   std::string SharedMemory::get_addresss()
   {
-	return m_shm_address;
+    return m_shm_address;
   }
   /*!
    * @if jp
@@ -342,7 +342,7 @@ namespace coil
    */
   char *SharedMemory::get_data()
   {
-	return m_shm;
+    return m_shm;
   }
 
 
@@ -368,8 +368,8 @@ namespace coil
    */
   int SharedMemory::unlink()
   {
-	shm_unlink(m_shm_address.c_str());
-	return 0;
+     shm_unlink(m_shm_address.c_str());
+     return 0;
   }
 
 
@@ -394,7 +394,7 @@ namespace coil
   */
   bool SharedMemory::created()
   {
-	return m_fd >= 0;
+    return m_fd >= 0;
   }
 
 

--- a/src/lib/coil/posix/coil/SharedMemory.h
+++ b/src/lib/coil/posix/coil/SharedMemory.h
@@ -188,8 +188,8 @@ namespace coil
      *
      * @endif
      */
-	virtual int open(std::string shm_address,
-		unsigned long long memory_size = DEFAULT_MEMORY_SIZE);
+    virtual int open(std::string shm_address,
+                     unsigned long long memory_size = DEFAULT_MEMORY_SIZE);
 
 
     /*!
@@ -298,7 +298,7 @@ namespace coil
      *
      * @endif
      */
-	virtual std::string get_addresss();
+    virtual std::string get_addresss();
     /*!
      * @if jp
      *

--- a/src/lib/coil/vxworks/coil/Affinity.cpp
+++ b/src/lib/coil/vxworks/coil/Affinity.cpp
@@ -69,7 +69,7 @@ namespace coil
     }
     else
     {
-	return false;
+        return false;
     }
 
     STATUS result = taskCpuAffinitySet(pid, cpu_set);

--- a/src/lib/coil/vxworks/coil/DynamicLib.cpp
+++ b/src/lib/coil/vxworks/coil/DynamicLib.cpp
@@ -135,13 +135,13 @@ namespace coil
     m_fd = ::open(const_cast<char*>(dll_name), O_RDONLY, 0);
     if (!m_fd)
     {
-    	return -1;
+      return -1;
     }
     m_id = loadModule(m_fd, open_mode);
     if (!m_id)
     {
-    	::close(m_fd);
-    	return -1;
+      ::close(m_fd);
+      return -1;
     }
 #endif
     m_name = dll_name;
@@ -226,13 +226,13 @@ namespace coil
 #ifndef __RTP__
   extern "C" bool SymbolIterator(char* name, int val, SYM_TYPE type, int arg, UINT16 group)
    {
-	  SymbolObj* symbolObj = reinterpret_cast<SymbolObj*>(arg);
-   	if (group == symbolObj->group && std::strcmp(name, symbolObj->name) == 0)
-   	{
-   		symbolObj->addr = reinterpret_cast<void*>(val);
-   		return false;
-   	}
-   	else return true;
+     SymbolObj* symbolObj = reinterpret_cast<SymbolObj*>(arg);
+     if (group == symbolObj->group && std::strcmp(name, symbolObj->name) == 0)
+     {
+       symbolObj->addr = reinterpret_cast<void*>(val);
+       return false;
+     }
+     else return true;
    };
 #endif
 };

--- a/src/lib/coil/vxworks/coil/DynamicLib.h
+++ b/src/lib/coil/vxworks/coil/DynamicLib.h
@@ -304,9 +304,9 @@ namespace coil
 #ifndef __RTP__
   typedef struct
   {
-  	const char* name;
-  	int         group;
-  	void*       addr;
+    const char* name;
+    int         group;
+    void*       addr;
   }SymbolObj;
   
   extern "C" bool SymbolIterator(char* name, int val, SYM_TYPE type, int arg, UINT16 group);

--- a/src/lib/coil/vxworks/coil/SharedMemory.cpp
+++ b/src/lib/coil/vxworks/coil/SharedMemory.cpp
@@ -141,7 +141,7 @@ namespace coil
   int SharedMemory::open(std::string shm_address, unsigned long long memory_size)
   {
     m_shm_address = shm_address;
-	m_memory_size = memory_size;
+    m_memory_size = memory_size;
  
     return 0;
   }
@@ -169,14 +169,13 @@ namespace coil
    */
   int SharedMemory::write(const char *data, const unsigned long long pos, const unsigned long long size)
   {
-	  if (!created())
-	  {
-		  return -1;
-	  }
-	  memcpy(&m_shm[pos],&data[0],static_cast<size_t>(size));
+    if (!created())
+    {
+      return -1;
+    }
+    memcpy(&m_shm[pos],&data[0],static_cast<size_t>(size));
 
-    
-	  return 0;
+    return 0;
   }
 
   /*!
@@ -202,13 +201,13 @@ namespace coil
    */
   int SharedMemory::read(char* data, const unsigned long long pos, const unsigned long long size)
   {
-	  if (!created())
-	  {
-		  return -1;
-	  }
-	  memcpy(&data[0],&m_shm[pos],static_cast<size_t>(size));
+    if (!created())
+    {
+      return -1;
+    }
+    memcpy(&data[0],&m_shm[pos],static_cast<size_t>(size));
 
-	  return 0;
+    return 0;
   }
 
   /*!
@@ -239,7 +238,7 @@ namespace coil
     }
     else
     {
-	return -1;
+      return -1;
     }
     if(m_file_create)
     {
@@ -269,7 +268,7 @@ namespace coil
    */
   unsigned long long SharedMemory::get_size()
   {
-	return m_memory_size;
+    return m_memory_size;
   }
   /*!
    * @if jp
@@ -292,7 +291,7 @@ namespace coil
    */
   std::string SharedMemory::get_addresss()
   {
-	return m_shm_address;
+    return m_shm_address;
   };
   /*!
    * @if jp
@@ -315,7 +314,7 @@ namespace coil
    */
   char *SharedMemory::get_data()
   {
-	return m_shm;
+    return m_shm;
   }
 
 
@@ -341,7 +340,7 @@ namespace coil
    */
   int SharedMemory::unlink()
   {
-	return -1;
+    return -1;
   }
 
 
@@ -366,10 +365,7 @@ namespace coil
   */
   bool SharedMemory::created()
   {
-	return false;
+    return false;
   }
-
-
-
 
 }

--- a/src/lib/coil/vxworks/coil/SharedMemory.h
+++ b/src/lib/coil/vxworks/coil/SharedMemory.h
@@ -181,8 +181,8 @@ namespace coil
      *
      * @endif
      */
-	virtual int open(std::string shm_address,
-		unsigned long long memory_size = DEFAULT_MEMORY_SIZE);
+    virtual int open(std::string shm_address,
+                     unsigned long long memory_size = DEFAULT_MEMORY_SIZE);
 
 
     /*!

--- a/src/lib/coil/vxworks/coil/UUID.cpp
+++ b/src/lib/coil/vxworks/coil/UUID.cpp
@@ -44,13 +44,13 @@ namespace coil
 
   uuid_t::uuid_t()
   {
-	    time_low = 0;
-	    time_mid = 0;
-	    time_hi_version = 0;
-	    clock_seq_low = 0;
-	    clock_seq_hi_variant = 0;
-	    node_low = 0;
-	    node_high = 0;
+    time_low = 0;
+    time_mid = 0;
+    time_hi_version = 0;
+    clock_seq_low = 0;
+    clock_seq_hi_variant = 0;
+    node_low = 0;
+    node_high = 0;
   }
   UUID_Generator::UUID_Generator(){}
   
@@ -91,33 +91,33 @@ namespace coil
   }
   
   UUID::UUID(uuid_t *uuid){
-	  _uuid.time_low = uuid->time_low;
-	  _uuid.time_mid = uuid->time_mid;
-	  _uuid.time_hi_version = uuid->time_hi_version;
-	  _uuid.clock_seq_low = uuid->clock_seq_low;
-	  _uuid.clock_seq_hi_variant = uuid->clock_seq_hi_variant;
-	  
-	  _uuid.node_low = uuid->node_low;
-	  _uuid.node_high = uuid->node_high;
+    _uuid.time_low = uuid->time_low;
+    _uuid.time_mid = uuid->time_mid;
+    _uuid.time_hi_version = uuid->time_hi_version;
+    _uuid.clock_seq_low = uuid->clock_seq_low;
+    _uuid.clock_seq_hi_variant = uuid->clock_seq_hi_variant;
+  
+    _uuid.node_low = uuid->node_low;
+    _uuid.node_high = uuid->node_high;
   }
   
   const char* UUID::to_string()
   {
-	  std::string result;
-	  
-	  result = StringToUUID<uint32_t>(_uuid.time_low,8);
-	  result += "-";
-	  result += StringToUUID<uint16_t>(_uuid.time_mid,4);
-	  result += "-";
-	  result += StringToUUID<uint16_t>(_uuid.time_hi_version,4);
-	  result += "-";
-	  result += StringToUUID<uint16_t>((uint16_t)_uuid.clock_seq_low,2);
-	  result += StringToUUID<uint16_t>((uint16_t)_uuid.clock_seq_hi_variant,2);
-	  result += "-";
-	  result += StringToUUID<uint32_t>(_uuid.node_low,8);
-	  result += StringToUUID<uint16_t>(_uuid.node_high,4);
-	  
-	  return strdup(result.c_str());
+    std::string result;
+
+    result = StringToUUID<uint32_t>(_uuid.time_low,8);
+    result += "-";
+    result += StringToUUID<uint16_t>(_uuid.time_mid,4);
+    result += "-";
+    result += StringToUUID<uint16_t>(_uuid.time_hi_version,4);
+    result += "-";
+    result += StringToUUID<uint16_t>((uint16_t)_uuid.clock_seq_low,2);
+    result += StringToUUID<uint16_t>((uint16_t)_uuid.clock_seq_hi_variant,2);
+    result += "-";
+    result += StringToUUID<uint32_t>(_uuid.node_low,8);
+    result += StringToUUID<uint16_t>(_uuid.node_high,4);
+
+    return strdup(result.c_str());
   }
 
 

--- a/src/lib/coil/vxworks/coil/UUID.h
+++ b/src/lib/coil/vxworks/coil/UUID.h
@@ -49,7 +49,7 @@ namespace coil
     std::stringstream stream;
     stream << std::hex << v;
     std::string ret(stream.str());
-	
+
     if(ret.size() < size)
     {
       for(unsigned int i=ret.size();i < size;i++)

--- a/src/lib/coil/win32/coil/Affinity.cpp
+++ b/src/lib/coil/win32/coil/Affinity.cpp
@@ -36,16 +36,16 @@ namespace coil
   {
     DWORD_PTR processMask, systemMask = 0;
     HANDLE h = GetCurrentProcess();
-	BOOL success = GetProcessAffinityMask(h, static_cast<PDWORD_PTR>(&processMask), static_cast<PDWORD_PTR>(&systemMask));
-	if (success != 0)
+    BOOL success = GetProcessAffinityMask(h, static_cast<PDWORD_PTR>(&processMask), static_cast<PDWORD_PTR>(&systemMask));
+    if (success != 0)
     {
-		for (int i = 0; i < 32; i++)
-		{
-			if ((processMask & (static_cast<DWORD_PTR>(0x00000001) << i)) != 0U)
-			{
-				cpu_mask.emplace_back(i);
-			}
-		}
+      for (int i = 0; i < 32; i++)
+      {
+        if ((processMask & (static_cast<DWORD_PTR>(0x00000001) << i)) != 0U)
+        {
+          cpu_mask.emplace_back(i);
+         }
+      }
       return true;
     }
     else
@@ -59,7 +59,7 @@ namespace coil
     DWORD_PTR cpu_num = listToCUPNUM(cpu_mask);
     HANDLE h = GetCurrentProcess();
     BOOL success = SetProcessAffinityMask(h, cpu_num);
-	return success != 0;
+    return success != 0;
   }
 
   bool setProcCpuAffinity(const std::string& cpu_mask)
@@ -87,7 +87,7 @@ namespace coil
     DWORD_PTR cpu_num = listToCUPNUM(cpu_mask);
     HANDLE h = GetCurrentThread();
     DWORD_PTR success = SetThreadAffinityMask(h, cpu_num);
-	return success != 0;
+    return success != 0;
   }
 
   bool setThreadCpuAffinity(const std::string& cpu_mask)

--- a/src/lib/coil/win32/coil/SharedMemory.cpp
+++ b/src/lib/coil/win32/coil/SharedMemory.cpp
@@ -115,11 +115,11 @@ namespace coil
     DWORD lowsize = static_cast<DWORD>(m_memory_size & 0xFFFFFFFF);
     m_handle = CreateFileMapping(
         static_cast<HANDLE>(INVALID_HANDLE_VALUE),
-		nullptr,
-		PAGE_READWRITE | SEC_COMMIT,
+        nullptr,
+        PAGE_READWRITE | SEC_COMMIT,
         highsize,
         lowsize,
-		shm_address.c_str());
+        shm_address.c_str());
 
     m_shm = static_cast<char *>(MapViewOfFile(m_handle, FILE_MAP_ALL_ACCESS, 0, 0, 0));
     return 0;
@@ -150,7 +150,7 @@ namespace coil
   int SharedMemory::open(std::string shm_address, unsigned long long memory_size)
   {
     m_shm_address = std::move(shm_address);
-	m_memory_size = memory_size;
+    m_memory_size = memory_size;
     m_handle = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, m_shm_address.c_str());
     m_shm = static_cast<char *>(MapViewOfFile(m_handle, FILE_MAP_ALL_ACCESS, 0, 0, 0));
     return 0;
@@ -179,18 +179,18 @@ namespace coil
    */
   int SharedMemory::write(const char *data, const unsigned long long pos, const unsigned long long size)
   {
-	  if (!created())
-	  {
-		  return -1;
-	  }
+    if (!created())
+    {
+      return -1;
+    }
 
-      if (m_memory_size < size + pos)
-      {
-          return -1;
-      }
-      memcpy(&m_shm[pos],&data[0], static_cast<size_t>(size));
+    if (m_memory_size < size + pos)
+    {
+      return -1;
+    }
+    memcpy(&m_shm[pos],&data[0], static_cast<size_t>(size));
     
-	  return 0;
+   return 0;
   }
 
   /*!
@@ -216,13 +216,13 @@ namespace coil
    */
   int SharedMemory::read(char* data, const unsigned long long pos, const unsigned long long size)
   {
-	  if (!created())
-	  {
-		  return -1;
-	  }
+    if (!created())
+    {
+     return -1;
+    }
 
-	  memcpy(&data[0],&m_shm[pos], static_cast<size_t>(size));
-	  return 0;
+    memcpy(&data[0],&m_shm[pos], static_cast<size_t>(size));
+    return 0;
   }
 
   /*!
@@ -248,20 +248,20 @@ namespace coil
   {
     if (created())
     {
-        UnmapViewOfFile(m_shm);
+      UnmapViewOfFile(m_shm);
     }
-	else
-	{
-		return -1;
-	}
+    else
+    {
+      return -1;
+    }
     if(m_handle != nullptr)
     {
-    	if (CloseHandle(m_handle) == 0)
-    	{
-    		return -1;
-    	}
-        m_handle = nullptr;
-        return 0;
+      if (CloseHandle(m_handle) == 0)
+      {
+        return -1;
+      }
+      m_handle = nullptr;
+      return 0;
     }
     return 0;
 
@@ -287,7 +287,7 @@ namespace coil
    */
   unsigned long long SharedMemory::get_size()
   {
-	return m_memory_size;
+    return m_memory_size;
   }
   /*!
    * @if jp
@@ -310,7 +310,7 @@ namespace coil
    */
   std::string SharedMemory::get_addresss()
   {
-	return m_shm_address;
+    return m_shm_address;
   };
   /*!
    * @if jp
@@ -333,7 +333,7 @@ namespace coil
    */
   char *SharedMemory::get_data()
   {
-	return m_shm;
+    return m_shm;
   }
 
 
@@ -359,7 +359,7 @@ namespace coil
    */
   int SharedMemory::unlink()
   {
-	return -1;
+    return -1;
   }
 
 
@@ -384,10 +384,7 @@ namespace coil
   */
   bool SharedMemory::created()
   {
-	return m_handle != nullptr;
+    return m_handle != nullptr;
   }
-
-
-
 
 } // namespace coil

--- a/src/lib/coil/win32/coil/SharedMemory.h
+++ b/src/lib/coil/win32/coil/SharedMemory.h
@@ -181,7 +181,7 @@ namespace coil
      *
      * @endif
      */
-	virtual int open(std::string shm_address,
+    virtual int open(std::string shm_address,
         unsigned long long memory_size = DEFAULT_MEMORY_SIZE);
 
 
@@ -291,7 +291,7 @@ namespace coil
      *
      * @endif
      */
-	virtual std::string get_addresss();
+    virtual std::string get_addresss();
     /*!
      * @if jp
      *

--- a/src/lib/rtm/CORBA_IORUtil.cpp
+++ b/src/lib/rtm/CORBA_IORUtil.cpp
@@ -319,7 +319,7 @@ namespace CORBA_IORUtil
 #if !defined(ORB_IS_ORBEXPRESS) && !defined(ORB_IS_TAO) && !defined(ORB_IS_RTORB)
   std::vector<IIOP::Address> getEndpoints(IOP::IOR& ior)
   {
-	std::vector<IIOP::Address> addr;
+    std::vector<IIOP::Address> addr;
 #ifndef ORB_IS_RTORB
     if (ior.profiles.length() == 0 && strlen(ior.type_id) == 0)
       {

--- a/src/lib/rtm/CORBA_RTCUtil.cpp
+++ b/src/lib/rtm/CORBA_RTCUtil.cpp
@@ -124,7 +124,7 @@ namespace CORBA_RTCUtil
         eclist = rtc->get_participating_contexts();
         if (pec_id >= static_cast<CORBA::Long>(eclist->length()))
           { return RTC::ExecutionContext::_nil(); }
-		if (CORBA::is_nil(eclist[static_cast<CORBA::ULong>(pec_id)]))
+        if (CORBA::is_nil(eclist[static_cast<CORBA::ULong>(pec_id)]))
           { return RTC::ExecutionContext::_nil(); }
 #ifdef ORB_IS_TAO
         return RTC::ExecutionContext::_duplicate(eclist[(CORBA::ULong)pec_id].in());
@@ -1341,7 +1341,7 @@ namespace CORBA_RTCUtil
     SDOPackage::Configuration_var conf = rtc->get_configuration();
     SDOPackage::ConfigurationSet_var confset = conf->get_active_configuration_set();
 #ifdef ORB_IS_TAO
-	return std::string(confset->id);
+    return std::string(confset->id);
 #else
     return static_cast<char*>(confset->id);
 #endif

--- a/src/lib/rtm/ConnectorListener.cpp
+++ b/src/lib/rtm/ConnectorListener.cpp
@@ -113,7 +113,7 @@ namespace RTC
   }
 
   ConnectorDataListenerHolder::ReturnCode
-	  ConnectorDataListenerHolder::notify(ConnectorInfo& info,
+    ConnectorDataListenerHolder::notify(ConnectorInfo& info,
                                                  ByteData& cdrdata, const std::string& marshalingtype)
   {
     std::lock_guard<std::mutex> guard(m_mutex);
@@ -198,7 +198,7 @@ namespace RTC
   }
 
   ConnectorListenerHolder::ReturnCode
-	  ConnectorListenerHolder::notify(ConnectorInfo& info)
+    ConnectorListenerHolder::notify(ConnectorInfo& info)
   {
     std::lock_guard<std::mutex> guard(m_mutex);
     ConnectorListenerHolder::ReturnCode ret(NO_CHANGE);

--- a/src/lib/rtm/DefaultConfiguration.h
+++ b/src/lib/rtm/DefaultConfiguration.h
@@ -58,7 +58,7 @@ namespace RTC {
     "logger.log_level",                      "INFO",
     "logger.stream_lock",                    "NO",
     "logger.master_logger",                  "",
-	"logger.escape_sequence_enable",         "NO",
+    "logger.escape_sequence_enable",         "NO",
     "module.conf_path",                      "",
     "module.load_path",                      "",
     "naming.enable",                         "YES",

--- a/src/lib/rtm/DirectInPortBase.h
+++ b/src/lib/rtm/DirectInPortBase.h
@@ -25,110 +25,110 @@
 
 namespace RTC
 {
-	/*!
-	* @if jp
-	* @class DirectInPortBase
-	* @brief direct接続用InPort基底クラス
-	*
-	*
-	* @since 1.2.0
-	*
-	* @else
-	* @class DirectOutPortBase
-	* @brief
-	*
-	*
-	*
-	* @since 1.2.0
-	*
-	* @endif
-	*/
+  /*!
+   * @if jp
+   * @class DirectInPortBase
+   * @brief direct接続用InPort基底クラス
+   *
+   *
+   * @since 1.2.0
+   *
+   * @else
+   * @class DirectOutPortBase
+   * @brief
+   *
+   *
+   *
+   * @since 1.2.0
+   *
+   * @endif
+   */
   template <class DataType>
   class DirectInPortBase : public DirectPortBase
   {
   public:
     
-	/*!
-	* @if jp
-	* @brief デストラクタ
-	*
-	*
-	* @else
-	* @brief Destructor
-	*
-	*
-	* @endif
-	*/
-    ~DirectInPortBase() override = default;
+     /*!
+      * @if jp
+      * @brief デストラクタ
+      *
+      *
+      * @else
+      * @brief Destructor
+      *
+      *
+      * @endif
+      */
+      ~DirectInPortBase() override = default;
 
 
 
-    
-    /*!
-     * @if jp
-     *
-     * @brief 最新データが存在するか確認する
-     * 
-     * InPortに未読の最新データが到着しているかをbool値で返す。
-     * InPortが未接続の場合、および接続コネクタのバッファがEmpty
-     * の場合にはfalseを返す。
-     *
-     * @return true 未読の最新データが存在する
-     *         false 未接続またはバッファにデータが存在しない。
-     * 
-     * @else
-     *
-     * @brief Check whether the data is newest
-     * 
-     * Check whether the data stored at a current buffer position is newest.
-     *
-     * @return Newest data check result
-     *         ( true:Newest data. Data has not been readout yet.
-     *          false:Past data．Data has already been readout.)
-     * 
-     * @endif
-     */
-    virtual bool isNew() = 0;
+  
+     /*!
+      * @if jp
+      *
+      * @brief 最新データが存在するか確認する
+      * 
+      * InPortに未読の最新データが到着しているかをbool値で返す。
+      * InPortが未接続の場合、および接続コネクタのバッファがEmpty
+      * の場合にはfalseを返す。
+      *
+      * @return true 未読の最新データが存在する
+      *         false 未接続またはバッファにデータが存在しない。
+      * 
+      * @else
+      *
+      * @brief Check whether the data is newest
+      * 
+      * Check whether the data stored at a current buffer position is newest.
+      *
+      * @return Newest data check result
+      *         ( true:Newest data. Data has not been readout yet.
+      *          false:Past data．Data has already been readout.)
+      * 
+      * @endif
+      */
+     virtual bool isNew() = 0;
 
-    /*!
-     * @if jp
-     *
-     * @brief バッファが空かどうか確認する
-     * 
-     * InPortのバッファが空かどうかを bool 値で返す。
-     * 空の場合は true, 未読データがある場合は false を返す。
-     *
-     * @return true  バッファは空
-     *         false バッファに未読データがある
-     * 
-     * @else
-     *
-     * @brief Check whether the data is newest
-     * 
-     * Check whether the data stored at a current buffer position is newest.
-     *
-     * @return Newest data check result
-     *         ( true:Newest data. Data has not been readout yet.
-     *          false:Past data．Data has already been readout.)
-     * 
-     * @endif
-     */
-    virtual bool isEmpty() = 0;
+     /*!
+      * @if jp
+      *
+      * @brief バッファが空かどうか確認する
+      * 
+      * InPortのバッファが空かどうかを bool 値で返す。
+      * 空の場合は true, 未読データがある場合は false を返す。
+      *
+      * @return true  バッファは空
+      *         false バッファに未読データがある
+      * 
+      * @else
+      *
+      * @brief Check whether the data is newest
+      * 
+      * Check whether the data stored at a current buffer position is newest.
+      *
+      * @return Newest data check result
+      *         ( true:Newest data. Data has not been readout yet.
+      *          false:Past data．Data has already been readout.)
+      * 
+      * @endif
+      */
+     virtual bool isEmpty() = 0;
 
-	/*!
-	* @if jp
-	* @brief データの書き込み
-	*
-	* @param data データ
-	*
-	* @else
-	* @brief
-	*
-	* @param data
-	*
-	* @endif
-	*/
-    virtual void write(DataType& data) = 0;
+     /*!
+      * @if jp
+      * @brief データの書き込み
+      *
+      * @param data データ
+      *
+      * @else
+      * @brief
+      *
+      * @param data
+      *
+      * @endif
+      */
+     virtual void write(DataType& data) = 0;
 
 
   protected:

--- a/src/lib/rtm/DirectOutPortBase.h
+++ b/src/lib/rtm/DirectOutPortBase.h
@@ -47,60 +47,60 @@ namespace RTC
   class DirectOutPortBase : public DirectPortBase
   {
   public:
-	/*!
-	* @if jp
-	* @brief デストラクタ
-	*
-	*
-	* @else
-	* @brief Destructor
-	*
-	*
-	* @endif
-	*/
-	~DirectOutPortBase() override = default;
-	/*!
-	* @if jp
-	* @brief データの取得
-	* 
-	* @param data データを格納する変数
-	*
-	* @else
-	* @brief 
-	*
-	* @param data
-	*
-	* @endif
-	*/
-    virtual void read(DataType& data) = 0;
-	/*!
-	* @if jp
-	* @brief 新規データの存在確認
-	*
-	* @return true：新規データあり
-	*
-	* @else
-	* @brief
-	*
-	* @return
-	*
-	* @endif
-	*/
-    virtual bool isNew() = 0;
-	/*!
-	* @if jp
-	* @brief 新規データが無いことを確認
-	*
-	* @return true：新規データなし
-	*
-	* @else
-	* @brief
-	*
-	* @return
-	*
-	* @endif
-	*/
-    virtual bool isEmpty() = 0;
+     /*!
+      * @if jp
+      * @brief デストラクタ
+      *
+      *
+      * @else
+      * @brief Destructor
+      *
+      *
+      * @endif
+      */
+     ~DirectOutPortBase() override = default;
+     /*!
+      * @if jp
+      * @brief データの取得
+      * 
+      * @param data データを格納する変数
+      *
+      * @else
+      * @brief 
+      *
+      * @param data
+      *
+      * @endif
+      */
+     virtual void read(DataType& data) = 0;
+     /*!
+      * @if jp
+      * @brief 新規データの存在確認
+      *
+      * @return true：新規データあり
+      *
+      * @else
+      * @brief
+      *
+      * @return
+      *
+      * @endif
+      */
+     virtual bool isNew() = 0;
+     /*!
+      * @if jp
+      * @brief 新規データが無いことを確認
+      *
+      * @return true：新規データなし
+      *
+      * @else
+      * @brief
+      *
+      * @return
+      *
+      * @endif
+      */
+     virtual bool isEmpty() = 0;
     
   protected:
   };

--- a/src/lib/rtm/DirectPortBase.h
+++ b/src/lib/rtm/DirectPortBase.h
@@ -25,39 +25,39 @@
 
 namespace RTC
 {
-	/*!
-	* @if jp
-	* @class DirectPortBase
-	* @brief direct接続用Port基底クラス
-	*
-	*
-	* @since 1.2.0
-	*
-	* @else
-	* @class DirectPortBase
-	* @brief
-	*
-	*
-	*
-	* @since 1.2.0
-	*
-	* @endif
-	*/
+  /*!
+   * @if jp
+   * @class DirectPortBase
+   * @brief direct接続用Port基底クラス
+   *
+   *
+   * @since 1.2.0
+   *
+   * @else
+   * @class DirectPortBase
+   * @brief
+   *
+   *
+   *
+   * @since 1.2.0
+   *
+   * @endif
+   */
   class DirectPortBase
   {
   public:
-	/*!
-	* @if jp
-	* @brief デストラクタ
-	*
-	*
-	* @else
-	* @brief Destructor
-	*
-	*
-	* @endif
-	*/
-    virtual ~DirectPortBase() = default;
+     /*!
+      * @if jp
+      * @brief デストラクタ
+      *
+      *
+      * @else
+      * @brief Destructor
+      *
+      *
+      * @endif
+      */
+     virtual ~DirectPortBase() = default;
 
 
 

--- a/src/lib/rtm/Factory.cpp
+++ b/src/lib/rtm/Factory.cpp
@@ -99,8 +99,8 @@ namespace RTC
    * @endif
    */
   FactoryCXX::FactoryCXX(const coil::Properties& profile,
-			 RtcNewFunc new_func,
-			 RtcDeleteFunc delete_func,
+                         RtcNewFunc new_func,
+                         RtcDeleteFunc delete_func,
                          RTM::NumberingPolicyBase* policy)
     : FactoryBase(profile),
       m_New(new_func),

--- a/src/lib/rtm/FsmActionListener.h
+++ b/src/lib/rtm/FsmActionListener.h
@@ -266,9 +266,9 @@ namespace RTC
           "PRE_FSM_ACTION_LISTENER_NUM"
         };
       if (type < PreFsmActionListenerType::PRE_FSM_ACTION_LISTENER_NUM)
-	{
-	  return typeString[static_cast<uint8_t>(type)];
-	}
+        {
+          return typeString[static_cast<uint8_t>(type)];
+        }
       return "";
     }
 
@@ -758,9 +758,9 @@ namespace RTC
           "FSM_PROFILE_LISTENER_NUM"
         };
       if (type < FsmProfileListenerType::FSM_PROFILE_LISTENER_NUM)
-	{
-	  return typeString[static_cast<uint8_t>(type)];
-	}
+        {
+          return typeString[static_cast<uint8_t>(type)];
+        }
       return "";
     }
 
@@ -973,9 +973,9 @@ namespace RTC
           "FSM_STRUCTURE_LISTENER_NUM"
         };
       if (type < FsmStructureListenerType::FSM_STRUCTURE_LISTENER_NUM)
-	{
-	  return typeString[static_cast<uint8_t>(type)];
-	}
+       {
+         return typeString[static_cast<uint8_t>(type)];
+       }
       return "";
     }
 

--- a/src/lib/rtm/InPort.h
+++ b/src/lib/rtm/InPort.h
@@ -85,7 +85,7 @@ namespace RTC
    */
   template <class DataType>
   class InPort
-	  : public InPortBase, DirectInPortBase<DataType>
+       : public InPortBase, DirectInPortBase<DataType>
   {
   public:
     /*!

--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -723,15 +723,24 @@ namespace RTC
 
     // InPortProvider supports "push" dataflow type
     if (!provider_types.empty())
+    {
+      RTC_DEBUG(("dataflow_type push is supported"));
+      appendProperty("dataport.dataflow_type", "push");
+      coil::Properties prop_options;
+      for (auto& provider_type : provider_types)
       {
-        RTC_DEBUG(("dataflow_type push is supported"));
-        appendProperty("dataport.dataflow_type", "push");
-        for (auto & provider_type : provider_types)
-        {
-            appendProperty("dataport.interface_type",
-                        provider_type.c_str());
-        }
+        appendProperty("dataport.interface_type",
+          provider_type.c_str());
+        coil::Properties prop_if(factory.getProperties(provider_type));
+        coil::Properties& prop_node(prop_options.getNode(provider_type));
+        prop_node << prop_if;
       }
+      coil::Properties prop;
+      NVUtil::copyToProperties(prop, m_profile.properties);
+      coil::Properties& prop_dataport(prop.getNode("dataport.interface_type"));
+      prop_dataport << prop_options;
+      NVUtil::copyFromProperties(m_profile.properties, prop);
+    }
 
     m_providerTypes = provider_types;
   }
@@ -778,11 +787,20 @@ namespace RTC
       {
         RTC_PARANOID(("dataflow_type pull is supported"));
         appendProperty("dataport.dataflow_type", "pull");
+        coil::Properties prop_options;
         for (auto & consumer_type : consumer_types)
         {
             appendProperty("dataport.interface_type",
                         consumer_type.c_str());
+            coil::Properties prop_if(factory.getProperties(consumer_type));
+            coil::Properties& prop_node(prop_options.getNode(consumer_type));
+            prop_node << prop_if;
         }
+        coil::Properties prop;
+        NVUtil::copyToProperties(prop, m_profile.properties);
+        coil::Properties& prop_dataport(prop.getNode("dataport.interface_type"));
+        prop_dataport << prop_options;
+        NVUtil::copyFromProperties(m_profile.properties, prop);
       }
 
     m_consumerTypes = consumer_types;

--- a/src/lib/rtm/InPortBase.h
+++ b/src/lib/rtm/InPortBase.h
@@ -810,14 +810,14 @@ namespace RTC
     InPortConnector*
     createConnector(const ConnectorProfile& cprof, coil::Properties& prop,
                     OutPortConsumer* consumer);
-	 /*!
-	  * @if jp
-	  * @brief ローカルのピアOutPortを取得
-	  * @else
-	  * @brief Getting local peer OutPort if available
-	  * @endif
-	  */
-	OutPortBase* getLocalOutPort(const ConnectorInfo& profile);
+    /*!
+     * @if jp
+     * @brief ローカルのピアOutPortを取得
+     * @else
+     * @brief Getting local peer OutPort if available
+     * @endif
+     */
+    OutPortBase* getLocalOutPort(const ConnectorInfo& profile);
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortConnector.cpp
+++ b/src/lib/rtm/InPortConnector.cpp
@@ -33,7 +33,7 @@ namespace RTC
                                    ConnectorListenersBase* listeners,
                                    CdrBufferBase* buffer)
     : rtclog("InPortConnector"), m_profile(info),
-	m_listeners(listeners), m_buffer(buffer), m_littleEndian(true), m_outPortListeners(nullptr), m_directOutPort(nullptr), m_marshaling_type("cdr"), m_cdr(nullptr)
+      m_listeners(listeners), m_buffer(buffer), m_littleEndian(true), m_outPortListeners(nullptr), m_directOutPort(nullptr), m_marshaling_type("cdr"), m_cdr(nullptr)
   {
   }
 
@@ -157,16 +157,16 @@ namespace RTC
 
   bool InPortConnector::setOutPort(OutPortBase* directOutPort)
   {
-	  {
-		  if (directOutPort == nullptr)
-		  {
-			  return false;
-		  }
-		  m_directOutPort = directOutPort;
-		  
-		  m_outPortListeners = directOutPort->getListeners();
-		  return true;
-	  }
+    {
+      if (directOutPort == nullptr)
+      {
+        return false;
+      }
+      m_directOutPort = directOutPort;
+    
+      m_outPortListeners = directOutPort->getListeners();
+     return true;
+    }
   }
 
   BufferStatus InPortConnector::write(ByteData & /*cdr*/)

--- a/src/lib/rtm/InPortConsumer.h
+++ b/src/lib/rtm/InPortConsumer.h
@@ -143,7 +143,7 @@ namespace RTC
      *
      * @endif
      */
-	virtual DataPortStatus put(ByteData& data) = 0;
+    virtual DataPortStatus put(ByteData& data) = 0;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortCorbaCdrConsumer.cpp
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.cpp
@@ -67,7 +67,7 @@ namespace RTC
    * @endif
    */
   DataPortStatus InPortCorbaCdrConsumer::
-	  put(ByteData& data)
+     put(ByteData& data)
   {
     RTC_PARANOID(("put()"));
     CORBA::ULong len = static_cast<CORBA::ULong>(data.getDataLength());

--- a/src/lib/rtm/InPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/InPortCorbaCdrConsumer.h
@@ -153,7 +153,7 @@ namespace RTC
      *
      * @endif
      */
-	DataPortStatus put(ByteData& data) override;
+    DataPortStatus put(ByteData& data) override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortCorbaCdrUDPConsumer.cpp
+++ b/src/lib/rtm/InPortCorbaCdrUDPConsumer.cpp
@@ -189,7 +189,6 @@ namespace RTC
 
 
     CORBA::Object_var obj = orb->string_to_object(ior);
-	
 
 #ifdef ORB_IS_TAO
     TAO_Stub *stub = obj->_stubobj();

--- a/src/lib/rtm/InPortCorbaCdrUDPProvider.cpp
+++ b/src/lib/rtm/InPortCorbaCdrUDPProvider.cpp
@@ -38,7 +38,6 @@ namespace RTC
 #ifdef ORB_IS_OMNIORB
     PortableServer::ObjectId_var oid = ::RTC::Manager::instance().theShortCutPOA()->activate_object(this);
 #endif
-	
     m_objref = this->_this();
     
     // set InPort's reference
@@ -183,43 +182,43 @@ namespace RTC
   * @endif
   */
   void
-	  InPortCorbaCdrUDPProvider::convertReturn(BufferStatus status,
-		  ByteData& data)
+  InPortCorbaCdrUDPProvider::convertReturn(BufferStatus status,
+                                           ByteData& data)
   {
-	  switch (status)
-	  {
-	  case BufferStatus::OK:
-		  onBufferWrite(data);
-		  break;
+    switch (status)
+    {
+      case BufferStatus::OK:
+        onBufferWrite(data);
+         break;
 
-	  case BufferStatus::BUFFER_ERROR:
-		  onReceiverError(data);
-		  break;
+      case BufferStatus::BUFFER_ERROR:
+        onReceiverError(data);
+        break;
 
-	  case BufferStatus::FULL:
-		  onBufferFull(data);
-		  onReceiverFull(data);
-		  break;
+      case BufferStatus::FULL:
+        onBufferFull(data);
+        onReceiverFull(data);
+        break;
 
-	  case BufferStatus::EMPTY:
-		  // never come here
-		  break;
+      case BufferStatus::EMPTY:
+        // never come here
+        break;
 
-	  case BufferStatus::PRECONDITION_NOT_MET:
-		  onReceiverError(data);
-		  break;
+      case BufferStatus::PRECONDITION_NOT_MET:
+        onReceiverError(data);
+        break;
 
-	  case BufferStatus::TIMEOUT:
-		  onBufferWriteTimeout(data);
-		  onReceiverTimeout(data);
-		  break;
+      case BufferStatus::TIMEOUT:
+        onBufferWriteTimeout(data);
+        onReceiverTimeout(data);
+        break;
     case BufferStatus::NOT_SUPPORTED: /* FALLTHROUGH */
     default:
       return;
 
-	  }
+    }
 
-	  onReceiverError(data);
+    onReceiverError(data);
   }
 
 

--- a/src/lib/rtm/InPortCorbaCdrUDPProvider.h
+++ b/src/lib/rtm/InPortCorbaCdrUDPProvider.h
@@ -362,14 +362,14 @@ namespace RTC
     }
 
   private:
-	  /*!
-	  * @if jp
-	  * @brief リターンコード変換
-	  * @else
-	  * @brief Return codes conversion
-	  * @endif
-	  */
-	  void convertReturn(BufferStatus status, ByteData& data);
+    /*!
+     * @if jp
+     * @brief リターンコード変換
+     * @else
+     * @brief Return codes conversion
+     * @endif
+     */
+    void convertReturn(BufferStatus status, ByteData& data);
 
     CdrBufferBase* m_buffer;
     ::OpenRTM::InPortCdrUDP_var m_objref;

--- a/src/lib/rtm/InPortDSConsumer.cpp
+++ b/src/lib/rtm/InPortDSConsumer.cpp
@@ -65,7 +65,7 @@ namespace RTC
    * @endif
    */
   DataPortStatus InPortDSConsumer::
-	  put(ByteData& data)
+     put(ByteData& data)
   {
     RTC_PARANOID(("put()"));
 

--- a/src/lib/rtm/InPortDSConsumer.h
+++ b/src/lib/rtm/InPortDSConsumer.h
@@ -151,7 +151,7 @@ namespace RTC
      *
      * @endif
      */
-	DataPortStatus put(ByteData& data) override;
+    DataPortStatus put(ByteData& data) override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortDirectConsumer.cpp
+++ b/src/lib/rtm/InPortDirectConsumer.cpp
@@ -67,7 +67,7 @@ namespace RTC
    * @endif
    */
   DataPortStatus InPortDirectConsumer::
-	  put(ByteData&  /*data*/)
+     put(ByteData&  /*data*/)
   {
     RTC_PARANOID(("put(): never called."));
     return DataPortStatus::UNKNOWN_ERROR;

--- a/src/lib/rtm/InPortDirectConsumer.h
+++ b/src/lib/rtm/InPortDirectConsumer.h
@@ -152,7 +152,7 @@ namespace RTC
      *
      * @endif
      */
-	DataPortStatus put(ByteData& data) override;
+    DataPortStatus put(ByteData& data) override;
 
     /*!
      * @if jp

--- a/src/lib/rtm/InPortSHMConsumer.h
+++ b/src/lib/rtm/InPortSHMConsumer.h
@@ -52,8 +52,8 @@ namespace RTC
    * @endif
    */
   class InPortSHMConsumer
-	  : public InPortConsumer,
-	  public CorbaConsumer< ::OpenRTM::PortSharedMemory >
+       : public InPortConsumer,
+         public CorbaConsumer< ::OpenRTM::PortSharedMemory >
   {
   public:
     /*!
@@ -145,26 +145,26 @@ namespace RTC
      * @endif
      */
     bool setObject(CORBA::Object_ptr obj) override;
-	void publishInterfaceProfile(SDOPackage::NVList& properties) override;
-	bool subscribeInterface(const SDOPackage::NVList& properties) override;
-	void unsubscribeInterface(const SDOPackage::NVList& properties) override;
+    void publishInterfaceProfile(SDOPackage::NVList& properties) override;
+    bool subscribeInterface(const SDOPackage::NVList& properties) override;
+    void unsubscribeInterface(const SDOPackage::NVList& properties) override;
   
 private:
-	bool subscribeFromIor(const SDOPackage::NVList& properties);
-	bool subscribeFromRef(const SDOPackage::NVList& properties);
-	bool unsubscribeFromIor(const SDOPackage::NVList& properties);
-	bool unsubscribeFromRef(const SDOPackage::NVList& properties);
+    bool subscribeFromIor(const SDOPackage::NVList& properties);
+    bool subscribeFromRef(const SDOPackage::NVList& properties);
+    bool unsubscribeFromIor(const SDOPackage::NVList& properties);
+    bool unsubscribeFromRef(const SDOPackage::NVList& properties);
 
 protected:
-	static DataPortStatus convertReturnCode(OpenRTM::PortStatus ret);
+    static DataPortStatus convertReturnCode(OpenRTM::PortStatus ret);
 
-	coil::Properties m_properties;
-	std::mutex m_mutex;
-	std::string m_shm_address;
-	SharedMemoryPort m_shmem;
-	int m_memory_size{0};
-	bool m_endian{true};
-	mutable Logger rtclog{"InPortSHMConsumer"};
+   coil::Properties m_properties;
+   std::mutex m_mutex;
+   std::string m_shm_address;
+   SharedMemoryPort m_shmem;
+   int m_memory_size{0};
+   bool m_endian{true};
+   mutable Logger rtclog{"InPortSHMConsumer"};
   };
 } // namespace RTC
 

--- a/src/lib/rtm/InPortSHMProvider.cpp
+++ b/src/lib/rtm/InPortSHMProvider.cpp
@@ -97,7 +97,7 @@ namespace RTC
 
   void InPortSHMProvider::setConnector(InPortConnector* connector)
   {
-	  m_connector = connector;
+    m_connector = connector;
   }
 
 
@@ -114,31 +114,31 @@ namespace RTC
   {
     RTC_PARANOID(("InPortSHMProvider::put()"));
     if (m_connector == nullptr)
-	{
-		return ::OpenRTM::PORT_ERROR;
-	}
-	
-	bool endian_type = m_connector->isLittleEndian();
+    {
+      return ::OpenRTM::PORT_ERROR;
+    }
 
-	try
-	{
-		setEndian(endian_type);
-		read(m_cdr);
-		
-		RTC_PARANOID(("received data size: %d", m_cdr.getDataLength()));
+    bool endian_type = m_connector->isLittleEndian();
 
-		
-	}
-	catch (...)
-	{
+    try
+    {
+      setEndian(endian_type);
+      read(m_cdr);
 
-	}
-	
-	onReceived(m_cdr);
-	
+      RTC_PARANOID(("received data size: %d", m_cdr.getDataLength()));
+
+
+    }
+    catch (...)
+    {
+
+    }
+
+    onReceived(m_cdr);
+
     BufferStatus ret = m_connector->write(m_cdr);
-	
-	return convertReturn(ret, m_cdr);
+
+    return convertReturn(ret, m_cdr);
   }
 
   /*!

--- a/src/lib/rtm/InPortSHMProvider.h
+++ b/src/lib/rtm/InPortSHMProvider.h
@@ -141,24 +141,24 @@ namespace RTC
      */
     void setListener(ConnectorInfo& info,
                              ConnectorListenersBase* listeners) override;
-	/*!
-	* @if jp
-	* @brief Connectorを設定する。
-	*
-	*
-	*
-	* @param connector OutPortConnector
-	*
-	* @else
-	* @brief set Connector
-	*
-	* 
-	*
-	* @param connector OutPortConnector
-	*
-	* @endif
-	*/
-	void setConnector(InPortConnector* connector) override;
+    /*!
+     * @if jp
+     * @brief Connectorを設定する。
+     *
+     *
+     *
+     * @param connector OutPortConnector
+     *
+     * @else
+     * @brief set Connector
+     *
+     * 
+     *
+     * @param connector OutPortConnector
+     *
+     * @endif
+     */
+    void setConnector(InPortConnector* connector) override;
 
     /*!
      * @if jp
@@ -228,7 +228,7 @@ namespace RTC
 
   private:
     CdrBufferBase* m_buffer{nullptr};
-	::OpenRTM::PortSharedMemory_var  m_objref;
+    ::OpenRTM::PortSharedMemory_var  m_objref;
     ConnectorListenersBase* m_listeners;
     ConnectorInfo m_profile;
     InPortConnector* m_connector{nullptr};

--- a/src/lib/rtm/LogstreamFile.cpp
+++ b/src/lib/rtm/LogstreamFile.cpp
@@ -97,7 +97,7 @@ namespace RTC
   */
   void FileStreamBase::enableEscapeSequence()
   {
-	  m_esEnable = true;
+    m_esEnable = true;
   }
 
   /*!
@@ -117,7 +117,7 @@ namespace RTC
   */
   void FileStreamBase::disableEscapeSequence()
   {
-	  m_esEnable = false;
+    m_esEnable = false;
   }
 
 

--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -1716,141 +1716,141 @@ namespace RTC
     bool initFactories();
 
     void initCpuAffinity();
-	/*!
-	 * @if jp
-	 * @brief 起動時にrtc.confで指定したポートを接続する
-	 *
-	 * 例:
-	 * manager.components.preconnect: RTC0.port0?port=RTC0.port1&interface_type=corba_cdr&dataflow_type=pull&~,~
-	 *
-	 *
-	 * @else
-	 * @brief 
-	 *
-	 *
-	 * @endif
-	 */
-	void initPreConnection();
-	/*!
-	 * @if jp
-	 * @brief 起動時にrtc.confで指定したRTCをアクティベーションする
-	 *
-	 * 例:
-	 * manager.components.preactivation: RTC1,RTC2~
-	 *
-	 *
-	 * @else
-	 * @brief
-	 *
-	 *
-	 * @endif
-	 */
-	void initPreActivation();
-	/*!
-	 * @if jp
-	 * @brief 起動時にrtc.confで指定したRTCを生成する
-	 *
-	 * 例:
-	 * manager.components.precreate RTC1,RTC2~
-	 *
-	 *
-	 * @else
-	 * @brief
-	 *
-	 *
-	 * @endif
-	 */
-	void initPreCreation();
-	/*!
-	* @if jp
-	* @brief 
-	*
-	*
-	*
-	* @else
-	* @brief
-	*
-	*
-	* @endif
-	*/
-	void invokeInitProc();
-	/*!
-	* @if jp
-	* @brief
-	* @param comp
-	*
-	*
-	*
-	* @else
-	* @brief
-	* @param comp
-	*
-	*
-	* @endif
-	*/
-	void publishPorts(RTObject_impl* comp);
-	/*!
-	* @if jp
-	* @brief
-	* @param comp
-	*
-	*
-	*
-	* @else
-	* @brief
-	* @param comp
-	*
-	*
-	* @endif
-	*/
-	void subscribePorts(RTObject_impl* comp);
-	/*!
-	* @if jp
-	* @brief
-	* @param comp
-	*
-	*
-	*
-	* @else
-	* @brief
-	* @param comp
-	*
-	*
-	* @endif
-	*/
-	PortServiceList* getPortsOnNameServers(const std::string& nsname, const std::string& kind);
-	/*!
-	* @if jp
-	* @brief
-	* @param port
-	* @param target_ports
-	*
-	*
-	* @else
-	* @brief
-	* @param port
-	* @param target_ports
-	*
-	*
-	* @endif
-	*/
-	void connectDataPorts(PortService_ptr port, PortServiceList_var& target_ports);
-	/*!
-	* @if jp
-	* @brief
-	* @param port
-	* @param target_ports
-	*
-	*
-	* @else
-	* @brief
-	* @param port
-	* @param target_ports
-	*
-	*
-	* @endif
-	*/
-	void connectServicePorts(PortService_ptr port, PortServiceList_var& target_ports);
+    /*!
+     * @if jp
+     * @brief 起動時にrtc.confで指定したポートを接続する
+     *
+     * 例:
+     * manager.components.preconnect: RTC0.port0?port=RTC0.port1&interface_type=corba_cdr&dataflow_type=pull&~,~
+     *
+     *
+     * @else
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    void initPreConnection();
+    /*!
+     * @if jp
+     * @brief 起動時にrtc.confで指定したRTCをアクティベーションする
+     *
+     * 例:
+     * manager.components.preactivation: RTC1,RTC2~
+     *
+     *
+     * @else
+     * @brief
+     *
+     *
+     * @endif
+     */
+    void initPreActivation();
+    /*!
+     * @if jp
+     * @brief 起動時にrtc.confで指定したRTCを生成する
+     *
+     * 例:
+     * manager.components.precreate RTC1,RTC2~
+     *
+     *
+     * @else
+     * @brief
+     *
+     *
+     * @endif
+     */
+    void initPreCreation();
+    /*!
+     * @if jp
+     * @brief 
+     *
+     *
+     *
+     * @else
+     * @brief
+     *
+     *
+     * @endif
+     */
+    void invokeInitProc();
+    /*!
+     * @if jp
+     * @brief
+     * @param comp
+     *
+     *
+     *
+     * @else
+     * @brief
+     * @param comp
+     *
+     *
+     * @endif
+     */
+    void publishPorts(RTObject_impl* comp);
+    /*!
+     * @if jp
+     * @brief
+     * @param comp
+     *
+     *
+     *
+     * @else
+     * @brief
+     * @param comp
+     *
+     *
+     * @endif
+     */
+    void subscribePorts(RTObject_impl* comp);
+    /*!
+     * @if jp
+     * @brief
+     * @param comp
+     *
+     *
+     *
+     * @else
+     * @brief
+     * @param comp
+     *
+     *
+     * @endif
+     */
+    PortServiceList* getPortsOnNameServers(const std::string& nsname, const std::string& kind);
+    /*!
+     * @if jp
+     * @brief
+     * @param port
+     * @param target_ports
+     *
+     *
+     * @else
+     * @brief
+     * @param port
+     * @param target_ports
+     *
+     *
+     * @endif
+     */
+    void connectDataPorts(PortService_ptr port, PortServiceList_var& target_ports);
+    /*!
+     * @if jp
+     * @brief
+     * @param port
+     * @param target_ports
+     *
+     *
+     * @else
+     * @brief
+     * @param port
+     * @param target_ports
+     *
+     *
+     * @endif
+     */
+    void connectServicePorts(PortService_ptr port, PortServiceList_var& target_ports);
 
     /*!
      * @if jp

--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -138,7 +138,7 @@ namespace RTC
    */
   void ManagerConfig::parseArgs(int argc, char** argv)
   {
-	bool ignoreNoConf(false);
+    bool ignoreNoConf(false);
     coil::GetOpt get_opts(argc, argv, "af:io:p:d", 0);
     int opt;
 

--- a/src/lib/rtm/ManagerServant.h
+++ b/src/lib/rtm/ManagerServant.h
@@ -690,21 +690,21 @@ namespace RTM
     RTC::RTObject_ptr
     createComponentByAddress(const std::string& create_arg);
 
-	/*
-	* @if jp
-	* @brief マスターマネージャの有無を確認してリストを更新する
-	*
-	*
-	*
-	* @else
-	* @brief 
-	*
-	*
-	* @endif
-	*/
-	void updateMasterManager();
-	std::string getParameterByModulename(const std::string& param_name, std::string &module_name);
-	static bool isProcessIDManager(const std::string& mgrname);
+    /*
+     * @if jp
+     * @brief マスターマネージャの有無を確認してリストを更新する
+     *
+     *
+     *
+     * @else
+     * @brief 
+     *
+     *
+     * @endif
+     */
+    void updateMasterManager();
+    std::string getParameterByModulename(const std::string& param_name, std::string &module_name);
+    static bool isProcessIDManager(const std::string& mgrname);
 
   private:
     /*!
@@ -813,24 +813,23 @@ namespace RTM
   class CompParam
   {
   public:
-	  CompParam(std::string module_name);
-	  ~CompParam();
-	  static const unsigned int prof_list_size = 6;
-	  static const char* prof_list[prof_list_size];
-	  std::string vendor();
-	  std::string category();
-	  std::string impl_id();
-	  std::string language();
-	  std::string version();
+    CompParam(std::string module_name);
+    ~CompParam();
+    static const unsigned int prof_list_size = 6;
+    static const char* prof_list[prof_list_size];
+    std::string vendor();
+    std::string category();
+    std::string impl_id();
+    std::string language();
+    std::string version();
   private:
-	  std::string m_type;
-	  std::string m_vendor;
-	  std::string m_category;
-	  std::string m_impl_id;
-	  std::string m_language;
-	  std::string m_version;
-
-	  
+    std::string m_type;
+    std::string m_vendor;
+    std::string m_category;
+    std::string m_impl_id;
+    std::string m_language;
+    std::string m_version;
+  
   };
 
 } // namespace RTM

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -771,7 +771,7 @@ namespace RTC
     };
 
     vProperties m_modprofs;
-	std::map<std::string, coil::vstring> m_loadfailmods;
+    std::map<std::string, coil::vstring> m_loadfailmods;
 
   };   // class ModuleManager
 } // namespace RTC

--- a/src/lib/rtm/NamingManager.cpp
+++ b/src/lib/rtm/NamingManager.cpp
@@ -336,7 +336,7 @@ namespace RTC
   * @endif
   */
   NamingOnManager::NamingOnManager(CORBA::ORB_ptr orb, Manager* mgr)
-	  : m_orb(orb), m_mgr(mgr)
+    : m_orb(orb), m_mgr(mgr)
   {
   }
   /*!
@@ -347,24 +347,24 @@ namespace RTC
   * @endif
   */
   void NamingOnManager::bindObject(const char* name,
-	  const RTObject_impl*  /*rtobj*/)
+    const RTObject_impl*  /*rtobj*/)
   {
-	  RTC_TRACE(("bindObject(name = %s, rtobj)", name));
-	  return;
+    RTC_TRACE(("bindObject(name = %s, rtobj)", name));
+    return;
   }
 
   void NamingOnManager::bindObject(const char* name,
-	  const PortBase*  /*port*/)
+    const PortBase*  /*port*/)
   {
-	  RTC_TRACE(("bindObject(name = %s, port)", name));
-	  return;
+    RTC_TRACE(("bindObject(name = %s, port)", name));
+    return;
   }
 
   void NamingOnManager::bindObject(const char* name,
-	  const RTM::ManagerServant*  /*mgr*/)
+    const RTM::ManagerServant*  /*mgr*/)
   {
-	  RTC_TRACE(("bindObject(name = %s, mgr)", name));
-	  return;
+    RTC_TRACE(("bindObject(name = %s, mgr)", name));
+    return;
   }
 
   /*!
@@ -376,14 +376,14 @@ namespace RTC
   */
   void NamingOnManager::unbindObject(const char* name)
   {
-	  RTC_TRACE(("unbindObject(name  = %s)", name));
-	  return;
+    RTC_TRACE(("unbindObject(name  = %s)", name));
+    return;
   }
 
   bool NamingOnManager::isAlive()
   {
-	  RTC_TRACE(("isAlive()"));
-	  return true;
+    RTC_TRACE(("isAlive()"));
+    return true;
   }
 
   /*!
@@ -406,46 +406,45 @@ namespace RTC
    */
   RTC::RTCList NamingOnManager::string_to_component(std::string name)
   {
-	  RTC::RTCList rtc_list;
-	  coil::vstring tmp = coil::split(name, "://");
-	  if (tmp.size() > 1)
-	  {
-		  if (tmp[0] == "rtcloc")
-		  {
-			  std::string url = tmp[1];
-			  coil::vstring r = coil::split(url, "/");
+    RTC::RTCList rtc_list;
+    coil::vstring tmp = coil::split(name, "://");
+    if (tmp.size() > 1)
+    {
+      if (tmp[0] == "rtcloc")
+      {
+        std::string url = tmp[1];
+        coil::vstring r = coil::split(url, "/");
 
-			  if (r.size() > 1)
-			  {
-				  std::string host = r[0];
-				  std::string rtc_name = url.substr(host.size()+1, url.size() - host.size());
+        if (r.size() > 1)
+        {
+          std::string host = r[0];
+          std::string rtc_name = url.substr(host.size()+1, url.size() - host.size());
 
-				  RTM::Manager_var mgr = getManager(host);
-				  
-				  if (!CORBA::is_nil(mgr))
-				  {
-					 
-					  rtc_list = (*mgr->get_components_by_name(rtc_name.c_str()));
-					  RTM::ManagerList* slaves = mgr->get_slave_managers();
-					  for (unsigned int i = 0; i < slaves->length(); i++)
-					  {
-						  
-						  try
-						  {
-							  RTC::RTCList slave_rtcs = (*(*slaves)[i]->get_components_by_name(rtc_name.c_str()));
-							  CORBA_SeqUtil::push_back_list(rtc_list, slave_rtcs);
-						  }
-						  catch (...)
-						  {
-							  mgr->remove_slave_manager((*slaves)[i]);
-						  }
-					  }
-				  }
-				  return rtc_list;
-			  }
-		  }
-	  }
-	  return rtc_list;
+          RTM::Manager_var mgr = getManager(host);
+
+          if (!CORBA::is_nil(mgr))
+          {
+
+            rtc_list = (*mgr->get_components_by_name(rtc_name.c_str()));
+            RTM::ManagerList* slaves = mgr->get_slave_managers();
+            for (unsigned int i = 0; i < slaves->length(); i++)
+            {
+              try
+              {
+                RTC::RTCList slave_rtcs = (*(*slaves)[i]->get_components_by_name(rtc_name.c_str()));
+                CORBA_SeqUtil::push_back_list(rtc_list, slave_rtcs);
+              }
+              catch (...)
+              {
+                mgr->remove_slave_manager((*slaves)[i]);
+              }
+            }
+          }
+          return rtc_list;
+        }
+      }
+    }
+    return rtc_list;
   }
 
 
@@ -821,13 +820,13 @@ namespace RTC
             return nullptr;
           }
       }
-	else if (m == "manager")
-	{
-		NamingBase* name;
-		CORBA::ORB_var orb = m_manager->getORB();
-		name = new NamingOnManager(orb.in(), m_manager);
-		return name;
-	}
+    else if (m == "manager")
+      {
+        NamingBase* name;
+        CORBA::ORB_var orb = m_manager->getORB();
+        name = new NamingOnManager(orb.in(), m_manager);
+        return name;
+      }
     return nullptr;
   }
 
@@ -995,18 +994,17 @@ namespace RTC
    */
   RTCList NamingManager::string_to_component(const std::string& name)
   {
-	  
-	  for (auto & n : m_names) {
-		  if (n->ns != nullptr)
-		  {
-			  RTCList comps = n->ns->string_to_component(name);
-			  if (comps.length() > 0)
-			  {
-				  return comps;
-			  }
-		  }
-	  }
-	  
-	  return RTCList();
+   
+    for (auto & n : m_names) {
+    if (n->ns != nullptr)
+    {
+      RTCList comps = n->ns->string_to_component(name);
+      if (comps.length() > 0)
+      {
+        return comps;
+      }
+    }
+   }  
+   return RTCList();
   }
 } // namespace RTC

--- a/src/lib/rtm/NamingManager.h
+++ b/src/lib/rtm/NamingManager.h
@@ -170,24 +170,24 @@ namespace RTC
      * @endif
      */
     virtual bool isAlive() = 0;
-	/*!
-	* @if jp
-	*
-	* @brief rtcloc形式でRTCのオブジェクトリファレンスを取得する
-	*
-	* @param name RTC名
-	* @return RTCのオブジェクトリファレンスのリスト
-	*
-	* @else
-	*
-	* @brief
-	*
-	* @param name
-	* @return
-	*
-	* @endif
-	*/
-	virtual RTC::RTCList string_to_component(std::string name) = 0;
+    /*!
+     * @if jp
+     *
+     * @brief rtcloc形式でRTCのオブジェクトリファレンスを取得する
+     *
+     * @param name RTC名
+     * @return RTCのオブジェクトリファレンスのリスト
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param name
+     * @return
+     *
+     * @endif
+     */
+    virtual RTC::RTCList string_to_component(std::string name) = 0;
   };
 
   /*!
@@ -365,45 +365,45 @@ namespace RTC
      * @endif
      */
     bool isAlive() override;
-	/*!
-	 * @if jp
-	 *
-	 * @brief ネーミングサービスからRTCをインスタンス名から検索し、
-	 *        一致するRTCのリストを取得する
-	 *
-	 * @param context 現在検索中のコンテキスト
-	 * @param name RTCのインスタンス名
-	 * @param rtcs RTCのリスト
-	 *
-	 * @else
-	 *
-	 * @brief 
-	 *
-	 * @param context
-	 * @param name 
-	 * @param rtcs 
-	 *
-	 * @endif
-	 */
-	void getComponentByName(CosNaming::NamingContext_ptr context, const std::string& name, RTC::RTCList& rtcs);
-	/*!
-	* @if jp
-	*
-	* @brief rtcname形式でRTCのオブジェクトリファレンスを取得する
-	*
-	* @param name RTC名
-	* @return RTCのオブジェクトリファレンスのリスト
-	*
-	* @else
-	*
-	* @brief 
-	*
-	* @param name 
-	* @return 
-	*
-	* @endif
-	*/
-	RTC::RTCList string_to_component(std::string name) override;
+    /*!
+     * @if jp
+     *
+     * @brief ネーミングサービスからRTCをインスタンス名から検索し、
+     *        一致するRTCのリストを取得する
+     *
+     * @param context 現在検索中のコンテキスト
+     * @param name RTCのインスタンス名
+     * @param rtcs RTCのリスト
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param context
+     * @param name 
+     * @param rtcs 
+     *
+     * @endif
+     */
+    void getComponentByName(CosNaming::NamingContext_ptr context, const std::string& name, RTC::RTCList& rtcs);
+    /*!
+     * @if jp
+     *
+     * @brief rtcname形式でRTCのオブジェクトリファレンスを取得する
+     *
+     * @param name RTC名
+     * @return RTCのオブジェクトリファレンスのリスト
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param name 
+     * @return 
+     *
+     * @endif
+     */
+    RTC::RTCList string_to_component(std::string name) override;
     CorbaNaming& getCorbaNaming() { return m_cosnaming; }
 
   private:
@@ -457,7 +457,7 @@ namespace RTC
      *
      * @endif
      */
-	 NamingOnManager(CORBA::ORB_ptr orb, Manager* mgr);
+    NamingOnManager(CORBA::ORB_ptr orb, Manager* mgr);
     
     /*!
      * @if jp
@@ -470,7 +470,7 @@ namespace RTC
      *
      * @endif
      */
-	 ~NamingOnManager() override = default;
+    ~NamingOnManager() override = default;
     
     /*!
      * @if jp
@@ -554,49 +554,49 @@ namespace RTC
      * @endif
      */
     bool isAlive() override;
-	/*!
-	* @if jp
-	*
-	* @brief rtcname形式でRTCのオブジェクトリファレンスを取得する
-	*
-	* @param name rtcloc形式でのRTC名
-	* rtcloc://localhost:2809/example/ConsoleIn
-	* @return RTCのオブジェクトリファレンスのリスト
-	*
-	* @else
-	*
-	* @brief 
-	*
-	* @param name 
-	* @return 
-	*
-	* @endif
-	*/
-	RTC::RTCList string_to_component(std::string name) override;
-	/*!
-	* @if jp
-	*
-	* @brief 指定ホスト名、ポート名でManagerのオブジェクトリファレンスを取得
-	*
-	* @param name ホスト名、ポート名
-	* 
-	* @return Managerのオブジェクトリファレンス
-	*
-	* @else
-	*
-	* @brief
-	*
-	* @param name
-	* @return
-	*
-	* @endif
-	*/
-	RTM::Manager_ptr getManager(const std::string& name);
+    /*!
+     * @if jp
+     *
+     * @brief rtcname形式でRTCのオブジェクトリファレンスを取得する
+     *
+     * @param name rtcloc形式でのRTC名
+     * rtcloc://localhost:2809/example/ConsoleIn
+     * @return RTCのオブジェクトリファレンスのリスト
+     *
+     * @else
+     *
+     * @brief 
+     *
+     * @param name 
+     * @return 
+     *
+     * @endif
+     */
+    RTC::RTCList string_to_component(std::string name) override;
+    /*!
+     * @if jp
+     *
+     * @brief 指定ホスト名、ポート名でManagerのオブジェクトリファレンスを取得
+     *
+     * @param name ホスト名、ポート名
+     * 
+     * @return Managerのオブジェクトリファレンス
+     *
+     * @else
+     *
+     * @brief
+     *
+     * @param name
+     * @return
+     *
+     * @endif
+     */
+    RTM::Manager_ptr getManager(const std::string& name);
 
   private:
     Logger rtclog;
-	CORBA::ORB_ptr m_orb;
-	Manager* m_mgr;
+    CORBA::ORB_ptr m_orb;
+    Manager* m_mgr;
   };
   
   /*!
@@ -812,29 +812,29 @@ namespace RTC
     std::vector<RTObject_impl*> getObjects();
     std::vector<NamingService*>& getNameServices() { return m_names; }
 
-	/*!
-	* @if jp
-	*
-	* @brief rtcloc形式でRTCのオブジェクトリファレンスを取得
-	*
-	*
-	*
-	* @param name rtcloc形式でのRTC名
-	* rtcloc://localhost:2809/example/ConsoleIn
-	* @return RTCのオブジェクトリファレンスのリスト
-	*
-	* @else
-	*
-	* @brief
-	* registerMgrName
-	* @param name
-	*
-	* @return
-	*
-	*
-	* @endif
-	*/
-	RTCList string_to_component(const std::string& name);
+    /*!
+     * @if jp
+     *
+     * @brief rtcloc形式でRTCのオブジェクトリファレンスを取得
+     *
+     *
+     *
+     * @param name rtcloc形式でのRTC名
+     * rtcloc://localhost:2809/example/ConsoleIn
+     * @return RTCのオブジェクトリファレンスのリスト
+     *
+     * @else
+     *
+     * @brief
+     * registerMgrName
+     * @param name
+     *
+     * @return
+     *
+     *
+     * @endif
+     */
+    RTCList string_to_component(const std::string& name);
     
   protected:
     /*!

--- a/src/lib/rtm/NamingServiceNumberingPolicy.cpp
+++ b/src/lib/rtm/NamingServiceNumberingPolicy.cpp
@@ -27,7 +27,7 @@ namespace RTM
   //============================================================
   NamingServiceNumberingPolicy::NamingServiceNumberingPolicy()
     {
-	  m_mgr = &RTC::Manager::instance();
+      m_mgr = &RTC::Manager::instance();
     }
   /*!
    * @if jp
@@ -38,25 +38,24 @@ namespace RTM
    */
   std::string NamingServiceNumberingPolicy::onCreate(void* obj)
     {
-	  int num = 0;
-	  while (true)
-	  {
-		  std::string num_str = coil::otos<int>(num);
-		  RTC::RTObject_impl *rtobj = static_cast<RTC::RTObject_impl *>(obj);
+      int num = 0;
+      while (true)
+        {
+          std::string num_str = coil::otos<int>(num);
+          RTC::RTObject_impl *rtobj = static_cast<RTC::RTObject_impl *>(obj);
 
+          std::string name = rtobj->getTypeName() + num_str;
 
-		  std::string name = rtobj->getTypeName() + num_str;
-
-		  if (!find(name))
-		  {
-			  return num_str;
-		  }
-		  else
-		  {
-			  num++;
-		  }
-	  }
-	  return  coil::otos<int>(num);
+          if (!find(name))
+            {
+              return num_str;
+            }
+          else
+            {
+                  num++;
+            }
+        }
+      return  coil::otos<int>(num);
     }
   
   /*!
@@ -70,38 +69,38 @@ namespace RTM
     {
     }
   
-	/*!
-	* @if jp
-	*
-	* @brief オブジェクトの検索
-	*
-	* 指定名のインスタンス名のRTCを検索し、
-	* 　　　　一致するRTCが存在する場合はTrueを返す
-	*
-	* @param name 検索対象オブジェクトの名前
-	*
-	* @return 判定
-	*
-	* @else
-	*
-	* @brief
-	*
-	*
-	* @param name
-	*
-	* @return
-	*
-	* @endif
-	*/
+  /*!
+   * @if jp
+   *
+   * @brief オブジェクトの検索
+   *
+   * 指定名のインスタンス名のRTCを検索し、
+   * 　　　　一致するRTCが存在する場合はTrueを返す
+   *
+   * @param name 検索対象オブジェクトの名前
+   *
+   * @return 判定
+   *
+   * @else
+   *
+   * @brief
+   *
+   *
+   * @param name
+   *
+   * @return
+   *
+   * @endif
+   */
   bool NamingServiceNumberingPolicy::find(std::string name)
     {
-	  RTC::RTCList rtcs;
-	  std::string rtc_name = "rtcname://*/*/";
-	  rtc_name += name;
+      RTC::RTCList rtcs;
+      std::string rtc_name = "rtcname://*/*/";
+      rtc_name += name;
 
-	  rtcs = m_mgr->getNaming()->string_to_component(rtc_name);
+      rtcs = m_mgr->getNaming()->string_to_component(rtc_name);
 
-	  return rtcs.length() > 0;
+      return rtcs.length() > 0;
     }
 } //namespace RTM 
 
@@ -112,9 +111,9 @@ extern "C"
     ::RTM::NumberingPolicyFactory::
       instance().addFactory("ns_unique",
                             ::coil::Creator< ::RTM::NumberingPolicyBase,
-							::RTM::NamingServiceNumberingPolicy>,
+                                                      ::RTM::NamingServiceNumberingPolicy>,
                             ::coil::Destructor< ::RTM::NumberingPolicyBase,
-							::RTM::NamingServiceNumberingPolicy>);
+                                                      ::RTM::NamingServiceNumberingPolicy>);
     }
 }
 

--- a/src/lib/rtm/NamingServiceNumberingPolicy.h
+++ b/src/lib/rtm/NamingServiceNumberingPolicy.h
@@ -46,7 +46,7 @@ namespace RTM
    *
    * @endif
    */
-	class NamingServiceNumberingPolicy
+  class NamingServiceNumberingPolicy
     : public NumberingPolicyBase
   {
   public:
@@ -65,7 +65,7 @@ namespace RTM
      *
      * @endif
      */
-	  NamingServiceNumberingPolicy();
+    NamingServiceNumberingPolicy();
     
     /*!
      * @if jp
@@ -78,7 +78,7 @@ namespace RTM
      *
      * @endif
      */
-	  ~NamingServiceNumberingPolicy() override = default;
+    ~NamingServiceNumberingPolicy() override = default;
     
     /*!
      * @if jp
@@ -133,34 +133,34 @@ namespace RTM
 
     
   protected:
-	  /*!
-	  * @if jp
-	  *
-	  * @brief オブジェクトの検索
-	  *
-	  * 指定名のインスタンス名のRTCを検索し、
-	  * 　　　　一致するRTCが存在する場合はTrueを返す
-	  *
-	  * @param name 検索対象オブジェクトの名前
-	  *
-	  * @return 判定
-	  *
-	  * @else
-	  *
-	  * @brief
-	  *
-	  *
-	  * @param name
-	  *
-	  * @return
-	  *
-	  * @endif
-	  */
-	  virtual bool find(std::string name);
+    /*!
+     * @if jp
+     *
+     * @brief オブジェクトの検索
+     *
+     * 指定名のインスタンス名のRTCを検索し、
+     * 　　　　一致するRTCが存在する場合はTrueを返す
+     *
+     * @param name 検索対象オブジェクトの名前
+     *
+     * @return 判定
+     *
+     * @else
+     *
+     * @brief
+     *
+     *
+     * @param name
+     *
+     * @return
+     *
+     * @endif
+     */
+    virtual bool find(std::string name);
     
   private:
     std::vector<void*> m_objects;
-	RTC::Manager *m_mgr;
+    RTC::Manager *m_mgr;
   };
 } // namespace RTM
 

--- a/src/lib/rtm/NodeNumberingPolicy.cpp
+++ b/src/lib/rtm/NodeNumberingPolicy.cpp
@@ -25,10 +25,10 @@ namespace RTM
   //============================================================
   // NodeNumberingPolicy
   //============================================================
-	NodeNumberingPolicy::NodeNumberingPolicy()
-	{
-		m_mgr = &RTC::Manager::instance();
-	}
+  NodeNumberingPolicy::NodeNumberingPolicy()
+    {
+      m_mgr = &RTC::Manager::instance();
+    }
   /*!
    * @if jp
    * @brief オブジェクト生成時の名称作成
@@ -36,28 +36,27 @@ namespace RTM
    * @brief Create the name when creating objects
    * @endif
    */
-	std::string NodeNumberingPolicy::onCreate(void* obj)
-  {
-	  int num = 0;
-	  while (true)
-	  {
-		  std::string num_str = coil::otos<int>(num);
-		  RTC::RTObject_impl *rtobj = static_cast<RTC::RTObject_impl *>(obj);
+  std::string NodeNumberingPolicy::onCreate(void* obj)
+    {
+      int num = 0;
+      while (true)
+        {
+          std::string num_str = coil::otos<int>(num);
+          RTC::RTObject_impl *rtobj = static_cast<RTC::RTObject_impl *>(obj);
 
+          std::string name = rtobj->getTypeName() + num_str;
 
-		  std::string name = rtobj->getTypeName() + num_str;
-
-		  if (!find(name))
-		  {
-			  return num_str;
-		  }
-		  else
-		  {
-			  num++;
-		  }
-	  }
-	  return  coil::otos<int>(num);
-  }
+          if (!find(name))
+            {
+              return num_str;
+            }
+          else
+            {
+              num++;
+            }
+        }
+      return  coil::otos<int>(num);
+    }
   
   /*!
    * @if jp
@@ -66,57 +65,57 @@ namespace RTM
    * @brief Delete the name when deleting objects
    * @endif
    */
-	void NodeNumberingPolicy::onDelete(void* /*obj*/)
-  {
-  }
+  void NodeNumberingPolicy::onDelete(void* /*obj*/)
+    {
+    }
   
-	/*!
-	* @if jp
-	*
-	* @brief オブジェクトの検索
-	*
-	* マスターマネージャ、およびスレーブマネージャに登録されたRTCを検索し、
-	* 　　　　名前が一致するRTCが存在する場合はTrueを返す
-	* このプロセスで起動したマネージャがマスターマネージャではなく、
-	*  さらにマスターマネージャが1つも登録されていない場合はこのプロセスのマネージャから検索
-	*
-	* @param name 検索対象オブジェクトの名前
-	*
-	* @return 判定
-	*
-	* @else
-	*
-	* @brief
-	*
-	*
-	* @param name
-	*
-	* @return
-	*
-	* @endif
-	*/
-	bool NodeNumberingPolicy::find(std::string name)
-	{
-		RTC::RTCList rtcs;
-		std::string rtc_name = "rtcloc://*/*/";
-		rtc_name += name;
+  /*!
+  * @if jp
+  *
+  * @brief オブジェクトの検索
+  *
+  * マスターマネージャ、およびスレーブマネージャに登録されたRTCを検索し、
+  * 　　　　名前が一致するRTCが存在する場合はTrueを返す
+  * このプロセスで起動したマネージャがマスターマネージャではなく、
+  *  さらにマスターマネージャが1つも登録されていない場合はこのプロセスのマネージャから検索
+  *
+  * @param name 検索対象オブジェクトの名前
+  *
+  * @return 判定
+  *
+  * @else
+  *
+  * @brief
+  *
+  *
+  * @param name
+  *
+  * @return
+  *
+  * @endif
+  */
+  bool NodeNumberingPolicy::find(std::string name)
+    {
+      RTC::RTCList rtcs;
+      std::string rtc_name = "rtcloc://*/*/";
+      rtc_name += name;
 
-		rtcs = m_mgr->getNaming()->string_to_component(rtc_name);
+      rtcs = m_mgr->getNaming()->string_to_component(rtc_name);
 
-		return rtcs.length() > 0;
-	}
+      return rtcs.length() > 0;
+    }
 } //namespace RTM 
 
 extern "C"
 {
-	void NodeNumberingPolicyInit()
+  void NodeNumberingPolicyInit()
   {
     ::RTM::NumberingPolicyFactory::
       instance().addFactory("node_unique",
                             ::coil::Creator< ::RTM::NumberingPolicyBase,
-							::RTM::NodeNumberingPolicy>,
+                                              ::RTM::NodeNumberingPolicy>,
                             ::coil::Destructor< ::RTM::NumberingPolicyBase,
-							::RTM::NodeNumberingPolicy>);
+                                              ::RTM::NodeNumberingPolicy>);
   }
 }
 

--- a/src/lib/rtm/NodeNumberingPolicy.h
+++ b/src/lib/rtm/NodeNumberingPolicy.h
@@ -47,7 +47,7 @@ namespace RTM
    *
    * @endif
    */
-	class NodeNumberingPolicy
+  class NodeNumberingPolicy
     : public NumberingPolicyBase
   {
   public:
@@ -66,7 +66,7 @@ namespace RTM
      *
      * @endif
      */
-	  NodeNumberingPolicy();
+    NodeNumberingPolicy();
     
     /*!
      * @if jp
@@ -79,7 +79,7 @@ namespace RTM
      *
      * @endif
      */
-	  ~NodeNumberingPolicy() override = default;
+    ~NodeNumberingPolicy() override = default;
     
     /*!
      * @if jp
@@ -132,36 +132,36 @@ namespace RTM
     void onDelete(void* obj) override;
     
   protected:
-	  /*!
-	  * @if jp
-	  *
-	  * @brief オブジェクトの検索
-	  *
-	  * マスターマネージャ、およびスレーブマネージャに登録されたRTCを検索し、
-	  * 　　　　名前が一致するRTCが存在する場合はTrueを返す
-	  * このプロセスで起動したマネージャがマスターマネージャではなく、
-	  *  さらにマスターマネージャが1つも登録されていない場合はこのプロセスのマネージャから検索
-	  *
-	  * @param name 検索対象オブジェクトの名前
-	  *
-	  * @return 判定
-	  *
-	  * @else
-	  *
-	  * @brief
-	  *
-	  *
-	  * @param name
-	  *
-	  * @return
-	  *
-	  * @endif
-	  */
-	  virtual bool find(std::string name);
+    /*!
+     * @if jp
+     *
+     * @brief オブジェクトの検索
+     *
+     * マスターマネージャ、およびスレーブマネージャに登録されたRTCを検索し、
+     * 　　　　名前が一致するRTCが存在する場合はTrueを返す
+     * このプロセスで起動したマネージャがマスターマネージャではなく、
+     *  さらにマスターマネージャが1つも登録されていない場合はこのプロセスのマネージャから検索
+     *
+     * @param name 検索対象オブジェクトの名前
+     *
+     * @return 判定
+     *
+     * @else
+     *
+     * @brief
+     *
+     *
+     * @param name
+     *
+     * @return
+     *
+     * @endif
+     */
+    virtual bool find(std::string name);
     
   private:
     std::vector<void*> m_objects;
-	RTC::Manager *m_mgr;
+    RTC::Manager *m_mgr;
   };
 } // namespace RTM
 

--- a/src/lib/rtm/OpenHRPExecutionContext.cpp
+++ b/src/lib/rtm/OpenHRPExecutionContext.cpp
@@ -272,25 +272,25 @@ namespace RTC
   * @brief onAddedComponent() template function
   */
   RTC::ReturnCode_t OpenHRPExecutionContext::
-	  onAddedComponent(RTC::LightweightRTObject_ptr  /*rtobj*/)
+     onAddedComponent(RTC::LightweightRTObject_ptr  /*rtobj*/)
   {
-	  std::lock_guard<std::mutex> guard(m_tickmutex);
+    std::lock_guard<std::mutex> guard(m_tickmutex);
 
-	  ExecutionContextBase::m_worker.updateComponentList();
+    ExecutionContextBase::m_worker.updateComponentList();
 
-	  return RTC::RTC_OK;
+    return RTC::RTC_OK;
   }
   /*!
   * @brief onRemovedComponent() template function
   */
   RTC::ReturnCode_t OpenHRPExecutionContext::
-	  onRemovedComponent(RTC::LightweightRTObject_ptr  /*rtobj*/)
+     onRemovedComponent(RTC::LightweightRTObject_ptr  /*rtobj*/)
   {
-	  std::lock_guard<std::mutex> guard(m_tickmutex);
+    std::lock_guard<std::mutex> guard(m_tickmutex);
 
-	  ExecutionContextBase::m_worker.updateComponentList();
+    ExecutionContextBase::m_worker.updateComponentList();
 
-	  return RTC::RTC_OK;
+    return RTC::RTC_OK;
   }
 } // namespace RTC
 

--- a/src/lib/rtm/OpenHRPExecutionContext.h
+++ b/src/lib/rtm/OpenHRPExecutionContext.h
@@ -467,17 +467,17 @@ namespace RTC
      */
     RTC::ExecutionContextProfile* get_profile() override;
   protected:
-    // template virtual functions adding/removing component	
+    // template virtual functions adding/removing component
     /*!
-    * @brief onAddedComponent() template function
-    */
+     * @brief onAddedComponent() template function
+     */
     RTC::ReturnCode_t
-		onAddedComponent(RTC::LightweightRTObject_ptr rtobj) override;
+        onAddedComponent(RTC::LightweightRTObject_ptr rtobj) override;
     /*!
-    * @brief onRemovedComponent() template function
-    */
+     * @brief onRemovedComponent() template function
+     */
     RTC::ReturnCode_t
-		onRemovedComponent(RTC::LightweightRTObject_ptr rtobj) override;
+        onRemovedComponent(RTC::LightweightRTObject_ptr rtobj) override;
     /*!
      * @brief Mutex to guard tick() reenter.
      */

--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -76,7 +76,7 @@ namespace RTC
    */
   template <class DataType>
   class OutPort
-	  : public OutPortBase, DirectOutPortBase<DataType>
+      : public OutPortBase, DirectOutPortBase<DataType>
   {
   public:
     /*!
@@ -104,8 +104,8 @@ namespace RTC
      */
     OutPort(const char* name, DataType& value)
       : OutPortBase(name, ::CORBA_Util::toRepositoryId<DataType>()),
-	  m_value(value), m_onWrite(nullptr), m_onWriteConvert(nullptr),
-	  m_directNewData(false), m_directValue(value)
+        m_value(value), m_onWrite(nullptr), m_onWriteConvert(nullptr),
+        m_directNewData(false), m_directValue(value)
     {
       this->initConnectorListeners();
       this->addConnectorDataListener(ConnectorDataListenerType::ON_BUFFER_WRITE,
@@ -113,7 +113,7 @@ namespace RTC
       this->addConnectorDataListener(ConnectorDataListenerType::ON_SEND,
                                      new Timestamp<DataType>("on_send"));
 
-	  m_directport = this;
+      m_directport = this;
 
       CdrMemoryStreamInit<DataType>();
 

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -1126,30 +1126,29 @@ namespace RTC
 
   ReturnCode_t OutPortBase::notify_connect(ConnectorProfile& connector_profile)
   {
-	  Properties prop;
-	  NVUtil::copyToProperties(prop, connector_profile.properties);
+    Properties prop;
+    NVUtil::copyToProperties(prop, connector_profile.properties);
 
-	  Properties node = prop.getNode("dataport.outport");
+    Properties node = prop.getNode("dataport.outport");
 
-	  Properties portprop(m_properties);
+    Properties portprop(m_properties);
 
-	  node << portprop;
+    node << portprop;
 
-	  
 
-	  NVUtil::copyFromProperties(connector_profile.properties, prop);
+    NVUtil::copyFromProperties(connector_profile.properties, prop);
 
-	  std::string _str = node["fan_out"];
-	  unsigned int value = 100;
+    std::string _str = node["fan_out"];
+    unsigned int value = 100;
 
-	  coil::stringTo<unsigned int>(value, _str.c_str());
+    coil::stringTo<unsigned int>(value, _str.c_str());
 
-	  if (value <= m_connectors.size())
-	  {
-		  return RTC::PRECONDITION_NOT_MET;
-	  }
+    if (value <= m_connectors.size())
+    {
+      return RTC::PRECONDITION_NOT_MET;
+    }
 
-	  return PortBase::notify_connect(connector_profile);
+    return PortBase::notify_connect(connector_profile);
   }
   /*!
    * @if jp
@@ -1167,7 +1166,7 @@ namespace RTC
    */
   ConnectorListenersBase* OutPortBase::getListeners()
   {
-	  return m_listeners;
+    return m_listeners;
   }
   /*!
    * @if jp

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -760,11 +760,20 @@ namespace RTC
       {
         RTC_DEBUG(("dataflow_type pull is supported"));
         appendProperty("dataport.dataflow_type", "pull");
+        coil::Properties prop_options;
         for (auto & provider_type : provider_types)
         {
             appendProperty("dataport.interface_type",
                         provider_type.c_str());
+            coil::Properties prop_if(factory.getProperties(provider_type));
+            coil::Properties& prop_node(prop_options.getNode(provider_type));
+            prop_node << prop_if;
         }
+        coil::Properties prop;
+        NVUtil::copyToProperties(prop, m_profile.properties);
+        coil::Properties& prop_dataport(prop.getNode("dataport.interface_type"));
+        prop_dataport << prop_options;
+        NVUtil::copyFromProperties(m_profile.properties, prop);
       }
 
     m_providerTypes = provider_types;
@@ -812,11 +821,20 @@ namespace RTC
       {
         RTC_PARANOID(("dataflow_type push is supported"));
         appendProperty("dataport.dataflow_type", "push");
+        coil::Properties prop_options;
         for (auto & consumer_type : consumer_types)
         {
             appendProperty("dataport.interface_type",
                         consumer_type.c_str());
+            coil::Properties prop_if(factory.getProperties(consumer_type));
+            coil::Properties& prop_node(prop_options.getNode(consumer_type));
+            prop_node << prop_if;
         }
+        coil::Properties prop;
+        NVUtil::copyToProperties(prop, m_profile.properties);
+        coil::Properties& prop_dataport(prop.getNode("dataport.interface_type"));
+        prop_dataport << prop_options;
+        NVUtil::copyFromProperties(m_profile.properties, prop);
       }
 
     m_consumerTypes = consumer_types;

--- a/src/lib/rtm/OutPortBase.h
+++ b/src/lib/rtm/OutPortBase.h
@@ -771,24 +771,24 @@ namespace RTC
     ReturnCode_t
     connect(ConnectorProfile& connector_profile) override;
 
-	/*!
-	* @if jp
-	* @brief リスナホルダを取得する
-	*
-	* InPortBaseが保持するリスナホルダを返す。
-	*
-	* @return ConnectorListeners
-	*
-	* @else
-	* @brief Getting listeners holder
-	*
-	* This operation returns listeners holder.
-	*
-	* @return ConnectorListeners
-	*
-	* @endif
-	*/
-	virtual ConnectorListenersBase* getListeners();
+    /*!
+     * @if jp
+     * @brief リスナホルダを取得する
+     *
+     * InPortBaseが保持するリスナホルダを返す。
+     *
+     * @return ConnectorListeners
+     *
+     * @else
+     * @brief Getting listeners holder
+     *
+     * This operation returns listeners holder.
+     *
+     * @return ConnectorListeners
+     *
+     * @endif
+     */
+    virtual ConnectorListenersBase* getListeners();
 
 
   protected:

--- a/src/lib/rtm/OutPortConnector.cpp
+++ b/src/lib/rtm/OutPortConnector.cpp
@@ -32,7 +32,7 @@ namespace RTC
   OutPortConnector::OutPortConnector(ConnectorInfo& info,
                                      ConnectorListenersBase* listeners)
     : rtclog("OutPortConnector"), m_profile(info), m_littleEndian(true),
-	m_directInPort(nullptr), m_listeners(listeners), m_directMode(false), m_marshaling_type("cdr"), m_cdr(nullptr)
+      m_directInPort(nullptr), m_listeners(listeners), m_directMode(false), m_marshaling_type("cdr"), m_cdr(nullptr)
   {
   }
 
@@ -148,7 +148,7 @@ namespace RTC
   */
   void OutPortConnector::setPullDirectMode()
   {
-	  m_directMode = true;
+    m_directMode = true;
   }
 
   /*!
@@ -165,23 +165,23 @@ namespace RTC
   */
   bool OutPortConnector::pullDirectMode()
   {
-	  return m_directMode;
+    return m_directMode;
   }
 
   bool OutPortConnector::setInPort(InPortBase* directInPort)
   {
-	  if (directInPort == nullptr)
-	  {
-		  return false;
-	  }
-	  m_directInPort = directInPort;
-	  m_inPortListeners = directInPort->getListeners();
-	  return true;
+    if (directInPort == nullptr)
+    {
+      return false;
+    }
+    m_directInPort = directInPort;
+    m_inPortListeners = directInPort->getListeners();
+    return true;
   }
 
   BufferStatus OutPortConnector::read(ByteData&  /*data*/)
   {
-      return BufferStatus::OK;
+    return BufferStatus::OK;
   }
 
   void OutPortConnector::unsubscribeInterface(const coil::Properties& /*prop*/)

--- a/src/lib/rtm/OutPortDirectConsumer.h
+++ b/src/lib/rtm/OutPortDirectConsumer.h
@@ -52,7 +52,7 @@ namespace RTC
    *
    * @endif
    */
-	class OutPortDirectConsumer
+  class OutPortDirectConsumer
     : public OutPortConsumer
   {
   public:
@@ -70,7 +70,7 @@ namespace RTC
      *
      * @endif
      */
-	 OutPortDirectConsumer();
+    OutPortDirectConsumer();
 
     /*!
      * @if jp
@@ -85,7 +85,7 @@ namespace RTC
      *
      * @endif
      */
-	~OutPortDirectConsumer() override;
+    ~OutPortDirectConsumer() override;
 
     /*!
      * @if jp
@@ -257,8 +257,8 @@ namespace RTC
     void unsubscribeInterface(const SDOPackage::NVList& properties) override;
     
 private:
-	mutable Logger rtclog;
-	coil::Properties m_properties;
+    mutable Logger rtclog;
+    coil::Properties m_properties;
   };
 } // namespace RTC
 
@@ -277,7 +277,7 @@ extern "C"
    *
    * @endif
    */
-	void OutPortDirectConsumerInit(void);
+  void OutPortDirectConsumerInit(void);
 }
 
 #endif // RTC_OUTPORTDIRECTCONSUMER_H

--- a/src/lib/rtm/OutPortSHMConsumer.cpp
+++ b/src/lib/rtm/OutPortSHMConsumer.cpp
@@ -61,8 +61,7 @@ namespace RTC
    */
   void OutPortSHMConsumer::init(coil::Properties&  /*prop*/)
   {
-	RTC_TRACE(("OutPortSHMConsumer::init()"));
-	
+    RTC_TRACE(("OutPortSHMConsumer::init()"));
   }
 
   /*!
@@ -96,11 +95,11 @@ namespace RTC
   bool OutPortSHMConsumer::setObject(CORBA::Object_ptr obj)
   {
     RTC_PARANOID(("setObject()"));
-	if (CorbaConsumer< ::OpenRTM::PortSharedMemory >::setObject(obj))
-	{
-		_ptr()->setInterface(m_shmem._this());
-		return true;
-	}
+    if (CorbaConsumer< ::OpenRTM::PortSharedMemory >::setObject(obj))
+    {
+      _ptr()->setInterface(m_shmem._this());
+      return true;
+    }
 
 
     return false;
@@ -121,32 +120,32 @@ namespace RTC
     try
       {
           
-            std::lock_guard<std::mutex> guard(m_mutex);
+        std::lock_guard<std::mutex> guard(m_mutex);
             
 
-            ::OpenRTM::PortStatus ret(_ptr()->get());
-			if (ret == ::OpenRTM::PORT_OK)
-			{
-				m_shmem.read(data);
+        ::OpenRTM::PortStatus ret(_ptr()->get());
+        if (ret == ::OpenRTM::PORT_OK)
+          {
+            m_shmem.read(data);
 
-				RTC_DEBUG(("get() successful"));
-                RTC_PARANOID(("CDR data length: %d", data.getDataLength()));
+            RTC_DEBUG(("get() successful"));
+            RTC_PARANOID(("CDR data length: %d", data.getDataLength()));
 
-				onReceived(data);
-				onBufferWrite(data);
+            onReceived(data);
+            onBufferWrite(data);
 
-				if (m_buffer->full())
-				{
-					RTC_INFO(("InPort buffer is full."));
-					onBufferFull(data);
-					onReceiverFull(data);
-				}
-				m_buffer->put(data);
-				m_buffer->advanceWptr();
-				m_buffer->advanceRptr();
+            if (m_buffer->full())
+              {
+                RTC_INFO(("InPort buffer is full."));
+                onBufferFull(data);
+                onReceiverFull(data);
+              }
+            m_buffer->put(data);
+            m_buffer->advanceWptr();
+            m_buffer->advanceRptr();
 
-				return DataPortStatus::PORT_OK;
-			}
+            return DataPortStatus::PORT_OK;
+          }
           
         return convertReturn(ret, data);
       }

--- a/src/lib/rtm/OutPortSHMConsumer.h
+++ b/src/lib/rtm/OutPortSHMConsumer.h
@@ -323,9 +323,9 @@ protected:
     int m_memory_size;
     bool m_endian;
 
-	CdrBufferBase* m_buffer;
-	ConnectorListenersBase* m_listeners{nullptr};
-	ConnectorInfo m_profile;
+    CdrBufferBase* m_buffer;
+    ConnectorListenersBase* m_listeners{nullptr};
+    ConnectorInfo m_profile;
   };
 } // namespace RTC
 

--- a/src/lib/rtm/PeriodicECSharedComposite.cpp
+++ b/src/lib/rtm/PeriodicECSharedComposite.cpp
@@ -153,11 +153,11 @@ namespace SDOPackage
       {
 
         Member& member(*it);
-		size_t len = strlen(id);
-		if (len < strlen(member.profile_->instance_name))
-		{
-			len = strlen(member.profile_->instance_name);
-		}
+        size_t len = strlen(id);
+        if (len < strlen(member.profile_->instance_name))
+          {
+            len = strlen(member.profile_->instance_name);
+          }
         if (strncmp(id, member.profile_->instance_name, len) != 0)
           {
             ++it;
@@ -172,13 +172,12 @@ namespace SDOPackage
         removeOrganizationFromTarget(member);
         startOwnedEC(member);
         it = m_rtcMembers.erase(it);
-		break;
+        break;
 
       }
 
     CORBA::Boolean result;
     result = ::SDOPackage::Organization_impl::remove_member(id);
-	
     
     return result;
   }
@@ -196,7 +195,7 @@ namespace SDOPackage
     updateExportedPortsList();
     MemIt it(m_rtcMembers.begin());
     MemIt it_end(m_rtcMembers.end());
-	
+
     while (it != it_end)
       {
         Member& member(*it);

--- a/src/lib/rtm/PortAdmin.cpp
+++ b/src/lib/rtm/PortAdmin.cpp
@@ -175,9 +175,9 @@ namespace RTC
     if (index >= 0)
       {
 #ifdef ORB_IS_ORBEXPRESS
-	return RTC::PortService::_duplicate(m_portRefs[index].in());
+        return RTC::PortService::_duplicate(m_portRefs[index].in());
 #else
-	return RTC::PortService::_duplicate(m_portRefs[index]);
+        return RTC::PortService::_duplicate(m_portRefs[index]);
 #endif
       }
     return RTC::PortService::_nil();

--- a/src/lib/rtm/PortBase.cpp
+++ b/src/lib/rtm/PortBase.cpp
@@ -1002,7 +1002,7 @@ namespace RTC
   */
   DirectPortBase* PortBase::getDirectPort()
   {
-	  return m_directport;
+      return m_directport;
   }
 
 

--- a/src/lib/rtm/PortBase.h
+++ b/src/lib/rtm/PortBase.h
@@ -1259,20 +1259,20 @@ namespace RTC
      */
     void setPortConnectListenerHolder(PortConnectListeners* portconnListeners);
 
-	/*!
-	* @if jp
-	* @brief direct通信用ポートオブジェクト取得
-	*
-	* @return ポートのポインタ
-	*
-	* @else
-	* @brief 
-	*
-	* @return
-	*
-	* @endif
-	*/
-	virtual DirectPortBase* getDirectPort();
+    /*!
+     * @if jp
+     * @brief direct通信用ポートオブジェクト取得
+     *
+     * @return ポートのポインタ
+     *
+     * @else
+     * @brief 
+     *
+     * @return
+     *
+     * @endif
+     */
+    virtual DirectPortBase* getDirectPort();
     //============================================================
     // protected operations
     //============================================================
@@ -2236,7 +2236,7 @@ namespace RTC
      */
     PortConnectListeners* m_portconnListeners{nullptr};
 
-	DirectPortBase *m_directport{nullptr};
+    DirectPortBase *m_directport{nullptr};
 
     //============================================================
     // Functor
@@ -2271,7 +2271,7 @@ namespace RTC
 #ifdef ORB_IS_ORBEXPRESS
       bool operator()(PortService_var port_ref)
       {
-	return m_port->_is_equivalent(port_ref.in());
+        return m_port->_is_equivalent(port_ref.in());
       }
 #else
       bool operator()(PortService_ptr port_ref)

--- a/src/lib/rtm/RTObject.cpp
+++ b/src/lib/rtm/RTObject.cpp
@@ -72,7 +72,7 @@ namespace RTC
       m_sdoservice(*this),
       m_readAll(false), m_writeAll(false),
       m_readAllCompletion(false), m_writeAllCompletion(false),
-	  m_insref(RTC::LightweightRTObject::_nil()), m_sdoconterm(nullptr)
+      m_insref(RTC::LightweightRTObject::_nil()), m_sdoconterm(nullptr)
   {
     m_objref = this->_this();
     m_pSdoConfigImpl = new SDOPackage::Configuration_impl(m_configsets,
@@ -1938,8 +1938,7 @@ namespace RTC
       }
     m_sdoconterm = new SdoServiceConsumerTerminator();
     m_sdoconterm->setSdoServiceConsumer(&m_sdoservice, id);
-    m_sdoconterm->activate();
-	  
+    m_sdoconterm->activate();  
   }
 
   /*!

--- a/src/lib/rtm/SdoConfiguration.cpp
+++ b/src/lib/rtm/SdoConfiguration.cpp
@@ -352,7 +352,7 @@ namespace SDOPackage
       {
 #ifndef ORB_IS_RTORB
 #ifdef ORB_IS_ORBEXPRESS
-	oe_out << e << oe_endl << oe_flush;
+        oe_out << e << oe_endl << oe_flush;
 #else
         RTC_ERROR(("CORBA::SystemException cought: %s", e._name()));
 #endif

--- a/src/lib/rtm/SdoOrganization.h
+++ b/src/lib/rtm/SdoOrganization.h
@@ -833,7 +833,7 @@ namespace SDOPackage
       {
         CORBA::String_var id(sdo->get_sdo_id());
 
-	return m_id == (const char*)id;
+        return m_id == (const char*)id;
       }
       std::string m_id;
     };  // struct sdo_id

--- a/src/lib/rtm/SimulatorExecutionContext.cpp
+++ b/src/lib/rtm/SimulatorExecutionContext.cpp
@@ -35,11 +35,8 @@ namespace RTC
    * @endif
    */
   SimulatorExecutionContext::SimulatorExecutionContext()
-		: RTC::OpenHRPExecutionContext()
+    : RTC::OpenHRPExecutionContext()
   {
-	  
-	  
-	
   }
 
   /*!
@@ -75,29 +72,29 @@ namespace RTC
    * @endif
    */
   RTC::ReturnCode_t SimulatorExecutionContext::
-	  activate_component(RTC::LightweightRTObject_ptr comp)
+    activate_component(RTC::LightweightRTObject_ptr comp)
   {
-	std::lock_guard<std::mutex> guard(m_tickmutex);
+    std::lock_guard<std::mutex> guard(m_tickmutex);
 
-	RTC_impl::RTObjectStateMachine* rtobj = m_worker.findComponent(comp);
+    RTC_impl::RTObjectStateMachine* rtobj = m_worker.findComponent(comp);
 
-	if (rtobj == nullptr)
-	{
-		return RTC::BAD_PARAMETER;
-	}
-	if (!(rtobj->isCurrentState(RTC::INACTIVE_STATE)))
-	{
-		return RTC::PRECONDITION_NOT_MET;
-	}
-	m_syncActivation = false;
+    if (rtobj == nullptr)
+    {
+      return RTC::BAD_PARAMETER;
+    }
+    if (!(rtobj->isCurrentState(RTC::INACTIVE_STATE)))
+    {
+      return RTC::PRECONDITION_NOT_MET;
+    }
+    m_syncActivation = false;
 
-	ExecutionContextBase::activateComponent(comp);
-	invokeWorkerPreDo();
-	if ((rtobj->isCurrentState(RTC::ACTIVE_STATE)))
-	{
-		return RTC::RTC_OK;
-	}
-	return RTC::RTC_ERROR;
+    ExecutionContextBase::activateComponent(comp);
+    invokeWorkerPreDo();
+    if ((rtobj->isCurrentState(RTC::ACTIVE_STATE)))
+    {
+      return RTC::RTC_OK;
+    }
+    return RTC::RTC_ERROR;
 
   }
 
@@ -127,29 +124,29 @@ namespace RTC
   RTC::ReturnCode_t SimulatorExecutionContext::
   deactivate_component(RTC::LightweightRTObject_ptr comp)
   {
-	std::lock_guard<std::mutex> guard(m_tickmutex);
+    std::lock_guard<std::mutex> guard(m_tickmutex);
 
-	RTC_impl::RTObjectStateMachine* rtobj = m_worker.findComponent(comp);
+    RTC_impl::RTObjectStateMachine* rtobj = m_worker.findComponent(comp);
 
-	if (rtobj == nullptr)
-	{
-		  return RTC::BAD_PARAMETER;
-	}
-	if (!(rtobj->isCurrentState(RTC::ACTIVE_STATE)))
-	{
-		  return RTC::PRECONDITION_NOT_MET;
-	}
-	m_syncDeactivation = false;
-	ExecutionContextBase::deactivateComponent(comp);
-	invokeWorkerPreDo();
-	invokeWorkerDo();
-	invokeWorkerPostDo();
+    if (rtobj == nullptr)
+    {
+      return RTC::BAD_PARAMETER;
+    }
+    if (!(rtobj->isCurrentState(RTC::ACTIVE_STATE)))
+    {
+      return RTC::PRECONDITION_NOT_MET;
+    }
+    m_syncDeactivation = false;
+    ExecutionContextBase::deactivateComponent(comp);
+    invokeWorkerPreDo();
+    invokeWorkerDo();
+    invokeWorkerPostDo();
 
-	if ((rtobj->isCurrentState(RTC::INACTIVE_STATE)))
-	{
-		return RTC::RTC_OK;
-	}
-	return RTC::RTC_ERROR;
+    if ((rtobj->isCurrentState(RTC::INACTIVE_STATE)))
+    {
+      return RTC::RTC_OK;
+    }
+    return RTC::RTC_ERROR;
 
   }
 
@@ -179,29 +176,29 @@ namespace RTC
   RTC::ReturnCode_t SimulatorExecutionContext::
   reset_component(RTC::LightweightRTObject_ptr comp)
   {
-	std::lock_guard<std::mutex> guard(m_tickmutex);
+    std::lock_guard<std::mutex> guard(m_tickmutex);
 
-	RTC_impl::RTObjectStateMachine* rtobj = m_worker.findComponent(comp);
+    RTC_impl::RTObjectStateMachine* rtobj = m_worker.findComponent(comp);
 
-	if (rtobj == nullptr)
-	{
-		return RTC::BAD_PARAMETER;
-	}
-	if (!(rtobj->isCurrentState(RTC::ERROR_STATE)))
-	{
-		return RTC::PRECONDITION_NOT_MET;
-	}
-	m_syncReset = false;
-	ExecutionContextBase::resetComponent(comp);
-	invokeWorkerPreDo();
-	invokeWorkerDo();
-	invokeWorkerPostDo();
+    if (rtobj == nullptr)
+    {
+      return RTC::BAD_PARAMETER;
+    }
+    if (!(rtobj->isCurrentState(RTC::ERROR_STATE)))
+    {
+      return RTC::PRECONDITION_NOT_MET;
+    }
+    m_syncReset = false;
+    ExecutionContextBase::resetComponent(comp);
+    invokeWorkerPreDo();
+    invokeWorkerDo();
+    invokeWorkerPostDo();
 
-	if ((rtobj->isCurrentState(RTC::INACTIVE_STATE)))
-	{
-		return RTC::RTC_OK;
-	}
-	return RTC::RTC_ERROR;
+    if ((rtobj->isCurrentState(RTC::INACTIVE_STATE)))
+    {
+      return RTC::RTC_OK;
+    }
+    return RTC::RTC_ERROR;
 
 
   }

--- a/src/lib/rtm/VxWorksInterruptExecutionContext.cpp
+++ b/src/lib/rtm/VxWorksInterruptExecutionContext.cpp
@@ -26,20 +26,20 @@
 
 #if defined(__powerpc__)
 #include <arch/ppc/ivPpc.h>
-#define	IV_CI	0
-#define	IV_SRI	4
-#define	IV_STI	5
-#define	IV_JRI	6
-#define	IV_JTI	7
-#define	IV_D0I	8
-#define	IV_D1I	9
-#define	IV_D2I	10
-#define	IV_D3I	11
-#define	IV_E0I	27
-#define	IV_E1I	28
-#define	IV_E2I	29
-#define	IV_E3I	30
-#define	IV_E4I	31
+#define IV_CI 0
+#define IV_SRI 4
+#define IV_STI 5
+#define IV_JRI 6
+#define IV_JTI 7
+#define IV_D0I 8
+#define IV_D1I 9
+#define IV_D2I 10
+#define IV_D3I 11
+#define IV_E0I 27
+#define IV_E1I 28
+#define IV_E2I 29
+#define IV_E3I 30
+#define IV_E4I 31
 #else
 #include <arch/simlinux/ivSimlinux.h>
 #endif

--- a/src/lib/rtm/VxWorksInterruptExecutionContext.h
+++ b/src/lib/rtm/VxWorksInterruptExecutionContext.h
@@ -604,16 +604,16 @@ namespace RTC
      * @brief onStarted() template function
      */
     virtual RTC::ReturnCode_t onStarted();
-    // template virtual functions adding/removing component	
-    /*!	
-     * @brief onAddedComponent() template function	
-     */	
-     virtual RTC::ReturnCode_t	
-     onAddedComponent(RTC::LightweightRTObject_ptr rtobj);	
-    /*!	
-     * @brief onRemovedComponent() template function	
-     */	
-    virtual RTC::ReturnCode_t	
+    // template virtual functions adding/removing component
+    /*!
+     * @brief onAddedComponent() template function
+     */
+     virtual RTC::ReturnCode_t
+     onAddedComponent(RTC::LightweightRTObject_ptr rtobj);
+    /*!
+     * @brief onRemovedComponent() template function
+     */
+    virtual RTC::ReturnCode_t
     onRemovedComponent(RTC::LightweightRTObject_ptr rtobj);
     /*!
      * @brief onWaitingActivated() template function


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROSTransportをRos4Winでビルドする場合に、エラー、警告が発生する。


## Description of the Change

- 以前の変更でpkg_check_modulesを使ってroscppを検出するように変更したが、これはWindowsでは使えないためWindowsの場合はfind_packageでroscppを検出するように変更した。
- Ros4Win付属のBoostの問題だと思うが、実際のライブラリ名が`boost_thread-vc141-mt-x64-1_68.lib`だが`libboost_thread-vc141-mt-x64-1_68.lib`とリンクしようとしてエラーになるため、`libboost_thread-vc141-mt-x64-1_68.lib`の先頭の`lib`を付けないように修正した(`_RTLDLL`と`BOOST_ALL_DYN_LINK`の定義)。これに伴い、FileNameserviceにもROSTransportのビルドが有効になっている場合に同様の定義をするように修正した。
- ROSのヘッダーファイルで`getpid`を#defineで定義しており、`coil::getpid`がエラーになるため#undefするように修正した。
- ROSのヘッダーファイルの警告(C4267)を抑制するように修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
