### PR TITLE
Raspbian用一括インストールスクリプトのOpenRTM2.0対応

### DIFF
--- a/scripts/openrtm2_install_raspbian.sh
+++ b/scripts/openrtm2_install_raspbian.sh
@@ -8,6 +8,7 @@
 
 VERSION=2.0.0.01
 FILENAME=openrtm2_install_raspbian.sh
+BIT=`getconf LONG_BIT`
 
 #---------------------------------------
 # usage
@@ -64,11 +65,11 @@ autotools="autoconf libtool libtool-bin"
 base_tools="bc iputils-ping net-tools zip"
 common_devel="python3-yaml"
 cxx_devel="gcc g++ make $common_devel"
-cmake_tools="cmake doxygen"
+cmake_tools="cmake doxygen graphviz nkf"
 build_tools="subversion git"
 deb_pkg="uuid-dev libboost-filesystem-dev"
 pkg_tools="build-essential debhelper devscripts"
-fluentbit="td-agent-bit"
+#fluentbit="td-agent-bit"
 omni_devel="libomniorb4-dev omniidl"
 omni_runtime="omniorb-nameserver"
 openrtm2_devel="openrtm2-doc openrtm2-idl openrtm2-dev"
@@ -340,7 +341,7 @@ check_reposerver()
 #---------------------------------------
 create_srclist () {
   openrtm_repo="deb http://$reposerver/pub/Linux/raspbian/ $code_name main"
-  fluent_repo="deb https://packages.fluentbit.io/raspbian/$code_name $code_name main"
+  #fluent_repo="deb https://packages.fluentbit.io/raspbian/$code_name $code_name main"
 }
 
 #---------------------------------------
@@ -367,16 +368,16 @@ update_source_list () {
   else
     sudo apt install dirmngr
   fi
-  fluentsite=`apt-cache policy | grep "https://packages.fluentbit.io"`
-  if test "x$fluentsite" = "x" &&
-     test "x$OPT_CORE" = "xtrue" ; then
-    echo $fluent_repo | sudo tee -a /etc/apt/sources.list
-  fi  
+#  fluentsite=`apt-cache policy | grep "https://packages.fluentbit.io"`
+#  if test "x$fluentsite" = "x" &&
+#     test "x$OPT_CORE" = "xtrue" ; then
+#    echo $fluent_repo | sudo tee -a /etc/apt/sources.list
+#  fi
 　# 公開鍵登録
   wget -O- --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key | sudo apt-key add -
-  if test "x$OPT_CORE" = "xtrue" ; then
-    wget -O - https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -
-  fi
+#  if test "x$OPT_CORE" = "xtrue" ; then
+#    wget -O - https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -
+#  fi
 }
 
 #----------------------------------------
@@ -487,7 +488,8 @@ u_src_pkgs="$omni_runtime $omni_devel"
 dev_pkgs="$runtime_pkgs $src_pkgs $openrtm2_devel"
 u_dev_pkgs="$u_runtime_pkgs $openrtm2_devel"
 
-core_pkgs="$src_pkgs $build_tools $pkg_tools $fluentbit"
+#core_pkgs="$src_pkgs $build_tools $pkg_tools $fluentbit"
+core_pkgs="$src_pkgs $build_tools $pkg_tools"
 u_core_pkgs="$u_src_pkgs"
 
 
@@ -540,9 +542,9 @@ install_proc()
     if test "x$OPT_CORE" = "xtrue" ; then
       select_opt_p="[python] install tool_packages for core developer"
       install_packages $python_core_pkgs
-      pip3 install fluent-logger
-      tmp_pkg="$install_pkgs fluent-logger"
-      install_pkgs=$tmp_pkg
+      #pip3 install fluent-logger
+      #tmp_pkg="$install_pkgs fluent-logger"
+      #install_pkgs=$tmp_pkg
     elif test "x$OPT_RT" = "xtrue" ; then
       select_opt_p="[python] install robot component runtime"
       install_packages $python_runtime_pkgs
