### PR TITLE
create_component関数の不具合修正

### DIFF
--- a/src/lib/coil/common/coil/stringutil.cpp
+++ b/src/lib/coil/common/coil/stringutil.cpp
@@ -611,18 +611,22 @@ namespace coil
     coil::vstring params = coil::split(str.substr(qpos), "&");
 
     std::map<std::string, std::string> retmap;
-    for (auto & param : params)
+    for (auto& param : params)
+    {
+      if (coil::eraseBothEndsBlank(param).empty())
       {
-        std::string::size_type pos = param.find('=');
-        if (pos != std::string::npos)
-          {
-            retmap[param.substr(0, pos)] = param.substr(pos + 1);
-          }
-        else
-          {
-            retmap[param] = std::string("");
-          }
+        continue;
       }
+      std::string::size_type pos = param.find('=');
+      if (pos != std::string::npos)
+      {
+        const std::string key{ param.substr(0, pos) };
+        if (!coil::eraseBothEndsBlank(key).empty())
+        {
+          retmap[key] = param.substr(pos + 1);
+        }
+      }
+    }
     return retmap;
   }
 

--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -398,8 +398,16 @@ namespace RTM
     std::string create_arg(module_name);
     if (create_arg.empty()) // invalid arg
       {
+        RTC_ERROR(("RTC name is empty."));
         return RTC::RTObject::_nil();
       }
+
+    if (coil::eraseHeadBlank(create_arg).find("?") == 0)
+      {
+        RTC_ERROR(("RTC name is empty."));
+        return RTC::RTObject::_nil();
+      }
+
     coil::vstring tmp = coil::split(create_arg, "&");
     if (tmp.back().empty())
       {
@@ -462,7 +470,16 @@ namespace RTM
 
         if (manager_name.empty())
           {
-            create_arg = create_arg + "&manager_name=manager_%p";
+            if (create_arg.find("?") == std::string::npos)
+              {
+                create_arg += "?";
+              }
+            else
+              {
+                create_arg += "&";
+              }
+            create_arg += "manager_name=manager_%p";
+
             rtobj = createComponentByManagerName(create_arg, manager_name);
             if (!CORBA::is_nil(rtobj)) { return rtobj._retn(); }
           }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug


## Description of the Change

以下の不具合を修正した。

- コンポーネント名が空の場合にcreate_component関数を終了するように変更した。
  - 例えば、`?manager_name=manager_51510&instance_name=hogemunya`という文字列の場合
- urlparam2map関数で、コンポーネント名のみの文字列(例えば`ConsoleIn`)を入力した場合に、`{ConsoleIn: }`と言うようにコンポーネント名をキー、空の文字列を値とする配列を返すため、`=`が無い場合は無視するように修正した。
- マネージャ名を指定せずにRTCを生成する場合、manager_{プロセス番号}でマネージャを起動して、そのマネージャでRTCを起動するが、create_componentの引数で`ConsoleIn&manager_name=manager_51510`のように`?`を入れない場合がある問題を修正した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
