### PR TITLE
Managerのshutdown時にRTCのデストラクタが呼ばれない問題の修正

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -2056,6 +2056,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
           {
           }
       }
+    cleanupComponents();
     for (auto const& m_ec : m_ecs)
       {
         try {


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- #1098


## Description of the Change

上記のissueと同じくshutdownComponents関数内でcleanupComponents関数を呼ぶように修正した。
deleteComponent関数内でRTCの数が0になった場合にManagerを終了する処理について、2.0からはdeleteComponent関数内で直接終了処理を実行せずにatomic_flagをクリアするだけなので、2.0ではこの部分の修正はしていません。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
