### PR TITLE
Raspberry Pi用インストールスクリプトからJavaパッケージを除外

### DIFF
--- a/scripts/openrtm2_install_raspbian.sh
+++ b/scripts/openrtm2_install_raspbian.sh
@@ -6,7 +6,7 @@
 #         Nobu Kawauchi
 #
 
-VERSION=2.0.0.01
+VERSION=2.0.0.02
 FILENAME=openrtm2_install_raspbian.sh
 BIT=`getconf LONG_BIT`
 
@@ -18,21 +18,20 @@ usage()
   cat <<EOF
   Usage: 
 
-    $(FILENAME) -l {all|c++} [-r|-d|-s|-c] [-u|--yes]
-    $(FILENAME) [-u]
-    $(FILENAME) -l {python} [-r|-d|-c] [-u|--yes]
-    $(FILENAME) -l {java} [-r|-d|-c] [-u|--yes]
-    $(FILENAME) -l {rtshell} [-d] [-u|--yes]
-    $(FILENAME) {--help|-h|--version}
+    ${FILENAME} -l {all|c++} [-r|-d|-s|-c] [-u|--yes]
+    ${FILENAME} [-u]
+    ${FILENAME} -l {python} [-r|-d|-c] [-u|--yes]
+    ${FILENAME} -l {rtshell} [-d] [-u|--yes]
+    ${FILENAME} {--help|-h|--version}
 
   Example:
-    $(FILENAME) [= $(FILENAME) -l all -d]
-    $(FILENAME) -l all -d
-    $(FILENAME) -l c++ -c --yes
-    $(FILENAME) -l all -u
+    ${FILENAME} [= ${FILENAME} -l all -d]
+    ${FILENAME} -l all -d
+    ${FILENAME} -l c++ -c --yes
+    ${FILENAME} -l all -u
 
   Options:
-    -l <argument>  language or tool [c++|python|java|rtshell|all]
+    -l <argument>  language or tool [c++|python|rtshell|all]
         all        install packages of all the supported languages and tools
     -r             install robot component runtime
     -d             install robot component developer [default]
@@ -118,7 +117,7 @@ check_arg()
     all ) arg_all=true ;;
     c++ ) arg_cxx=true ;;
     python ) arg_python=true ;;
-    java ) arg_java=true ;;
+#    java ) arg_java=true ;;
     rtshell ) arg_rtshell=true ;;
     *) arg_err=-1 ;;
   esac
@@ -733,11 +732,11 @@ get_opt $@
 if test "x$arg_all" = "xfalse" ; then
   if test "x$arg_cxx" = "xfalse" ; then
     if test "x$arg_python" = "xfalse" ; then
-      if test "x$arg_java" = "xfalse" ; then
+#      if test "x$arg_java" = "xfalse" ; then
         if test "x$arg_rtshell" = "xfalse" ; then
           exit
         fi
-      fi
+#      fi
     fi
   fi
 fi
@@ -754,7 +753,7 @@ if test "x$arg_all" = "xtrue" &&
    test "x$OPT_OLD_RTM" = "xfalse" ; then
   arg_cxx=true
   arg_python=true
-  arg_java=true
+#  arg_java=true
   arg_rtshell=true
 
   if test "x$OPT_RT" != "xtrue" && 
@@ -776,12 +775,12 @@ else
 fi
 
 # install openjdk-8-jdk
-if test "x$OPT_FLG" = "xtrue" &&
-   test "x$BIT" = "x32" ; then
-  sudo apt -y install openjdk-8-jdk
-  JAVA8=`update-alternatives --list java | grep java-8`
-  sudo update-alternatives --set java ${JAVA8}
-fi
+#if test "x$OPT_FLG" = "xtrue" &&
+#   test "x$BIT" = "x32" ; then
+#  sudo apt -y install openjdk-8-jdk
+#  JAVA8=`update-alternatives --list java | grep java-8`
+#  sudo update-alternatives --set java ${JAVA8}
+#fi
 
 #if test "x$OPT_CORE" = "xtrue" ; then
 #  systemctl enable td-agent-bit


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #1074 


## Description of the Change
- スクリプト（openrtm2_install_raspbian.sh）を引数無し（-l all と同等）で実行し、C++, Python, rtshellが問題なくインストールされるように修正した
- Javaパッケージを除外したので、openjdk-8-jdkのインストール処理もコメントアウトした
- Javaパッケージを指定して（-l java）実行した場合、存在しないオプション指定ということでヘルプが表示されることを確認
- ヘルプ（--help）を実行した時の表示不具合を修正した



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 本スクリプトを引数無しで実行し、Raspbian buster(32bit), bullseye(32bit, 64bit)環境でのインストール動作OKを確認した
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
