### PR TITLE
create_component関数で2回RTCを起動する不具合の修正

### DIFF
--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -415,14 +415,14 @@ namespace RTM
     // create component by address
     std::string manager_address;
     rtobj = createComponentByAddress(create_arg, manager_address);
-    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); };
-    else if (!manager_address.empty()) { return RTC::RTObject::_nil(); };
+    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
+    else if (!manager_address.empty()) { return RTC::RTObject::_nil(); }
 
     // create component by manager's name
     std::string manager_name;
     rtobj = createComponentByManagerName(create_arg, manager_name);
-    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); };
-    else if (!manager_name.empty()) { return RTC::RTObject::_nil(); };
+    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
+    else if (!manager_name.empty()) { return RTC::RTObject::_nil(); }
 
 
 

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -415,13 +415,13 @@ namespace RTM
     // create component by address
     std::string manager_address;
     rtobj = createComponentByAddress(create_arg, manager_address);
-    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
+    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); };
     else if (!manager_address.empty()) { return RTC::RTObject::_nil(); };
 
     // create component by manager's name
     std::string manager_name;
     rtobj = createComponentByManagerName(create_arg, manager_name);
-    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
+    if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); };
     else if (!manager_name.empty()) { return RTC::RTObject::_nil(); };
 
 

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -413,16 +413,17 @@ namespace RTM
 
     RTC::RTObject_var rtobj;
     // create component by address
-    rtobj = createComponentByAddress(create_arg);
+    std::string manager_address;
+    rtobj = createComponentByAddress(create_arg, manager_address);
     if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
+    else if (!manager_address.empty()) { return RTC::RTObject::_nil(); };
 
     // create component by manager's name
-    rtobj = createComponentByManagerName(create_arg);
+    std::string manager_name;
+    rtobj = createComponentByManagerName(create_arg, manager_name);
     if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
+    else if (!manager_name.empty()) { return RTC::RTObject::_nil(); };
 
-
-    getParameterByModulename("manager_address", create_arg);
-    std::string manager_name = getParameterByModulename("manager_name", create_arg);
 
 
     CompParam comp_param(create_arg);
@@ -462,7 +463,7 @@ namespace RTM
         if (manager_name.empty())
           {
             create_arg = create_arg + "&manager_name=manager_%p";
-            rtobj = createComponentByManagerName(create_arg);
+            rtobj = createComponentByManagerName(create_arg, manager_name);
             if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
           }
         return RTC::RTObject::_nil();
@@ -1185,7 +1186,7 @@ namespace RTM
    * @endif
    */
   RTC::RTObject_ptr
-  ManagerServant::createComponentByManagerName(const std::string& create_arg)
+  ManagerServant::createComponentByManagerName(std::string& create_arg, std::string& mgrstr)
   {
     RTC_TRACE(("createComponentByManagerName(%s)",create_arg.c_str()));
     coil::mapstring param = coil::urlparam2map(create_arg);
@@ -1195,7 +1196,7 @@ namespace RTM
                    p.first.c_str(), p.second.c_str()));
       }
 
-    std::string mgrstr = param["manager_name"];
+    mgrstr = param["manager_name"];
     if (mgrstr.empty())
       {
         RTC_WARN(("No manager_name found: %s", mgrstr.c_str()));
@@ -1228,8 +1229,9 @@ namespace RTM
           }
 
         std::string lang_path_key("manager.modules.");
-        lang_path_key += lang + ".load_path";
-        rtcd_cmd += " -o \"manager.modules.load_path:" + coil::escape(prop["manager.modules.load_path"]) + "," + coil::escape(prop[lang_path_key]) + "\"";
+        lang_path_key += lang + ".load_paths";
+        rtcd_cmd += " -o \"manager.modules.load_path:" + coil::escape(prop["manager.modules.load_path"]) + "\"";
+        rtcd_cmd += " -o \"" + lang_path_key + ":" + coil::escape(prop[lang_path_key]) + "\"";
         
         rtcd_cmd += " -o \"manager.is_master:NO\"";
         rtcd_cmd += " -o \"manager.corba_servant:YES\"";
