### PR TITLE
独自のROS、ROS2用シリアライザ作成のためにヘッダファイル、CMake設定ファイルをインストールするように変更

### DIFF
--- a/src/ext/transport/FastRTPS/CMakeLists.txt
+++ b/src/ext/transport/FastRTPS/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
 endif()
 
 
-install(FILES FastRTPSMessageInfo.h DESTINATION ${INSTALL_RTM_INCLUDE_DIR}/rtm/ext COMPONENT ext)
+install(FILES FastRTPSMessageInfo.h DESTINATION ${INSTALL_RTM_INCLUDE_DIR}/rtm/ext/FastRTPS COMPONENT ext)
 
 
 

--- a/src/ext/transport/OpenSplice/CMakeLists.txt
+++ b/src/ext/transport/OpenSplice/CMakeLists.txt
@@ -78,7 +78,7 @@ else()
 endif()
 
 
-install(FILES OpenSpliceMessageInfo.h DESTINATION ${INSTALL_RTM_INCLUDE_DIR}/rtm/ext COMPONENT ext)
+install(FILES OpenSpliceMessageInfo.h DESTINATION ${INSTALL_RTM_INCLUDE_DIR}/rtm/ext/OpenSplice COMPONENT ext)
 
 
 

--- a/src/ext/transport/ROS2Transport/CMakeLists.txt
+++ b/src/ext/transport/ROS2Transport/CMakeLists.txt
@@ -34,6 +34,9 @@ set(target ROS2Transport)
 
 set(srcs ROS2Transport.cpp ROS2Transport.h ROS2MessageInfo.cpp ROS2MessageInfo.h ROS2Serializer.cpp ROS2Serializer.h)
 
+set(INSTALL_ROS2TRANSPORT_LIB_DIR ${INSTALL_RTM_EXT_DIR}/transport)
+set(INSTALL_ROS2TRANSPORT_INCLUDE_DIR ${INSTALL_RTM_INCLUDE_DIR}/rtm/ext)
+set(INSTALL_FASTRTPSTRANSPORT_LIB FastRTPSTransport)
 
 if(VXWORKS AND NOT RTP)
 	set(libs ${RTCSKEL_PROJECT_NAME} fastcdr fastrtps)
@@ -67,9 +70,9 @@ if(VXWORKS AND NOT RTP)
 		)
 	endif()
 
-	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_ROS2TRANSPORT_LIB_DIR}
+				ARCHIVE DESTINATION ${INSTALL_ROS2TRANSPORT_LIB_DIR}
+				RUNTIME DESTINATION ${INSTALL_ROS2TRANSPORT_LIB_DIR}
 				COMPONENT ext)
 else()
 	set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${DATATYPE_FACTORIES} FastRTPSTransport 
@@ -77,7 +80,6 @@ else()
 		${std_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp} 
 		${geometry_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp} 
 		${sensor_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp}
-		${std_msgs_LIBRARIES__rosidl_typesupport_fastrtps_cpp}
 		fastcdr fastrtps)
 	add_library(${target} SHARED ${srcs})
 	openrtm_common_set_compile_props(${target})
@@ -108,12 +110,15 @@ else()
 	set_target_properties(${target} PROPERTIES PREFIX "")
 
 
-	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_ROS2TRANSPORT_LIB_DIR}
+				ARCHIVE DESTINATION ${INSTALL_ROS2TRANSPORT_LIB_DIR}
+				RUNTIME DESTINATION ${INSTALL_ROS2TRANSPORT_LIB_DIR}
 				COMPONENT ext)
 endif()
 
+install(FILES ROS2MessageInfo.h ROS2Serializer.h DESTINATION ${INSTALL_ROS2TRANSPORT_INCLUDE_DIR}/ROS2Transport COMPONENT ext)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ROS2TransportConfig.cmake.in ${PROJECT_BINARY_DIR}/ROS2TransportConfig.cmake @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/ROS2TransportConfig.cmake DESTINATION ${INSTALL_RTM_CMAKE_DIR} COMPONENT cmakefiles)
 
 
 

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.cpp
@@ -25,7 +25,6 @@
 
 
 #include "ROS2Serializer.h"
