### PR TITLE
マネージャーのConfiguration修正

### DIFF
--- a/src/lib/rtm/DefaultConfiguration.h
+++ b/src/lib/rtm/DefaultConfiguration.h
@@ -99,11 +99,7 @@ namespace RTC {
     "manager.command",                       "rtcd2",
     "manager.nameservers",                   "default",
     "manager.language",                      "C++",
-#ifdef WIN32
     "manager.supported_languages",           "C++, Python, Java",
-#else
-    "manager.supported_languages",           "C++, Python, Python3, Java",
-#endif
     "manager.modules.C++.manager_cmd",       "rtcd2",
     "manager.modules.C++.profile_cmd",       "rtcprof2",
 #ifdef WIN32
@@ -120,12 +116,6 @@ namespace RTC {
     "manager.modules.Python.profile_cmd",    "rtcprof2_python",
     "manager.modules.Python.suffixes",       "py",
     "manager.modules.Python.load_paths",     "",
-#ifndef WIN32
-    "manager.modules.Python3.manager_cmd",    "rtcd2_python3",
-    "manager.modules.Python3.profile_cmd",    "rtcprof2_python3",
-    "manager.modules.Python3.suffixes",       "py",
-    "manager.modules.Python3.load_paths",     "",
-#endif
     "manager.modules.Java.manager_cmd",      "rtcd2_java",
     "manager.modules.Java.profile_cmd",      "rtcprof2_java",
     "manager.modules.Java.suffixes",         "class",


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #1142 


## Description of the Change

- PythonのLinux環境でのマネージャーコマンド名がWindowsと同じになったことを受け、不要となった rtcd2_python3 に関連する定義を削除した


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 修正ソース（C++, Python, Java）からdebパッケージを生成・インストールし、テスト仕様書にあるマネージャーのテストで問題ないことを確認した
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
