### PR TITLE
Raspberry Pi OS用OpenRTM2.0のdebパッケージ生成に関する修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -986,11 +986,10 @@ get_dist(DIST_NAME)
 message(STATUS "Distribution is ${DIST_NAME}")
 
 if(UNIX)
+  if(${DIST_NAME} MATCHES "Ubuntu")
     configure_file(${PROJECT_SOURCE_DIR}/packages/deb/debian/rules.in
 	 ${PROJECT_BINARY_DIR}/rules @ONLY
     )
-
-  if(${DIST_NAME} MATCHES "Ubuntu")
     file(STRINGS "/etc/os-release" data_list REGEX "^(VERSION_CODENAME)=")
 
     # Look for lines like VERSION_CODENAME="..."
@@ -1003,6 +1002,9 @@ if(UNIX)
       endif()
     endforeach()
   else()
+    configure_file(${PROJECT_SOURCE_DIR}/packages/deb/debian/rules.not-ros-support.in
+	 ${PROJECT_BINARY_DIR}/rules @ONLY
+    )
     configure_file(${PROJECT_SOURCE_DIR}/packages/deb/debian/control.not-ros-support
          ${PROJECT_BINARY_DIR}/control @ONLY
     )

--- a/packages/deb/debian/rules.not-ros-support.in
+++ b/packages/deb/debian/rules.not-ros-support.in
@@ -1,0 +1,179 @@
+#!/usr/bin/make -f
+# -*- makefile -*-
+# Sample debian/rules that uses debhelper.
+#
+# This file was originally written by Joey Hess and Craig Small.
+# As a special exception, when this file is copied by dh-make into a
+# dh-make output file, you may use that output file without restriction.
+# This special exception was added by Craig Small in version 0.37 of dh-make.
+#
+# Modified to make a template file for a multi-binary package with separated
+# build-arch and build-indep targets  by Bill Allombert 2001
+
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
+
+# This has to be exported to make some magic below work.
+export DH_OPTIONS
+
+INSTALL_PREFIX = @CMAKE_INSTALL_PREFIX@
+RTM_LIB_DIR=@INSTALL_RTM_LIB_DIR@
+RTM_EXT_DIR=@INSTALL_RTM_EXT_DIR@
+
+# These are used for cross-compiling and for saving the configure script
+# from having to guess our platform (since we know it already)
+DEB_HOST_GNU_TYPE   ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
+DEB_BUILD_GNU_TYPE  ?= $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
+
+# Multiarch support
+DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+
+# short version number
+SHORT_VER := $(shell dpkg-parsechangelog | sed -n 's/^Version: //p' | cut -b 1-3)
+
+CFLAGS = -Wall -g
+
+ifneq (,$(findstring noopt,$(DEB_BUILD_OPTIONS)))
+	CFLAGS += -O0
+else
+	CFLAGS += -O2
+endif
+
+TARGET = $(CURDIR)/debian/openrtm2/usr
+TARGET_dev = $(CURDIR)/debian/openrtm2-dev/usr
+TARGET_idl = $(CURDIR)/debian/openrtm2-idl/usr
+TARGET_example = $(CURDIR)/debian/openrtm2-example/usr
+TARGET_doc = $(CURDIR)/debian/openrtm2-doc/usr
+
+#Architecture 
+build: build-arch build-indep
+
+build-arch: build-arch-stamp
+build-arch-stamp:
+
+	# Add here commands to compile the arch part of the package.
+	#$(MAKE) 
+	touch $@
+
+build-indep: build-indep-stamp
+build-indep-stamp:
+
+	# Add here commands to compile the indep part of the package.
+	#$(MAKE) doc
+	touch $@
+
+clean:
+	dh_testdir
+	dh_testroot
+	rm -f build-arch-stamp build-indep-stamp #CONFIGURE-STAMP#
+
+	# Add here commands to clean up after the build process.
+	# -$(MAKE) distclean
+	#rm -f config.sub config.guess
+
+	dh_clean 
+
+install: install-indep install-arch
+install-indep:
+	dh_testdir
+	dh_testroot
+	dh_clean -k -i 
+	dh_installdirs -i
+
+	# Add here commands to install the indep part of the package into
+	# debian/<package>-doc.
+	#INSTALLDOC#
+	# for openrtm-aist-doc package
+	(mkdir -p $(TARGET_doc)/share/openrtm-$(SHORT_VER))
+	(cp -r $(INSTALL_PREFIX)/share/openrtm-$(SHORT_VER)/doc $(TARGET_doc)/share/openrtm-$(SHORT_VER))	
+	dh_install -i
+
+install-arch:
+	dh_testdir
+	dh_testroot
+	dh_clean -k -s 
+	dh_installdirs -s
+
+	# Add here commands to install the arch part of the package into 
+	# debian/tmp.
+
+	# for openrtm-aist package
+	(mkdir -p $(TARGET)/bin)
+	(cp $(INSTALL_PREFIX)/bin/rtcd2 $(TARGET)/bin)
+	(cp $(INSTALL_PREFIX)/bin/rtcprof2 $(TARGET)/bin)
+	(cp $(INSTALL_PREFIX)/bin/rtm-config2 $(TARGET)/bin)
+	(cp $(INSTALL_PREFIX)/bin/rtm2-naming $(TARGET)/bin)
+	(cp -r $(INSTALL_PREFIX)/etc $(TARGET))
+	(mkdir -p $(TARGET)/${RTM_EXT_DIR})
+	(cp -R $(INSTALL_PREFIX)/${RTM_LIB_DIR}/*.so* $(TARGET)/${RTM_LIB_DIR})
+	(cp $(INSTALL_PREFIX)/${RTM_LIB_DIR}/*.a $(TARGET)/${RTM_LIB_DIR})
+	(rm $(TARGET)/${RTM_LIB_DIR}/libhrtm*)
+	(cp -r $(INSTALL_PREFIX)/${RTM_EXT_DIR} $(TARGET)/${RTM_LIB_DIR})
+	(rm -r $(TARGET)/${RTM_EXT_DIR}/cmake)
+	(rm -r $(TARGET)/${RTM_EXT_DIR}/py_helper)
+	(cp -r $(INSTALL_PREFIX)/${RTM_LIB_DIR}/pkgconfig $(TARGET)/${RTM_LIB_DIR})
+
+	# for openrtm-dev package
+	(mkdir -p $(TARGET_dev)/bin)
+	(cp $(INSTALL_PREFIX)/bin/rtm-skelwrapper2 $(TARGET_dev)/bin)
+	(cp -r $(INSTALL_PREFIX)/include $(TARGET_dev))
+	(rm -r $(TARGET_dev)/include/openrtm-$(SHORT_VER)/hrtm)
+	(mkdir -p $(TARGET_dev)/${RTM_EXT_DIR})
+	(cp -r $(INSTALL_PREFIX)/${RTM_EXT_DIR}/cmake $(TARGET_dev)/${RTM_EXT_DIR})
+	(cp -r $(INSTALL_PREFIX)/${RTM_EXT_DIR}/py_helper $(TARGET_dev)/${RTM_EXT_DIR})
+
+	# for openrtm-aist-idl package
+	(mkdir -p $(TARGET_idl)/include/openrtm-$(SHORT_VER)/rtm/idl)
+	(mv $(TARGET_dev)/include/openrtm-$(SHORT_VER)/rtm/idl/*.idl $(TARGET_idl)/include/openrtm-$(SHORT_VER)/rtm/idl)
+	(mkdir -p $(TARGET_idl)/share/openrtm-$(SHORT_VER)/idl)
+	(cp $(TARGET_idl)/include/openrtm-$(SHORT_VER)/rtm/idl/* $(TARGET_idl)/share/openrtm-$(SHORT_VER)/idl)
+	(mkdir -p $(CURDIR)/debian/openrtm2-idl/etc/profile.d)
+	(echo "export RTM_IDL_DIR2=/usr/share/openrtm-$(SHORT_VER)/idl" > $(CURDIR)/debian/openrtm2-idl/etc/profile.d/openrtm2-idl.sh)
+
+	# for openrtm-aist-example package
+	(mkdir -p $(TARGET_example)/share/openrtm-$(SHORT_VER))
+	(cp -R $(INSTALL_PREFIX)/share/openrtm-$(SHORT_VER)/components $(TARGET_example)/share/openrtm-$(SHORT_VER))
+
+	dh_install -s
+# Must not depend on anything. This is to be called by
+# binary-arch/binary-indep
+# in another 'make' thread.
+binary-common:
+	dh_testdir
+	dh_testroot
+#	dh_installchangelogs ChangeLog
+#	dh_installdocs
+	dh_installexamples
+#	dh_installmenu
+#	dh_installdebconf	
+#	dh_installlogrotate	
+#	dh_installemacsen
+#	dh_installpam
+#	dh_installmime
+#	dh_python
+#	dh_installinit
+#	dh_installcron
+#	dh_installinfo
+	dh_installman
+	dh_link
+	dh_strip
+	dh_compress 
+	dh_fixperms
+#	dh_perl
+	dh_makeshlibs
+	dh_installdeb
+	dh_shlibdeps
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
+# Build architecture independant packages using the common target.
+binary-indep: build-indep install-indep
+	$(MAKE) -f debian/rules DH_OPTIONS=-i binary-common
+
+# Build architecture dependant packages using the common target.
+binary-arch: build-arch install-arch
+	$(MAKE) -f debian/rules DH_OPTIONS=-s binary-common
+
+binary: binary-arch binary-indep
+.PHONY: build clean binary-indep binary-arch binary install install-indep install-arch 
+

--- a/packages/deb/dpkg_build.sh
+++ b/packages/deb/dpkg_build.sh
@@ -56,7 +56,7 @@ check_codename ()
       else
         DISTRIB_CODENAME=`lsb_release -cs`
       fi
-    else
+    elif test ! "x$ID" = "xraspbian" ; then 
       echo "This distribution may not be debian."
       exit
     fi


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1061 
## Identify the Bug

Link to #1061 

## Description of the Change

- Raspberry Pi OS用のrules.not-ros-support.inを新設し、 ROSTransportのdebパッケージを生成しないように定義
- 一番トップのCMakeLists.txtにて、rulesファイル生成処理を次のように修正した
  - Ubuntuの場合は、rules.inからrulesを生成する
  - Ubuntu以外は、rules.not-ros-support.inからrulesを生成する

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Raspbian buster 32bit環境（OS：2022-04-04-raspios-buster-armhf-lite.img）でOpenRTM2.0のdebパッケージ生成動作を確認
- Ubuntu20.04でOpenRTM2.0のdebパッケージ生成が問題なくできることを確認
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