-#include "ROS2MessageInfo.h"
 
 
 namespace RTC
@@ -49,11 +48,7 @@ namespace RTC
   template <class DataType, class MessageType, typename originalType, typename convertedType>
   void ROS2SimpleDataInitBaseFunc(const char* name)
   {
-    addSerializer<DataType, ROS2SimpleData<DataType, MessageType, originalType, convertedType>>(name);
-
-    GlobalFastRTPSMessageInfoList::
-            instance().addInfo(name,
-            new ROS2MessageInfo<MessageType>());
+    addRos2Serializer<DataType, MessageType, ROS2SimpleData<DataType, MessageType, originalType, convertedType>>(name);
   }
 
   /*!
@@ -103,11 +98,7 @@ namespace RTC
   template <class DataType, class MessageType, typename originalType, typename convertedType>
   void ROS2SequenceDataInitBaseFunc(const char* name)
   {
-    addSerializer<DataType, ROS2SequenceData<DataType, MessageType, originalType, convertedType>>(name);
-
-    GlobalFastRTPSMessageInfoList::
-            instance().addInfo(name,
-            new ROS2MessageInfo<MessageType>());
+    addRos2Serializer<DataType, MessageType, ROS2SequenceData<DataType, MessageType, originalType, convertedType>>(name);
   }
 
   /*!
@@ -257,11 +248,7 @@ namespace RTC
    */
   void ROS2StringDataInit()
   {
-    addSerializer<TimedString, ROS2StringData>("ros2:std_msgs/String");
-
-    GlobalFastRTPSMessageInfoList::
-            instance().addInfo("ros2:std_msgs/String",
-            new ROS2MessageInfo<std_msgs::msg::String>());
+    addRos2Serializer<TimedString, std_msgs::msg::String, ROS2StringData>("ros2:std_msgs/String");
   }
 
   /*!
@@ -393,11 +380,7 @@ namespace RTC
    */
   void ROS2Pont3DDataInit()
   {
-    addSerializer<TimedPoint3D, ROS2Point3DData>("ros2:geometry_msgs/PointStamped");
-
-    GlobalFastRTPSMessageInfoList::
-            instance().addInfo("ros2:geometry_msgs/PointStamped",
-            new ROS2MessageInfo<geometry_msgs::msg::PointStamped>());
+    addRos2Serializer<TimedPoint3D, geometry_msgs::msg::PointStamped, ROS2Point3DData>("ros2:geometry_msgs/PointStamped");
   }
 
   /*!
@@ -530,11 +513,7 @@ namespace RTC
    */
   void ROS2QuaternionDataInit()
   {
-    addSerializer<TimedQuaternion, ROS2QuaternionData>("ros2:geometry_msgs/QuaternionStamped");
-
-    GlobalFastRTPSMessageInfoList::
-            instance().addInfo("ros2:geometry_msgs/QuaternionStamped",
-            new ROS2MessageInfo<geometry_msgs::msg::QuaternionStamped >());
+    addRos2Serializer<TimedQuaternion, geometry_msgs::msg::QuaternionStamped, ROS2QuaternionData>("ros2:geometry_msgs/QuaternionStamped");
   }
 
   /*!
@@ -667,11 +646,7 @@ namespace RTC
    */
   void ROS2Vector3DDataInit()
   {
-    addSerializer<TimedVector3D, ROS2Vector3DData>("ros2:geometry_msgs/Vector3Stamped");
-
-    GlobalFastRTPSMessageInfoList::
-            instance().addInfo("ros2:geometry_msgs/Vector3Stamped",
-            new ROS2MessageInfo<geometry_msgs::msg::Vector3Stamped >());
+    addRos2Serializer<TimedVector3D, geometry_msgs::msg::Vector3Stamped , ROS2Vector3DData>("ros2:geometry_msgs/Vector3Stamped");
   }
 
   

--- a/src/ext/transport/ROS2Transport/ROS2Serializer.h
+++ b/src/ext/transport/ROS2Transport/ROS2Serializer.h
@@ -82,6 +82,7 @@
 #include <sensor_msgs/msg/image__rosidl_typesupport_fastrtps_cpp.hpp>
 #endif
 
