### PR TITLE
Ubuntuでcoil::create_process関数が正常に動作しない場合がある問題の修正

### DIFF
--- a/src/lib/coil/posix/coil/Process.cpp
+++ b/src/lib/coil/posix/coil/Process.cpp
@@ -93,13 +93,15 @@ namespace coil
     do
       {
         char str[512];
-        fgets(str, 512, fd);
-        std::string line(str);
-        if (!line.empty())
+        if(fgets(str, 512, fd) != nullptr)
           {
-            line.erase(line.size() - 1);
+            std::string line(str);
+            if (!line.empty())
+              {
+                line.erase(line.size() - 1);
+              }
+            out.emplace_back(line);
           }
-        out.emplace_back(line);
       } while (feof(fd) == 0);
     
     (void) pclose(fd);


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Ubuntu環境でcoil::create_process関数が正常に動作しない場合がある。

例えば、以下のようにOpenSpliceのidlppを実行するとXML文書を出力する。

```
$ idlpp -l pythondesc BasicDataType.idl
<topics>
  <topictype>
    <id>RTC::TimedState</id>
    <keys></keys>
    <descriptor><![CDATA[<MetaData version="1.0.0"><Module name="RTC"><Struct name="Time"><Member name="sec"><ULong/></Member><Member name="nsec"><ULong/></Member></Struct><Struct name="TimedState"><Member name="tm"><Type name="Time"/></Member><Member name="data"><Short/></Member></Struct></Module></MetaData>]]></descriptor>
  </topictype>
(長いので省略)
  </topictype>
</topics>
```

これをcoil::create_process関数で実行して出力を取得すると以下のように最後の`</tipics>`が2つに増える。

```
<topics>
  <topictype>
    <id>RTC::TimedState</id>
    <keys></keys>
    <descriptor><![CDATA[<MetaData version="1.0.0"><Module name="RTC"><Struct name="Time"><Member name="sec"><ULong/></Member><Member name="nsec"><ULong/></Member></Struct><Struct name="TimedState"><Member name="tm"><Type name="Time"/></Member><Member name="data"><Short/></Member></Struct></Module></MetaData>]]></descriptor>
  </topictype>
(長いので省略)
  </topictype>
</topics>
</topics>
```

feof関数はEOFに到達したかどうかの判定なので、以下の場合にCCCを読み込んだ時点ではEOFに到達しておらず、4行目をfgetsで読もうとすると読み込みエラーになっていることが原因だと思います。fgetsが読み込み失敗しても変数outに取得した文字列を追加しています。

```
AAA
BBB
CCC
[EOF]
```

## Description of the Change

fgetsが読み込み失敗してnullを返したときに出力結果に追加する処理をしないようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
