### PR TITLE
RTC::CameraImage<->sensor_msgs/Imageの変換を正常に実行するための修正

### DIFF
--- a/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
@@ -759,10 +759,19 @@ namespace RTC
       }
       m_msg.step = 1920;
       m_msg.data.resize(data.pixels.length());
+      CORBA::ULong image_size = data.pixels.length() / 3;
+      for(CORBA::ULong i=0;i < image_size;i++)
+      {
+        m_msg.data[i*3] = data.pixels[i*3+2];
+        m_msg.data[i*3+1] = data.pixels[i*3+1];
+        m_msg.data[i*3+2] = data.pixels[i*3];
+      }
+      /*
       if(m_msg.data.size() > 0)
       {
         memcpy(&m_msg.data[0], &data.pixels[0], data.pixels.length());
       }
+      */
 
       
       return ROS2SerializerBase<RTC::CameraImage>::sensormsg_serialize(m_msg);
@@ -807,10 +816,19 @@ namespace RTC
 
       data.pixels.length((CORBA::ULong)m_msg.data.size());
       
+      CORBA::ULong image_size = data.pixels.length() / 3;
+      for(CORBA::ULong i=0;i < image_size;i++)
+      {
+        data.pixels[i*3+2] = m_msg.data[i*3];
+        data.pixels[i*3+1] = m_msg.data[i*3+1];
+        data.pixels[i*3] = m_msg.data[i*3+2];
+      }
+      /*
       if(data.pixels.length() > 0)
       {
         memcpy(&data.pixels[0], &m_msg.data[0], data.pixels.length());
       }
+      */
 
       return ret;
     }

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -794,10 +794,19 @@ namespace RTC
       }
       m_msg.step = 1920;
       m_msg.data.resize(data.pixels.length());
+      CORBA::ULong image_size = data.pixels.length() / 3;
+      for(CORBA::ULong i=0;i < image_size;i++)
+      {
+        m_msg.data[i*3] = data.pixels[i*3+2];
+        m_msg.data[i*3+1] = data.pixels[i*3+1];
+        m_msg.data[i*3+2] = data.pixels[i*3];
+      }
+      /*
       if(data.pixels.length() > 0)
       {
           memcpy(&m_msg.data[0], &data.pixels[0], data.pixels.length());
       }
+      */
       
       ROSSerializerBase<RTC::CameraImage>::m_message = ros::serialization::serializeMessage<sensor_msgs::Image>(m_msg);
 
@@ -842,10 +851,20 @@ namespace RTC
 
       data.pixels.length(static_cast<CORBA::ULong>(m_msg.data.size()));
       
+      CORBA::ULong image_size = data.pixels.length() / 3;
+      for(CORBA::ULong i=0;i < image_size;i++)
+      {
+        data.pixels[i*3+2] = m_msg.data[i*3];
+        data.pixels[i*3+1] = m_msg.data[i*3+1];
+        data.pixels[i*3] = m_msg.data[i*3+2];
+      }
+
+      /*
       if(m_msg.data.size() > 0)
       {
           memcpy(&data.pixels[0], &m_msg.data[0], data.pixels.length());
       }
+      */
       return true;
     }
   };


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

RTC::CameraImage型は画像データをRGB、sensor_msgs/Image型は画像データをBGRで表現するが、RTC::CameraImageとsensor_msgs/Imageの変換でデータをそのままコピーしていたため色がおかしくなっていた。


## Description of the Change

変換時に順番を入れ替えてコピーするように修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