+#include "ROS2MessageInfo.h"
 
 namespace RTC
 {
@@ -695,7 +696,31 @@ namespace RTC
       return ret;
     }
   };
-  
+
+  /*!
+   * @if jp
+   *
+   * @brief GlobalFactoryにROS2用シリアライザを追加する
+   * 
+   * @param marshalingtype シリアライザの名称
+   *
+   * @else
+   *
+   * @brief 
+   *
+   * @param marshalingtype 
+   *
+   * @endif
+   */
+  template <class DataType, class MessageType, class SerializerType>
+  void addRos2Serializer(const std::string &marshalingtype)
+  {
+    addSerializer<DataType, SerializerType>(marshalingtype);
+
+    GlobalFastRTPSMessageInfoList::
+            instance().addInfo(marshalingtype,
+            new ROS2MessageInfo<MessageType>());
+  }
 }
 
 

--- a/src/ext/transport/ROS2Transport/ROS2TransportConfig.cmake.in
+++ b/src/ext/transport/ROS2Transport/ROS2TransportConfig.cmake.in
@@ -1,0 +1,51 @@
+# -*- cmake -*-
+#
+# @file ROS2Transport.cmake
+# @brief cmake-config file for ROS2Transport
+#
+# This file is used for cmake config-mode.
+# The following variables are defined.
+#
+# Basic compiler/linker options
+# - ROS2TRANSPORT_CFLAGS: cflags 
+# - ROS2TRANSPORT_INCLUDE_DIRS: include directories
+# - ROS2TRANSPORT_LDFLAGS: linker options
+# - ROS2TRANSPORT_LIBRARY_DIRS: library directories
+# - ROS2TRANSPORT_LIBRARIES: libraries
+# - ROS2TRANSPORT_LIB_DIR: OpenRTM's lib directory
+#
+#
+# ROS2Transport version
+# - ROS2TRANSPORT_VERSION: x.y.z version
+# - ROS2TRANSPORT_VERSION_MAJOR: major version number
+# - ROS2TRANSPORT_VERSION_MINOR: minor version number
+# - ROS2TRANSPORT_VERSION_PATCH: revision number
+# - ROS2TRANSPORT_SHORT_VERSION: short version number 1.1.0->110
+#
+
+
+message(STATUS "ROS2Transport.cmake found.")
+message(STATUS "CMAKE_GENERATOR check mode.")
+
+find_package(OpenRTM @RTM_MAJOR_VERSION@.@RTM_MINOR_VERSION@ REQUIRED)
+
+
+# ROS2Transport version
+set(ROS2TRANSPORT_VERSION @RTM_VERSION@)
+set(ROS2TRANSPORT_VERSION_MAJOR @RTM_MAJOR_VERSION@)
+set(ROS2TRANSPORT_VERSION_MINOR @RTM_MINOR_VERSION@)
+set(ROS2TRANSPORT_VERSION_PATCH @RTM_REVISION_NUM@)
+set(ROS2TRANSPORT_SHORT_VERSION @RTM_VERSION@)
+
+# Basic compiler/linker options
+set(ROS2TRANSPORT_CFLAGS )
+set(ROS2TRANSPORT_INCLUDE_DIRS ${OPENRTM_DIR}/@INSTALL_ROS2TRANSPORT_INCLUDE_DIR@)
+set(ROS2TRANSPORT_LDFLAGS )
+
+set(ROS2TRANSPORT_LIBRARY_DIRS )
+set(ROS2TRANSPORT_LIBRARIES ${OPENRTM_DIR}/@INSTALL_ROS2TRANSPORT_LIB_DIR@/@target@@CMAKE_SHARED_LIBRARY_SUFFIX@ ${OPENRTM_DIR}/@INSTALL_ROS2TRANSPORT_LIB_DIR@/@INSTALL_FASTRTPSTRANSPORT_LIB@@CMAKE_SHARED_LIBRARY_SUFFIX@)
+
+
+
+
+# end of ROS2Transport.cmake

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -89,7 +89,7 @@ else()
 endif()
 
 
