### PR TITLE
rtc.confが見つからなかった場合にファイル名が表示されない問題の修正

### DIFF
--- a/src/lib/rtm/ManagerConfig.cpp
+++ b/src/lib/rtm/ManagerConfig.cpp
@@ -157,7 +157,7 @@ namespace RTC
           case 'f':
             if (!fileExist(get_opts.optarg))
               {
-                std::cerr << "Configuration file: " << m_configFile;
+                std::cerr << "Configuration file: " << get_opts.optarg;
                 std::cerr << " not found." << std::endl;
 #ifndef __QNX__
                 for (int i(0); i < argc; ++i)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

`-f`オプションで設定ファイルを指定してファイルが存在しなかった場合、以下のようにファイルが見つからなかったメッセージは出力されるが、ファイル名が表示されない問題が発生している。


```
Configuration file:  not found.
```


## Description of the Change

変数`m_configFile`にファイル名を格納する前にエラーメッセージを表示するようになっていたため、正常にファイル名が表示されるように修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