@@ -774,16 +776,17 @@ else
 fi
 
 # install openjdk-8-jdk
-if test "x$OPT_FLG" = "xtrue" ; then
+if test "x$OPT_FLG" = "xtrue" &&
+   test "x$BIT" = "x32" ; then
   sudo apt -y install openjdk-8-jdk
   JAVA8=`update-alternatives --list java | grep java-8`
   sudo update-alternatives --set java ${JAVA8}
 fi
 
-if test "x$OPT_CORE" = "xtrue" ; then
-  systemctl enable td-agent-bit
-  systemctl start td-agent-bit
-fi
+#if test "x$OPT_CORE" = "xtrue" ; then
+#  systemctl enable td-agent-bit
+#  systemctl start td-agent-bit
+#fi
 
 install_result $install_pkgs
 uninstall_result $uninstall_pkgs
@@ -793,18 +796,18 @@ if test ! "x$err_message" = "x" ; then
   echo "${ESC}[33m${err_message}${ESC}[m"
 fi
 
-ESC=$(printf '\033')
-if test "x$OPT_FLG" = "xtrue" &&
-   test "x$arg_cxx" = "xtrue" &&
-   test "x$OPT_COREDEVEL" = "xfalse" ; then
-  msg1='To use the log collection extension using the Fluentd logger,'
-  msg2='please install Fluent Bit by following the steps on the following web page.'
-  msg3='https://docs.fluentbit.io/manual/installation/linux/raspbian-raspberry-pi'
-  echo $LF
-  echo "${ESC}[33m${msg1}${ESC}[m"
-  echo "${ESC}[33m${msg2}${ESC}[m"
-  echo "${ESC}[33m${msg3}${ESC}[m"
-fi
+#ESC=$(printf '\033')
+#if test "x$OPT_FLG" = "xtrue" &&
+#   test "x$arg_cxx" = "xtrue" &&
+#   test "x$OPT_COREDEVEL" = "xfalse" ; then
+#  msg1='To use the log collection extension using the Fluentd logger,'
+#  msg2='please install Fluent Bit by following the steps on the following web page.'
+#  msg3='https://docs.fluentbit.io/manual/installation/linux/raspbian-raspberry-pi'
+#  echo $LF
+#  echo "${ESC}[33m${msg1}${ESC}[m"
+#  echo "${ESC}[33m${msg2}${ESC}[m"
+#  echo "${ESC}[33m${msg3}${ESC}[m"
+#fi
 if test "x$OPT_FLG" = "xfalse" ; then
   ESC=$(printf '\033')
   msg1='omniorb or other OpenRTM dependent packages may still exist. '


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1063 
## Identify the Bug

Link to #1063 
Issue内容に加え、下記を変更。
- docパッケージ生成用に graphvizとnkf のインストール追加
- bullseye 64bit環境はaptでopenjdk8をインストールできないため、32bit環境のみインストールするようにした（getconf LONG_BITの結果で判定）
- インストール対象からFulentbitを除外。理由は、buster, bullseyeの各32bit環境は対応しているが、bullseyeの64bit環境で対応していないため。
- Fluentbit関連処理は何か所もあるため、今後の利用可能時に対応できるようにコメントアウトとした
  - td-agent-bitパッケージは、bullseyeの64bit環境で提供されていない
  - bullseyeの64bit環境でのFluentbitソースビルドでcmakeエラーになる
  ```
  $ cd ~/fluent-bit-1.8.9/build
  $ cmake -DFLB_RELEASE=On -DFLB_TRACE=Off -DFLB_JEMALLOC=On -DFLB_TLS=On -DFLB_SHARED_LIB=On -DFLB_EXAMPLES=Off -DFLB_HTTP_SERVER=On -DFLB_IN_SYSTEMD=On -DFLB_OUT_KAFKA=On -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/home/vagrant/flb/install ..
   :
  -- Check for working C compiler: /usr/bin/cc - broken
  CMake Error at /usr/share/cmake-3.18/Modules/CMakeTestCCompiler.cmake:66 (message):
    The C compiler

      "/usr/bin/cc"

    is not able to compile a simple test program.
  ```




