### PR TITLE
Remove inline direective in private functions

### DIFF
--- a/src/lib/rtm/RingBuffer.h
+++ b/src/lib/rtm/RingBuffer.h
@@ -843,7 +843,7 @@ namespace RTC
     }
 
   private:
-    inline void initLength(const coil::Properties& prop)
+    void initLength(const coil::Properties& prop)
     {
       if (!prop["length"].empty())
         {
@@ -858,7 +858,7 @@ namespace RTC
         }
     }
 
-    inline void initWritePolicy(const coil::Properties& prop)
+    void initWritePolicy(const coil::Properties& prop)
     {
       std::string policy(coil::normalize(prop["write.full_policy"]));
       if (policy == "overwrite")
@@ -885,7 +885,7 @@ namespace RTC
         }
     }
 
-    inline void initReadPolicy(const coil::Properties& prop)
+    void initReadPolicy(const coil::Properties& prop)
     {
       std::string policy(prop["read.empty_policy"]);
       if (policy == "readback")


### PR DESCRIPTION
Inline directives in the private functions of the RingBuffer class template have been removed. When compilation by g++ 11.3 with the release option, RingBuffer instantiation fails with the following errors.

```
RingBuffer.h:846:17: error: inlining failed in call to ‘void RTC::RingBuffer<DataType>::initLength(const coil::Properties&) [with DataType = RTC::ByteData]’: --param max-inline-insns-single limit reached [-Werror=inline]
  846 |     inline void initLength(const coil::Properties& prop)
```

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to the issue describing the bug that you're fixing.  
If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.


## Description of the Change

We must be able to understand the design of your change from this description.


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
