### PR TITLE
OutPortConsumerのrtclogを派生クラスに移動させる

### DIFF
--- a/src/ext/transport/SSMTransport/SSMInPort.h
+++ b/src/ext/transport/SSMTransport/SSMInPort.h
@@ -260,6 +260,16 @@ namespace RTC
      */
     void unsubscribeInterface(const SDOPackage::NVList& properties) override;
     
+  protected:
+    /*!
+     * @if jp
+     * @brief ロガーストリーム
+     * @else
+     * @brief Logger stream
+     * @endif
+     */
+    mutable Logger rtclog;
+
   private:
       /*!
      * @if jp

--- a/src/lib/rtm/OutPortConsumer.h
+++ b/src/lib/rtm/OutPortConsumer.h
@@ -358,14 +358,6 @@ namespace RTC
     virtual void unsubscribeInterface(const SDOPackage::NVList& properties) = 0;
 
   protected:
-    /*!
-     * @if jp
-     * @brief ロガーストリーム
-     * @else
-     * @brief Logger stream
-     * @endif
-     */
-    mutable Logger rtclog;
 
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortCorbaCdrConsumer.h
+++ b/src/lib/rtm/OutPortCorbaCdrConsumer.h
@@ -256,7 +256,15 @@ namespace RTC
      * @endif
      */
     void unsubscribeInterface(const SDOPackage::NVList& properties) override;
-
+  protected:
+    /*!
+     * @if jp
+     * @brief ロガーストリーム
+     * @else
+     * @brief Logger stream
+     * @endif
+     */
+    mutable Logger rtclog;
   private:
     /*!
      * @if jp

--- a/src/lib/rtm/OutPortDSConsumer.h
+++ b/src/lib/rtm/OutPortDSConsumer.h
@@ -255,6 +255,16 @@ namespace RTC
      */
     void unsubscribeInterface(const SDOPackage::NVList& properties) override;
 
+  protected:
+    /*!
+     * @if jp
+     * @brief ロガーストリーム
+     * @else
+     * @brief Logger stream
+     * @endif
+     */
+    mutable Logger rtclog;
+
   private:
     /*!
      * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

OutPortConsumerクラスのメンバ変数にrtclogがあるが、OutPortConsumerは抽象クラスのためrtclogは派生クラスに移動したい。


## Description of the Change

OutPortConsumerからrtclogのメンバ変数は削除して派生クラスのSSMInPort、OutPortDSConsumer、OutPortCorbaCdrConsumerにrtclogを移動した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