## Description of the Change
- この修正が反映されれば下記手順でインストール可能
  - オプション指定無しなので、-l all で実行した場合と同じで全てがインストールされる
```
$ bash <(curl -s https://raw.githubusercontent.com/OpenRTM/OpenRTM-aist/master/scripts/pkg_install_raspbian.sh)
$ bash <(curl -s https://raw.githubusercontent.com/OpenRTM/OpenRTM-aist/master/scripts/openrtm2_install_raspbian.sh)
```



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 現時点で、まだOpenRTM2.0用debパッケージはアップロードされていないので、本スクリプトを実行してもインストールできない
- テストリポジトリを使った場合の、OpenRTM2.0の本スクリプトによる全パッケージインストール結果は以下の通り
- 現時点でテストリポジトリにアップロードしているのは、Raspbian buster(armhf)用パッケージのみなので、この環境で確認
```
$ dpkg -l | grep openrt
ii  openrtm2:armhf                       2.0.0-0                                 armhf        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm2-dev:armhf                   2.0.0-0                                 armhf        OpenRTM-aist headers for development
ii  openrtm2-doc                         2.0.0-0                                 all          Documentation for openrtm2
ii  openrtm2-example:armhf               2.0.0-0                                 armhf        OpenRTM-aist examples
ii  openrtm2-idl:armhf                   2.0.0-0                                 armhf        OpenRTM-aist idls for development
ii  openrtm2-java:armhf                  2.0.0-0                                 armhf        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm2-java-doc                    2.0.0-0                                 all          Documentation for openrtm2-java
ii  openrtm2-java-example:armhf          2.0.0-0                                 armhf        OpenRTM-aist-Java examples
ii  openrtm2-python3                     2.0.0-0                                 armhf        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm2-python3-doc                 2.0.0-0                                 all          Documentation for openrtm2-python3
ii  openrtm2-python3-example             2.0.0-0                                 armhf        OpenRTM-aist-Python examples
```
- 続けて、本PR作成用ブランチのOpenRTM1.2用スクリプトを実行すると、C++のみ2.0と1.2のパッケージが共存できることを確認
```
$ bash <(curl -s https://raw.githubusercontent.com/n-kawauchi/OpenRTM-aist/raspbian_install_script/scripts/pkg_install_raspbian.sh)
$ dpkg -l | grep openrt
ii  openrtm-aist:armhf                   1.2.2-0                                 armhf        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm-aist-dev:armhf               1.2.2-0                                 armhf        OpenRTM-aist headers for development
ii  openrtm-aist-doc                     1.2.2-0                                 all          Documentation for openrtm-aist
ii  openrtm-aist-example:armhf           1.2.2-0                                 armhf        OpenRTM-aist examples
ii  openrtm-aist-idl:armhf               1.2.2-0                                 armhf        OpenRTM-aist idls for development
ii  openrtm-aist-java:armhf              1.2.2-0                                 armhf        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm-aist-java-doc                1.2.2-0                                 all          Documentation for openrtm-aist-java
ii  openrtm-aist-java-example:armhf      1.2.2-0                                 armhf        OpenRTM-aist-Java examples
ii  openrtm-aist-python3                 1.2.2-0                                 armhf        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm-aist-python3-doc             1.2.2-0                                 all          Documentation for openrtm-aist-python
ii  openrtm-aist-python3-example         1.2.2-0                                 armhf        OpenRTM-aist-Python examples
ii  openrtm2:armhf                       2.0.0-0                                 armhf        OpenRTM-aist, RT-Middleware distributed by AIST
ii  openrtm2-dev:armhf                   2.0.0-0                                 armhf        OpenRTM-aist headers for development
ii  openrtm2-doc                         2.0.0-0                                 all          Documentation for openrtm2
ii  openrtm2-example:armhf               2.0.0-0                                 armhf        OpenRTM-aist examples
ii  openrtm2-idl:armhf                   2.0.0-0                                 armhf        OpenRTM-aist idls for development
```
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