@@ -1319,6 +1321,7 @@ namespace RTM
     getParameterByModulename("manager_name", create_arg_str);
     RTC_DEBUG(("Creating component on %s",  mgrstr.c_str()));
     RTC_DEBUG(("arg: %s", create_arg_str.c_str()));
+    create_arg = create_arg_str;
     try
       {
         return mgrobj->create_component(create_arg_str.c_str());
@@ -1343,7 +1346,7 @@ namespace RTM
    * @endif
    */
   RTC::RTObject_ptr
-  ManagerServant::createComponentByAddress(const std::string& create_arg)
+  ManagerServant::createComponentByAddress(std::string& create_arg, std::string& mgrstr)
   {
     RTC_TRACE(("createComponentByAddress(%s)",create_arg.c_str()));
     coil::mapstring param = coil::urlparam2map(create_arg);
@@ -1353,7 +1356,7 @@ namespace RTM
                    p.first.c_str(), p.second.c_str()));
       }
 
-    std::string mgrstr = param["manager_address"];
+    mgrstr = param["manager_address"];
     if (mgrstr.empty())
       {
         RTC_WARN(("No manager_address found: %s", mgrstr.c_str()));
@@ -1426,6 +1429,7 @@ namespace RTM
         getParameterByModulename("manager_address", create_arg_str);
         RTC_DEBUG(("Creating component on %s",  mgrstr.c_str()));
         RTC_DEBUG(("arg: %s", create_arg.c_str()));
+        create_arg = create_arg_str;
         try
           {
             return mgrobj->create_component(create_arg_str.c_str());

--- a/src/lib/rtm/ManagerServant.h
+++ b/src/lib/rtm/ManagerServant.h
@@ -667,7 +667,7 @@ namespace RTM
      * @endif
      */
     RTC::RTObject_ptr
-    createComponentByManagerName(const std::string& create_arg);
+    createComponentByManagerName(std::string& create_arg, std::string& mgrstr);
 
     /*
      * @if jp
@@ -688,7 +688,6 @@ namespace RTM
      * @endif
      */
     RTC::RTObject_ptr
-    createComponentByAddress(const std::string& create_arg);
 
 	/*
 	* @if jp
@@ -705,6 +704,7 @@ namespace RTM
 	void updateMasterManager();
 	std::string getParameterByModulename(const std::string& param_name, std::string &module_name);
 	static bool isProcessIDManager(const std::string& mgrname);
+    createComponentByAddress(std::string& create_arg, std::string& mgrstr);
 
   private:
     /*!

--- a/src/lib/rtm/ManagerServant.h
+++ b/src/lib/rtm/ManagerServant.h
@@ -688,6 +688,7 @@ namespace RTM
      * @endif
      */
     RTC::RTObject_ptr
+    createComponentByAddress(std::string& create_arg, std::string& mgrstr);
 
 	/*
 	* @if jp
@@ -704,7 +705,6 @@ namespace RTM
 	void updateMasterManager();
 	std::string getParameterByModulename(const std::string& param_name, std::string &module_name);
 	static bool isProcessIDManager(const std::string& mgrname);
-    createComponentByAddress(std::string& create_arg, std::string& mgrstr);
 
   private:
     /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ManagerServantクラスのcreate_component関数実行時にRTCを2回起動することがある。

これはマネージャ名を指定してRTCを起動する場合に、スレーブマネージャのcreate_componentを呼ぶが、これがタイムアウトで例外が発生すると、スレーブマネージャでRTCの生成処理が実行されるがマスターマネージャ側では生成失敗と判定する。

https://github.com/OpenRTM/OpenRTM-aist/blob/b9f40c75f125f956a85620113d85cb6bded20fe7/src/lib/rtm/ManagerServant.cpp#L1322-L1330

生成失敗した場合に指定言語のスレーブマネージャを検索してcreate_componentを呼ぶ処理を行うため、2回RTCを生成する結果になる。


## Description of the Change

マネージャ名を指定した場合に、指定マネージャでRTCを生成できなかった場合はその時点でcreate_component関数を終了するように変更した。アドレス名を指定した場合も同様。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
