### PR TITLE
openrtm2_install_ubuntu.shスクリプトのバグ修正

### DIFF
--- a/scripts/openrtm2_install_ubuntu.sh
+++ b/scripts/openrtm2_install_ubuntu.sh
@@ -14,7 +14,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.1.00
+VERSION=2.0.1.01
 FILENAME=openrtm2_install_ubuntu.sh
 
 #
@@ -431,8 +431,14 @@ update_source_list () {
       exit 0
     else
       echo $openrtm_repo | sudo tee /etc/apt/sources.list.d/openrtm.list > /dev/null
+      if [ ! -d /etc/apt/keyrings ]; then
+        sudo mkdir -p /etc/apt/keyrings
+      fi
       sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key -O /etc/apt/keyrings/openrtm.key
     fi
+  elif test "x$rtmsite2" != "x" &&
+       [ ! -e /etc/apt/keyrings/openrtm.key ]; then
+    sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key -O /etc/apt/keyrings/openrtm.key
   fi
   fluentsite=`apt-cache policy | grep "https://packages.fluentbit.io"`
   if test "x$fluentsite" = "x" &&


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1108 
## Identify the Bug

Link to #1108


## Description of the Change

- スクリプトのバージョンを 2.0.1.01 へ更新
- /etc/apt/keyrings ディレクトリが存在しない場合は作成するようにした
- バージョン2.0.1.00のスクリプトを実行してエラーになっている環境でもこの修正したスクリプトを実行すれば正常にインストールできるように対応した



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 以下の6環境で修正したopenrtm2_install_ubuntu.shの動作を確認した
1. Ubuntu20.04で初めてOpenRTMをインストールする環境
2. Ubuntu20.04でv2.0.1.00のスクリプトを実行してGPG公開鍵保存で失敗している環境
3. 上記2の不具合を手動で修正対応した環境
4. Ubuntu20.04でopenrtm.orgの公開鍵をapt-keyで管理している環境（初回にv2.0.1.00より古いスクリプトを実行した環境）
5. Ubuntu22.04でopenrtm.orgの公開鍵をapt-keyで管理している環境（初回にv2.0.1.00より古いスクリプトを実行した環境）
6. Ubuntu22.04でv2.0.1.00のスクリプトを実行している環境
- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