-install(FILES ROSMessageInfo.h ROSSerializer.h DESTINATION ${INSTALL_ROSTRANSPORT_INCLUDE_DIR} COMPONENT ext)
+install(FILES ROSMessageInfo.h ROSSerializer.h DESTINATION ${INSTALL_ROSTRANSPORT_INCLUDE_DIR}/ROSTransport COMPONENT ext)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ROSTransportConfig.cmake.in ${PROJECT_BINARY_DIR}/ROSTransportConfig.cmake @ONLY)
 install(FILES ${PROJECT_BINARY_DIR}/ROSTransportConfig.cmake DESTINATION ${INSTALL_RTM_CMAKE_DIR} COMPONENT cmakefiles)
 

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -50,6 +50,8 @@ set(target ROSTransport)
 
 set(srcs ROSTransport.cpp ROSTransport.h ROSInPort.cpp ROSInPort.h ROSOutPort.cpp ROSOutPort.h ROSMessageInfo.cpp ROSMessageInfo.h ROSTopicManager.cpp ROSTopicManager.h ROSSerializer.cpp ROSSerializer.h SubscriberLink.cpp SubscriberLink.h PublisherLink.cpp PublisherLink.h)
 
+set(INSTALL_ROSTRANSPORT_LIB_DIR ${INSTALL_RTM_EXT_DIR}/transport)
+set(INSTALL_ROSTRANSPORT_INCLUDE_DIR ${INSTALL_RTM_INCLUDE_DIR}/rtm/ext)
 
 if(VXWORKS AND NOT RTP)
 	set(libs ${RTCSKEL_PROJECT_NAME})
@@ -63,9 +65,9 @@ if(VXWORKS AND NOT RTP)
 	  PRIVATE${Boost_INCLUDE_DIRS})
 	target_link_libraries(${target} ${libs} ${roscpp_LINK_LIBRARIES} ${Boost_LIBRARIES})
 	
-	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_ROSTRANSPORT_LIB_DIR}
+				ARCHIVE DESTINATION ${INSTALL_ROSTRANSPORT_LIB_DIR}
+				RUNTIME DESTINATION ${INSTALL_ROSTRANSPORT_LIB_DIR}
 				COMPONENT ext)
 else()
 	set(libs ${RTM_PROJECT_NAME} ${ORB_LIBRARIES} ${DATATYPE_FACTORIES})
@@ -80,14 +82,16 @@ else()
 	target_link_libraries(${target} PRIVATE ${libs} ${RTM_LINKER_OPTION} ${roscpp_LIBRARIES} ${Boost_LIBRARIES})
 	set_target_properties(${target} PROPERTIES PREFIX "")
 
-	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				ARCHIVE DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
-				RUNTIME DESTINATION ${INSTALL_RTM_EXT_DIR}/transport
+	install(TARGETS ${target} LIBRARY DESTINATION ${INSTALL_ROSTRANSPORT_LIB_DIR}
+				ARCHIVE DESTINATION ${INSTALL_ROSTRANSPORT_LIB_DIR}
+				RUNTIME DESTINATION ${INSTALL_ROSTRANSPORT_LIB_DIR}
 				COMPONENT ext)
 endif()
 
 
-install(FILES ROSMessageInfo.h DESTINATION ${INSTALL_RTM_INCLUDE_DIR}/rtm/ext COMPONENT ext)
+install(FILES ROSMessageInfo.h ROSSerializer.h DESTINATION ${INSTALL_ROSTRANSPORT_INCLUDE_DIR} COMPONENT ext)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ROSTransport.cmake.in ${PROJECT_BINARY_DIR}/ROSTransport.cmake @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/ROSTransport.cmake DESTINATION ${INSTALL_RTM_CMAKE_DIR} COMPONENT cmakefiles)
 
 
 

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -90,8 +90,8 @@ endif()
 
 
 install(FILES ROSMessageInfo.h ROSSerializer.h DESTINATION ${INSTALL_ROSTRANSPORT_INCLUDE_DIR} COMPONENT ext)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ROSTransport.cmake.in ${PROJECT_BINARY_DIR}/ROSTransport.cmake @ONLY)
