### PR TITLE
getParameterByModulename()'s bug fixed

### DIFF
--- a/src/lib/rtm/ManagerServant.h
+++ b/src/lib/rtm/ManagerServant.h
@@ -703,6 +703,32 @@ namespace RTM
      * @endif
      */
     void updateMasterManager();
+    /*
+     * @if jp
+     * @brief create引数から指定されたキーの値を返す
+     *
+     * create引数から指定されたキーを値を返すとともに、そのキーと値を削除した引
+     * 数を返す。
+     * module_name: module_name?param1=value1&param2=value2&param3...
+     * param_name:  param2
+     * の場合
+     * 返り値: value2
+     * module_name: module_name?param1=value1&param3...
+     * となる。
+     *
+     * @else @brief returns value of specified param_name from create arg
+     *
+     * This function returns the value of specified param_name from
+     * create argument, and delete param_name=value from the create
+     * arg string. If the arguments are
+     * module_name: module_name?param1=value1&param2=value2&param3...
+     * param_name:  param2
+     * this function returns
+     * ret value: value2
+     * module_name: module_name?param1=value1&param3...
+     *
+     * @endif
+     */
     std::string getParameterByModulename(const std::string& param_name, std::string &module_name);
     static bool isProcessIDManager(const std::string& mgrname);
 


### PR DESCRIPTION
## Identify the Bug

#1123

## Description of the Change

getParameterByModulename() modified.
指定のパラメータが途中であっても、区切り文字"?"のままcreate_component()に引数を与えることができる。

```
create_component(RTC:AIST:example:ConsoleOut:C++:2.0.0?manager_name=manager_51510&instance_name=hogemunya)
```
のような引数に対して
```
create_component(RTC:AIST:example:ConsoleOut:C++:2.0.0?instance_name=hogemunya)
```
manager_nameを除いた文字列をスレーブのcreate_component() に与えることができている。
指定パラメータが（最後ではなく）途中であっても、以下のように区切り文字が"&"になることはない。
```
create_component(RTC:AIST:example:ConsoleOut:C++:2.0.0&instance_name=hogemunya)
```

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
