### PR TITLE
Managerを終了して再度初期化すると異常終了する問題の修正

### DIFF
--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1735,7 +1735,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
       {
         try
           {
-            m_pORB->shutdown(true);
+            m_pORB->destroy();
             RTC_DEBUG(("ORB was shutdown."));
             RTC_DEBUG(("ORB was destroied."));
             m_pORB = CORBA::ORB::_nil();


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

以下のようにManagerを終了して再度初期化した場合に、プロセスが異常終了する。

```CPP
  RTC::Manager* manager;
  manager = RTC::Manager::init(argc, argv);
  manager->setModuleInitProc(MyModuleInit);
  manager->activateManager();
  manager->runManager(true);

  std::this_thread::sleep_for(std::chrono::seconds(5));

  manager->terminate();

  manager->join();

  
  std::this_thread::sleep_for(std::chrono::seconds(2));

  manager = RTC::Manager::init(argc, argv);
  manager->setModuleInitProc(MyModuleInit);
  manager->activateManager();
  manager->runManager();
  
```

## Description of the Change

- ORBの終了処理について、shutdown関数はオブジェクトアダプタの終了処理、オブジェクトリファレンスの無効化、スレッドの停止処理を実行するが、オブジェクトのメモリ開放はdestroy関数が実行するためdestroy関数に変更した。destroy関数内でshutdown関数は実行するため、shutdown関数の実行は削除した。
- Logstreamの終了処理について、Logstreamを解放漏れしており、再度初期化した時に不具合が発生するため修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
