### PR TITLE
Ubuntu24.04環境でのビルドエラー対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,7 +688,7 @@ function(openrtm_common_set_compile_options target)
 		-Wstrict-null-sentinel
 		-Wstrict-overflow=5
 		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},6.9.9>: -Wstringop-overflow=4>
-		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},12.9.9>: -Wsuggest-attribute=cold>
+		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},13.9.9>: -Wsuggest-attribute=cold>
 		-Wsuggest-attribute=format
 		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},7.9.9>: -Wsuggest-attribute=malloc>
 		$<$<VERSION_GREATER:${CMAKE_CXX_COMPILER_VERSION},4.9.9>: -Wsuggest-override>

--- a/src/lib/rtm/Manager.cpp
+++ b/src/lib/rtm/Manager.cpp
@@ -1228,7 +1228,7 @@ std::vector<coil::Properties> Manager::getLoadableModules()
 
     for (auto const& itr : coil::split(m_config["manager.preload.modules"], ","))
       {
-        std::string mpm_{coil::eraseBothEndsBlank(std::move(itr))};
+        std::string mpm_{coil::eraseBothEndsBlank(itr)};
         if (mpm_.empty())
           {
               continue;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1145 

## Identify the Bug

Link to #1145 


## Description of the Change

- gcc cold属性をチェックする際のバージョンを、12.9.9 から 13.9.9 へ更新
-  redundant-move のエラーについては、Issueに記載した通りに修正


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- ビルドが通るところまでしか確認していない
-  Ubuntu24.04用のOpenRTM C++, Python, Javaのdebパッケージでインストールできるようになってからテスト仕様書にあるマネージャーテストを実行して動作確認する予定
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
 