### PR TITLE
DefaultConfiguration.hのrtcd、rtcprofコマンドの修正

### DIFF
--- a/src/lib/rtm/DefaultConfiguration.h
+++ b/src/lib/rtm/DefaultConfiguration.h
@@ -96,7 +96,11 @@ namespace RTC {
     "manager.termination_waittime",          "0.5",
     "manager.name",                          "manager",
     "manager.components.naming_policy",      "process_unique",
+#ifdef RTM_OS_LINUX
+    "manager.command",                       "rtcd2",
+#else
     "manager.command",                       "rtcd",
+#endif
     "manager.nameservers",                     "default",
     "manager.language",                      "C++",
 #ifdef WIN32
@@ -104,8 +108,13 @@ namespace RTC {
 #else
     "manager.supported_languages",           "C++, Python, Python3, Java",
 #endif
+#ifdef RTM_OS_LINUX
+    "manager.modules.C++.manager_cmd",       "rtcd2",
+    "manager.modules.C++.profile_cmd",       "rtcprof2",
+#else
     "manager.modules.C++.manager_cmd",       "rtcd",
     "manager.modules.C++.profile_cmd",       "rtcprof",
+#endif
 #ifdef WIN32
     "manager.modules.C++.suffixes",           "dll",
 #else


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

## Description of the Change

DefaultConfiguration.hのrtcd、rtcprofコマンドが、Linux環境ではrtcd2、rtcprof2になるため修正した。





## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
