### PR TITLE
Ubuntu用一括インストールスクリプトの出力メッセージ見直し

### DIFF
--- a/scripts/openrtm2_install_ubuntu.sh
+++ b/scripts/openrtm2_install_ubuntu.sh
@@ -14,7 +14,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.0.00
+VERSION=2.0.0.01
 FILENAME=openrtm2_install_ubuntu.sh
 
 #
@@ -138,7 +138,7 @@ err_message=""
 
 check_arg()
 {
-  local arg=$1
+  local arg=$1 tmp
   arg_err=0
   
   case "$arg" in
@@ -146,15 +146,18 @@ check_arg()
     c++ ) arg_cxx=true ;;
     python ) arg_python=true ;;
     java ) arg_java=true ;;
-    openrtp ) arg_openrtp=true ;;
+    openrtp ) arg_openrtp=true
+              if test "x${ARCH}" = "xaarch64"; then
+                arg_openrtp=false
+                msg="[WARNING] openrtp is not supported in aarch64 environment."
+                echo $msg
+                tmp="$err_message$LF$msg"
+                err_message=$tmp
+              fi
+	      shift ;;
     rtshell ) arg_rtshell=true ;;
     *) arg_err=-1 ;;
   esac
-
-  if test "x${ARCH}" = "xaarch64"; then
-    arg_openrtp=false
-    echo "[wARNING] openrtp is not supported in aarch64 environment."
-  fi
 }
 
 check_ros_arg()
@@ -580,6 +583,8 @@ u_java_core_pkgs="$omni_runtime"
 #---------------------------------------
 install_proc()
 {
+  local msg tmp
+
   if test "x$arg_cxx" = "xtrue" ; then
     if test "x$OPT_COREDEVEL" = "xtrue" ; then
       select_opt_c="[c++] install tool_packages for core developer"
@@ -646,8 +651,14 @@ install_proc()
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] install"
     install_packages python3-pip
-    rtshell_ret=`sudo pip3 install rtshell-aist`
-    sudo rtshell_post_install -n
+    rtshell_ret=`sudo python3 -m pip install rtshell-aist`
+    if test "x$rtshell_ret" != "x"; then
+      sudo rtshell_post_install -n
+    else
+      msg="\n[ERROR] Failed to install rtshell-aist."
+      tmp="$err_message$msg"
+      err_message=$tmp
+    fi
   fi
 }
 
@@ -656,6 +667,8 @@ install_proc()
 #---------------------------------------
 uninstall_proc()
 {
+  local msg tmp
+
   if test "x$arg_cxx" = "xtrue" ; then
     if test "x$OPT_COREDEVEL" = "xtrue" ; then
       select_opt_c="[c++] uninstall tool_packages for core developer"
@@ -718,7 +731,12 @@ uninstall_proc()
 
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] uninstall"
-    rtshell_ret=`sudo pip3 uninstall -y rtshell-aist rtctree-aist rtsprofile-aist`
+    rtshell_ret=`sudo python3 -m pip uninstall -y rtshell-aist rtctree-aist rtsprofile-aist`
+    if test "x$rtshell_ret" = "x"; then
+      msg="\n[ERROR] Failed to uninstall rtshell-aist."
+      tmp="$err_message$msg"
+      err_message=$tmp
+    fi
   fi
 }
 
@@ -841,7 +859,9 @@ if test "x$arg_all" = "xtrue" &&
   arg_java=true
   if test "x${ARCH}" = "xaarch64"; then
     arg_openrtp=false
-    echo "[WARNING] openrtp is not supported in aarch64 environment."
+    msg="[WARNING] openrtp is not supported in aarch64 environment."
+    tmp="$err_message$LF$msg"
+    err_message=$tmp
   else
     arg_openrtp=true
   fi
@@ -865,12 +885,6 @@ else
   uninstall_proc
 fi
 
-install_result $install_pkgs
-uninstall_result $uninstall_pkgs
-if test ! "x$err_message" = "x" ; then
-  echo $err_message
-fi
-
 # install openjdk-8-jdk
 if test "x$OPT_UNINST" = "xtrue" ; then
   sudo apt -y install openjdk-8-jdk
@@ -883,6 +897,14 @@ if test "x$OPT_COREDEVEL" = "xtrue" ; then
   systemctl start td-agent-bit
 fi
 
+install_result $install_pkgs
+uninstall_result $uninstall_pkgs
+if test ! "x$err_message" = "x" ; then
+  ESC=$(printf '\033')
+  echo $LF
+  echo "${ESC}[33m${err_message}${ESC}[m"
+fi
+
 ESC=$(printf '\033')
 if test "x$OPT_UNINST" = "xtrue" &&
    test "x$arg_cxx" = "xtrue" &&
@@ -890,6 +912,7 @@ if test "x$OPT_UNINST" = "xtrue" &&
   msg1='To use the log collection extension using the Fluentd logger,'
   msg2='please install Fluent Bit by following the steps on the following web page.'
   msg3='https://docs.fluentbit.io/manual/installation/linux/ubuntu'
+  echo $LF
   echo "${ESC}[33m${msg1}${ESC}[m"
   echo "${ESC}[33m${msg2}${ESC}[m"
   echo "${ESC}[33m${msg3}${ESC}[m"
@@ -897,6 +920,7 @@ fi
 if test "x$OPT_UNINST" = "xfalse" ; then
   msg1='omniorb or other OpenRTM dependent packages may still exist. '
   msg2='If you want to remove them, please do “apt autoremove” later.'
+  echo $LF
   echo "${ESC}[33m${msg1}${ESC}[m"
   echo "${ESC}[33m${msg2}${ESC}[m"
 fi


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1059 
## Identify the Bug

Link to #1059 

## Description of the Change
- Issueに記載した修正を、OpenRTM1.2系、2.0系の下記スクリプトへ加えた
  - pkg_install_ubuntu.sh
  - openrtm2_install_ubuntu.sh
- pipでのrtshellインストール・アンインストールに失敗した場合、インストール結果一覧表示後に黄文字で下記メッセージを出力するようにした
```
[ERROR] Failed to install rtshell-aist.
     or
[ERROR] Failed to uninstall rtshell-aist.
```



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- pipでのrtshellインストールがエラーになるように、存在しないパッケージ名を指定しての動作を確認した
- aarch64環境で、下記コマンドを実行することで下記動作を確認した
  - ERROR, WARNING合計が複数の場合、出力メッセージごとに改行される
  - -lオプションを複数個指定した場合でもopenrtpのWARNINGは1回しか出力しない
  ```
  $ sh pkg_install_ubuntu.sh -l openrtp -l rtshell
        :
  =============================================
   Uninstall package is ...
  =============================================
  There is no uninstall package.

  [WARNING] openrtp is not supported in aarch64 environment.
  [ERROR] Failed to install rtshell-aist.
  ```
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
