### PR TITLE
create_component関数の引数の不具合修正

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -613,14 +613,18 @@ namespace coil
     std::map<std::string, std::string> retmap;
     for (auto & param : params)
       {
+        if (coil::eraseBothEndsBlank(param).empty())
+          {
+            continue;
+          }
         std::string::size_type pos = param.find('=');
         if (pos != std::string::npos)
           {
-            retmap[param.substr(0, pos)] = param.substr(pos + 1);
-          }
-        else
-          {
-            retmap[param] = std::string("");
+            const std::string key{param.substr(0, pos)};
+            if (!coil::eraseBothEndsBlank(key).empty())
+              {
+                retmap[key] = param.substr(pos + 1);
+              }
           }
       }
     return retmap;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- #1123


## Description of the Change

- `manager_name/manager_address`が?の後ろで設定してあっても正常に機能するように、一旦パラメータのキーと値を全て取り出して引数文字列を再生成するように変更した。
- コンポーネント名が空の場合にcreate_component関数を途中で終了するように変更した。
  - 例えば、`?manager_name=manager_51510&instance_name=hogemunya`という文字列の場合
- urlparam2map関数で、コンポーネント名のみの文字列(例えば`ConsoleIn`)を入力した場合に、`{ConsoleIn: }`と言うようにコンポーネント名をキー、空の文字列を値とする配列を返すため、`=`が無い場合は無視するように修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
