### PR TITLE
一括インストールスクリプトのOS判定修正

### DIFF
--- a/scripts/openrtm2_install_raspbian.sh
+++ b/scripts/openrtm2_install_raspbian.sh
@@ -6,7 +6,7 @@
 #         Nobu Kawauchi
 #
 
-VERSION=2.0.2.00
+VERSION=2.0.2.01
 FILENAME=openrtm2_install_raspbian.sh
 BIT=`getconf LONG_BIT`
 
@@ -73,7 +73,6 @@ cmake_tools="cmake doxygen graphviz nkf"
 build_tools="subversion git"
 deb_pkg="uuid-dev libboost-filesystem-dev"
 pkg_tools="build-essential debhelper devscripts"
-#fluentbit="td-agent-bit"
 omni_devel="libomniorb4-dev omniidl"
 omni_runtime="omniorb-nameserver"
 openrtm2_devel="openrtm2-doc openrtm2-idl openrtm2-dev"
@@ -300,11 +299,13 @@ check_codename () {
   for c in $cnames; do
     if test -f "/etc/apt/sources.list"; then
       res=`grep $c /etc/apt/sources.list`
+      res2=`grep -r $c /etc/apt/sources.list.d`
     else
       echo $msg1
       exit
     fi
-    if test ! "x$res" = "x" ; then
+    if test ! "x$res" = "x" ||
+       test ! "x$res2" = "x" ; then
       code_name=$c
     fi
   done
@@ -346,7 +347,6 @@ check_reposerver()
 #---------------------------------------
 create_srclist () {
   openrtm_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openrtm.key] http://$reposerver/pub/Linux/raspbian/ $code_name main"
-  #fluent_repo="deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/raspbian/$code_name $code_name main"
 }
 
 #---------------------------------------
@@ -803,11 +803,6 @@ if test "x$OPT_FLG" = "xtrue" &&
   JAVA8=`update-alternatives --list java | grep java-8`
   sudo update-alternatives --set java ${JAVA8}
 fi
-
-#if test "x$OPT_CORE" = "xtrue" ; then
-#  sudo systemctl enable td-agent-bit
-#  sudo systemctl start td-agent-bit
-#fi
 
 install_result $install_pkgs
 uninstall_result $uninstall_pkgs

--- a/scripts/openrtm2_install_ubuntu.sh
+++ b/scripts/openrtm2_install_ubuntu.sh
@@ -14,7 +14,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.2.00
+VERSION=2.0.2.01
 FILENAME=openrtm2_install_ubuntu.sh
 
 #
@@ -92,7 +92,7 @@ cmake_tools="cmake doxygen graphviz nkf"
 build_tools="subversion git"
 deb_pkg="uuid-dev libboost-filesystem-dev"
 pkg_tools="build-essential debhelper devscripts"
-fluentbit="td-agent-bit"
+fluentbit="fluent-bit"
 omni_devel="libomniorb4-dev omniidl"
 omni_runtime="omniorb-nameserver"
 openrtm2_devel="openrtm2-doc openrtm2-idl openrtm2-dev"
@@ -402,11 +402,13 @@ create_srclist () {
   for c in $cnames; do
     if test -f "/etc/apt/sources.list"; then
       res=`grep $c /etc/apt/sources.list`
+      res2=`grep -r $c /etc/apt/sources.list.d`
     else
       echo $msg1
       exit
     fi
-    if test ! "x$res" = "x" ; then
+    if test ! "x$res" = "x" ||
+       test ! "x$res2" = "x" ; then
       code_name=$c
     fi
   done
@@ -910,8 +912,8 @@ if test "x$OPT_UNINST" = "xtrue" ; then
 fi
 
 if test "x$OPT_COREDEVEL" = "xtrue" ; then
-  sudo systemctl enable td-agent-bit
-  sudo systemctl start td-agent-bit
+  sudo systemctl enable fluent-bit
+  sudo systemctl start fluent-bit
 fi
 
 install_result $install_pkgs


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1147 
## Identify the Bug

Link to #1147 


## Description of the Change

- Ubuntu, Raspbian 両スクリプト共通修正
  - コードネーム検索は、従来の /etc/apt/sources.list に加え、/etc/apt/sources.list.d ディレクトリも対象にした
  - 今回の修正で、スクリプトのバージョン番号を 2.0.2.01 へ更新
- Ubuntu用スクリプトの修正
  - Fluentbitのdebパッケージ名が変更され fluent-bit となっているので対応
- Raspbian用スクリプトの修正
  - Fluentbitに関する処理をコメントアウトの形で残しておいた
  - Ubuntuと同様の処理を組み込んだが、2022/08時点での確認でFluentbitのソースビルドが通らない、arm64版のdebパッケージが見たらない等の理由でコメントアウトしたもの
  - Ubuntu用の修正でFluentbitのdebパッケージ名が変更になったこともあり、古くて使えない処理をコメントアウトの形で残していても紛らわしいため削除した

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu24.04環境へ -c オプションで開発ツールをインストールできることを確認した
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