-install(FILES ${PROJECT_BINARY_DIR}/ROSTransport.cmake DESTINATION ${INSTALL_RTM_CMAKE_DIR} COMPONENT cmakefiles)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ROSTransportConfig.cmake.in ${PROJECT_BINARY_DIR}/ROSTransportConfig.cmake @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/ROSTransportConfig.cmake DESTINATION ${INSTALL_RTM_CMAKE_DIR} COMPONENT cmakefiles)
 
 
 

--- a/src/ext/transport/ROSTransport/ROSSerializer.cpp
+++ b/src/ext/transport/ROSTransport/ROSSerializer.cpp
@@ -50,7 +50,6 @@
 #include <geometry_msgs/Vector3Stamped.h>
 #include <sensor_msgs/Image.h>
 #include "ROSSerializer.h"
-#include "ROSMessageInfo.h"
 
 
 namespace RTC
@@ -74,11 +73,7 @@ namespace RTC
   template <class DataType, class MessageType, typename originalType, typename convertedType>
   void ROSSimpleDataInitBaseFunc(const char* name)
   {
-    addSerializer<DataType, ROSSimpleData<DataType, MessageType, originalType, convertedType>>(name);
-
-    GlobalROSMessageInfoList::
-            instance().addInfo(name,
-            new ROSMessageInfo<MessageType>());
+    addRosSerializer<DataType, MessageType, ROSSimpleData<DataType, MessageType, originalType, convertedType>>(name);
   }
 
   /*!
@@ -127,11 +122,7 @@ namespace RTC
   template <class DataType, class MessageType, typename originalType, typename convertedType>
   void ROSSequenceDataInitBaseFunc(const char* name)
   {
-    addSerializer<DataType, ROSSequenceData<DataType, MessageType, originalType, convertedType>>(name);
-
-    GlobalROSMessageInfoList::
-            instance().addInfo(name,
-            new ROSMessageInfo<MessageType>());
+    addRosSerializer<DataType, MessageType, ROSSequenceData<DataType, MessageType, originalType, convertedType>>(name);
   }
 
   /*!
@@ -283,11 +274,7 @@ namespace RTC
    */
   void ROSStringDataInit()
   {
-    addSerializer<TimedString, ROSStringData>("ros:std_msgs/String");
-
-    GlobalROSMessageInfoList::
-            instance().addInfo("ros:std_msgs/String",
-            new ROSMessageInfo<std_msgs::String>());
+    addRosSerializer<TimedString, std_msgs::String, ROSStringData>("ros:std_msgs/String");
   }
 
   /*!
@@ -420,11 +407,7 @@ namespace RTC
    */
   void ROSPont3DDataInit()
   {
-    addSerializer<TimedPoint3D, ROSPoint3DData>("ros:geometry_msgs/PointStamped");
-
-    GlobalROSMessageInfoList::
-            instance().addInfo("ros:geometry_msgs/PointStamped",
-            new ROSMessageInfo<geometry_msgs::PointStamped>());
+    addRosSerializer<TimedPoint3D, geometry_msgs::PointStamped, ROSPoint3DData>("ros:geometry_msgs/PointStamped");
   }
 
 
@@ -560,11 +543,7 @@ namespace RTC
    */
   void ROSQuaternionDataInit()
   {
-    addSerializer<TimedQuaternion, ROSQuaternionData>("ros:geometry_msgs/QuaternionStamped");
-
-    GlobalROSMessageInfoList::
-            instance().addInfo("ros:geometry_msgs/QuaternionStamped",
-            new ROSMessageInfo<geometry_msgs::QuaternionStamped >());
+    addRosSerializer<TimedQuaternion, geometry_msgs::QuaternionStamped, ROSQuaternionData>("ros:geometry_msgs/QuaternionStamped");
   }
 
 
