### PR TITLE
openrtm2とopenrtm2-namingのdebパッケージ間の関連性を更新

### DIFF
--- a/packages/deb/debian/control.focal
+++ b/packages/deb/debian/control.focal
@@ -10,7 +10,7 @@ Package: openrtm2
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, omniorb-nameserver, openrtm2-naming
+Depends: ${misc:Depends}, omniorb-nameserver, openrtm2-naming (>= 2.0.2-0)
 Description: OpenRTM-aist, RT-Middleware distributed by AIST
  OpenRTM-aist is a reference implementation of RTC (Robotic Technology
  Component Version 1.1, formal/12-09-01) specification which is OMG
@@ -25,6 +25,8 @@ Description: OpenRTM-aist, RT-Middleware distributed by AIST
 Package: openrtm2-naming
 Architecture: any
 Multi-Arch: same
+Replaces: openrtm2 (<< 2.0.2-0)
+Breaks: openrtm2 (<< 2.0.2-0)
 Description: OpenRTM-aist name server launcher
 
 Package: openrtm2-ros-tp

--- a/packages/deb/debian/control.jammy
+++ b/packages/deb/debian/control.jammy
@@ -10,7 +10,7 @@ Package: openrtm2
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, omniorb-nameserver, openrtm2-naming
+Depends: ${misc:Depends}, omniorb-nameserver, openrtm2-naming (>= 2.0.2-0)
 Description: OpenRTM-aist, RT-Middleware distributed by AIST
  OpenRTM-aist is a reference implementation of RTC (Robotic Technology
  Component Version 1.1, formal/12-09-01) specification which is OMG
@@ -25,6 +25,8 @@ Description: OpenRTM-aist, RT-Middleware distributed by AIST
 Package: openrtm2-naming
 Architecture: any
 Multi-Arch: same
+Replaces: openrtm2 (<< 2.0.2-0)
+Breaks: openrtm2 (<< 2.0.2-0)
 Description: OpenRTM-aist name server launcher
 
 Package: openrtm2-ros2-tp

--- a/packages/deb/debian/control.not-ros-support
+++ b/packages/deb/debian/control.not-ros-support
@@ -10,7 +10,7 @@ Package: openrtm2
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, omniorb-nameserver, openrtm2-naming
+Depends: ${misc:Depends}, omniorb-nameserver, openrtm2-naming (>= 2.0.2-0)
 Description: OpenRTM-aist, RT-Middleware distributed by AIST
  OpenRTM-aist is a reference implementation of RTC (Robotic Technology
  Component Version 1.1, formal/12-09-01) specification which is OMG
@@ -25,6 +25,8 @@ Description: OpenRTM-aist, RT-Middleware distributed by AIST
 Package: openrtm2-naming
 Architecture: any
 Multi-Arch: same
+Replaces: openrtm2 (<< 2.0.2-0)
+Breaks: openrtm2 (<< 2.0.2-0)
 Description: OpenRTM-aist name server launcher
 
 Package: openrtm2-dev


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1134
## Identify the Bug

Link to #1134 


## Description of the Change
- 現在の設定では2.0.1 -> 2.0.2へのアップグレードでエラーになってしまうため、debian/controlで以下を修正
- openrtm2の定義では、openrtm2-namingを利用するバージョンを追記
  ```
  Depends: ${misc:Depends}, omniorb-nameserver, openrtm2-naming (>= 2.0.2-0)
  ```
- openrtm2-namingの定義ではバージョン2.0.2-0より古い場合はopenrtm2に含まれていた旨を追記
  ```
  Replaces: openrtm2 (<< 2.0.2-0)
  Breaks: openrtm2 (<< 2.0.2-0)
  ```

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu22.04(amd64, arm64)環境でRTM2.0.2へのアップグレード動作OKを確認
- 新規RTM2.0.2版インストールとしてラズパイ5環境でも動作OKを確認
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
