### PR TITLE
Ubuntu用一括インストールスクリプトのROS用オプション動作を変更

### DIFF
--- a/scripts/openrtm2_install_ubuntu.sh
+++ b/scripts/openrtm2_install_ubuntu.sh
@@ -14,7 +14,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.1.02
+VERSION=2.0.1.03
 FILENAME=openrtm2_install_ubuntu.sh
 
 #
@@ -171,7 +171,14 @@ check_ros_arg()
   arg_err=0
 
   case "$arg" in
-    all ) OPT_ROS=true ; OPT_ROS2=true ;;
+    all ) OPT_ROS2=true
+          res=`grep 18.04 /etc/lsb-release`
+          res1=`grep 20.04 /etc/lsb-release`
+          if test ! "x$res" = "x" ||
+             test ! "x$res1" = "x" ; then
+            OPT_ROS=true
+          fi
+          shift ;;
     ros ) OPT_ROS=true ;;
     ros2 ) OPT_ROS2=true ;;
     *) arg_err=-1 ;;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

close #1119 
## Identify the Bug

Link to #1119 


## Description of the Change

Issueに示したように修正した。

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- ROS, ROS2が提供されているUbuntu20.04と、ROS2のみが提供されているUbuntu22.04で、インストール動作を確認
```
$ sh openrtm2_install_ubuntu.sh -l c++ -e all
```
- Ubuntu20.04環境で、openrtm2-ros-tp、openrtm2-ros2-tp パッケージがインストールされることを確認
- Ubuntu22.04環境で、openrtm2-ros2-tp パッケージがインストールされることを確認
- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