@@ -698,11 +677,8 @@ namespace RTC
    */
   void ROSVector3DDataInit()
   {
-    addSerializer<TimedVector3D, ROSVector3DData>("ros:geometry_msgs/Vector3Stamped");
 
-    GlobalROSMessageInfoList::
-            instance().addInfo("ros:geometry_msgs/Vector3Stamped",
-            new ROSMessageInfo<geometry_msgs::Vector3Stamped >());
+    addRosSerializer<TimedVector3D, geometry_msgs::Vector3Stamped, ROSVector3DData>("ros:geometry_msgs/Vector3Stamped");
   }
 
   /*!
@@ -884,11 +860,7 @@ namespace RTC
    */
   void ROSCameraImageDataInit()
   {
-    addSerializer<CameraImage, ROSCameraImageData>("ros:sensor_msgs/Image");
-
-    RTC::GlobalROSMessageInfoList::
-            instance().addInfo("ros:sensor_msgs/Image",
-            new RTC::ROSMessageInfo<sensor_msgs::Image >());
+    addRosSerializer<CameraImage, sensor_msgs::Image, ROSCameraImageData>("ros:sensor_msgs/Image");
   }
 
 

--- a/src/ext/transport/ROSTransport/ROSSerializer.h
+++ b/src/ext/transport/ROSTransport/ROSSerializer.h
@@ -23,7 +23,7 @@
 #include <coil/Factory.h>
 #include <rtm/Manager.h>
 #include <ros/serialization.h>
-
+#include "ROSMessageInfo.h"
 
 
 namespace RTC
@@ -424,6 +424,30 @@ namespace RTC
       return true;
     }
   };
+  /*!
+   * @if jp
+   *
+   * @brief GlobalFactoryにROS用シリアライザを追加する
+   * 
+   * @param marshalingtype シリアライザの名称
+   *
+   * @else
+   *
+   * @brief 
+   *
+   * @param marshalingtype 
+   *
+   * @endif
+   */
+  template <class DataType, class MessageType, class SerializerType>
+  void addRosSerializer(const std::string &marshalingtype)
+  {
+    addSerializer<DataType, SerializerType>(marshalingtype);
+
+    RTC::GlobalROSMessageInfoList::
+            instance().addInfo(marshalingtype,
+            new RTC::ROSMessageInfo<MessageType>());
+  }
 }
 
 

