### PR TITLE
g_last_error_messageが未定義シンボルのためエラーになる問題の修正

### DIFF
--- a/src/ext/transport/ROSTransport/ROSTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.cpp
@@ -36,6 +36,8 @@ namespace ros
   }
 }
 
+std::string ros::console::g_last_error_message = "Unknown Error";
+
 
 namespace RTC
 {

--- a/src/ext/transport/ROSTransport/ROSTopicManager.cpp
+++ b/src/ext/transport/ROSTransport/ROSTopicManager.cpp
@@ -32,7 +32,40 @@ namespace ros
 {
   namespace network
   {
-    void init(const M_string& remappings);
+    void init(const M_string& remappings)
+    {
+      M_string::const_iterator it = remappings.find("__hostname");
+      if (it != remappings.end())
+      {
+        g_host = it->second;
+      }
+      else
+      {
+        it = remappings.find("__ip");
+        if (it != remappings.end())
+        {
+          g_host = it->second;
+        }
+      }
+
+      it = remappings.find("__tcpros_server_port");
+      if (it != remappings.end())
+      {
+        try
+        {
+          g_tcpros_server_port = boost::lexical_cast<uint16_t>(it->second);
+        }
+        catch (boost::bad_lexical_cast&)
+        {
+          throw ros::InvalidPortException("__tcpros_server_port [" + it->second + "] was not specified as a number within the 0-65535 range");
+        }
+      }
+
+      if (g_host.empty())
+      {
+        g_host = determineHost();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROSTransport.soをロードすると、変数g_last_error_messageの未定義シンボルでエラーになることがある。
Windowsではこの問題は確認済みだが、Ubuntu 18.04でも発生する場合がある。

rosconsole.cppのソースコードを見る限り、g_last_error_messageは定義されており、原因不明。
- https://github.com/ros/rosconsole/blob/melodic-devel/src/rosconsole/rosconsole.cpp

また、他に以下のシンボルエラーが発生する。

```
/usr/share/openrtm-2.0/components/c++/examples/ConsoleOutComp: symbol lookup error: /usr/lib/x86_64-linux-gnu/openrtm-2.0/transport/ROSTransport.so: undefined symbol: _ZN3ros7network4initERKSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_St4lessIS7_ESaISt4pairIKS7_S7_EEE
```

## Description of the Change

場当たり的ではあるが、ROSTopicManager.cpp内で変数を定義することで対応した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