--- a/src/ext/transport/ROSTransport/ROSTransport.cmake.in
+++ b/src/ext/transport/ROSTransport/ROSTransport.cmake.in
@@ -1,0 +1,61 @@
+# -*- cmake -*-
+#
+# @file ROSTransport.cmake
+# @brief cmake-config file for ROSTransport
+#
+# This file is used for cmake config-mode.
+# The following variables are defined.
+#
+# Basic compiler/linker options
+# - ROSTRANSPORT_CFLAGS: cflags 
+# - ROSTRANSPORT_INCLUDE_DIRS: include directories
+# - ROSTRANSPORT_LDFLAGS: linker options
+# - ROSTRANSPORT_LIBRARY_DIRS: library directories
+# - ROSTRANSPORT_LIBRARIES: libraries
+# - ROSTRANSPORT_LIB_DIR: OpenRTM's lib directory
+#
+#
+# ROSTRANSPORT version
+# - ROSTRANSPORT_VERSION: x.y.z version
+# - ROSTRANSPORT_VERSION_MAJOR: major version number
+# - ROSTRANSPORT_VERSION_MINOR: minor version number
+# - ROSTRANSPORT_VERSION_PATCH: revision number
+# - ROSTRANSPORT_SHORT_VERSION: short version number 1.1.0->110
+#
+
+
+message(STATUS "ROSTransport.cmake found.")
+message(STATUS "CMAKE_GENERATOR check mode.")
+
+find_package(OpenRTM @RTM_MAJOR_VERSION@.@RTM_MINOR_VERSION@ REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(roscpp roscpp)
+
+if(NOT roscpp_FOUND)
+	message(FATAL_ERROR "can not find roscpp.")
+endif()
+
+find_package(Boost COMPONENTS chrono filesystem system)
+if(NOT Boost_FOUND)
+	find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
+endif()
+
+# ROSTransport version
+set(ROSTRANSPORT_VERSION @RTM_VERSION@)
+set(ROSTRANSPORT_VERSION_MAJOR @RTM_MAJOR_VERSION@)
+set(ROSTRANSPORT_VERSION_MINOR @RTM_MINOR_VERSION@)
+set(ROSTRANSPORT_VERSION_PATCH @RTM_REVISION_NUM@)
+set(ROSTRANSPORT_SHORT_VERSION @RTM_VERSION@)
+
+# Basic compiler/linker options
+set(ROSTRANSPORT_CFLAGS )
+set(ROSTRANSPORT_INCLUDE_DIRS @INSTALL_ROSTRANSPORT_INCLUDE_DIR@)
+set(ROSTRANSPORT_LDFLAGS )
+
+set(ROSTRANSPORT_LIBRARY_DIRS )
+set(ROSTRANSPORT_LIBRARIES @INSTALL_ROSTRANSPORT_LIB_DIR@/@target@)
+
+
+
+
+# end of ROSTransport.cmake

--- a/src/ext/transport/ROSTransport/ROSTransportConfig.cmake.in
+++ b/src/ext/transport/ROSTransport/ROSTransportConfig.cmake.in
@@ -28,17 +28,7 @@ message(STATUS "ROSTransport.cmake found.")
 message(STATUS "CMAKE_GENERATOR check mode.")
 
 find_package(OpenRTM @RTM_MAJOR_VERSION@.@RTM_MINOR_VERSION@ REQUIRED)
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(roscpp roscpp)
 
-if(NOT roscpp_FOUND)
-	message(FATAL_ERROR "can not find roscpp.")
-endif()
-
-find_package(Boost COMPONENTS chrono filesystem system)
-if(NOT Boost_FOUND)
-	find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
-endif()
 
 # ROSTransport version
 set(ROSTRANSPORT_VERSION @RTM_VERSION@)
@@ -49,11 +39,11 @@ set(ROSTRANSPORT_SHORT_VERSION @RTM_VERSION@)
 
 # Basic compiler/linker options
 set(ROSTRANSPORT_CFLAGS )
-set(ROSTRANSPORT_INCLUDE_DIRS @INSTALL_ROSTRANSPORT_INCLUDE_DIR@)
+set(ROSTRANSPORT_INCLUDE_DIRS ${OPENRTM_DIR}/@INSTALL_ROSTRANSPORT_INCLUDE_DIR@)
 set(ROSTRANSPORT_LDFLAGS )
 
 set(ROSTRANSPORT_LIBRARY_DIRS )
-set(ROSTRANSPORT_LIBRARIES @INSTALL_ROSTRANSPORT_LIB_DIR@/@target@)
+set(ROSTRANSPORT_LIBRARIES ${OPENRTM_DIR}/@INSTALL_ROSTRANSPORT_LIB_DIR@/@target@@CMAKE_SHARED_LIBRARY_SUFFIX@)
 
 
 

--- a/src/ext/transport/ROSTransport/ROSTransportConfig.cmake.in
+++ b/src/ext/transport/ROSTransport/ROSTransportConfig.cmake.in
@@ -15,7 +15,7 @@
 # - ROSTRANSPORT_LIB_DIR: OpenRTM's lib directory
 #
 #
-# ROSTRANSPORT version
+# ROSTransport version
 # - ROSTRANSPORT_VERSION: x.y.z version
 # - ROSTRANSPORT_VERSION_MAJOR: major version number
 # - ROSTRANSPORT_VERSION_MINOR: minor version number


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

ROSTransport、ROS2Transportを使用して、独自のROS用シリアライザ、ROS2用シリアライザを作成する場合、以下の点が問題になる。

- ROSTransport.so、ROS2Transport.soをリンクする必要があるが、CMakeLists.txt内に共有ライブラリのフルパスを記載するなどして指定する必要があるため、ROSTransport.so、ROS2Transport.soをインストールしたパスが変わると修正の必要がある。
- OpenRTM-aistのインストールで必要なインクルードファイルが足りていないため、独自シリアライザをビルドする時にヘッダーファイルを入手する必要がある。


## Description of the Change

- ヘッダーファイルをインストールするように変更。現状では以下のパスにインストールされる。
  - {インストールパス}/include/ext/ROSTransport
  - {インストールパス}/include/ext/ROS2Transport
  - {インストールパス}/include/ext/FastRTPS

- ROSTransportConfig.cmake,、ROS2TransportConfig.cmakeを生成してインストールするように変更。OpenRTMConfig.cmakeと同じパスにインストールされる。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
