### PR TITLE
新しいUbuntuバージョンに対してROS2を有効にしてソースビルドできるように修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,15 +966,17 @@ if(UNIX)
     endif()
     file(STRINGS "/etc/os-release" data_list REGEX "^(VERSION_CODENAME)=")
 
-    # Look for lines like VERSION_CODENAME="..."
-    foreach(var ${data_list})
-      if("${var}" MATCHES "^(VERSION_CODENAME)=(.*)$")
-        set(ubuntu_codename "${CMAKE_MATCH_2}")
-        configure_file(${PROJECT_SOURCE_DIR}/packages/deb/debian/control.${ubuntu_codename}
+    if(BUILD_RTM_LINUX_PKGS)
+      # Look for lines like VERSION_CODENAME="..."
+      foreach(var ${data_list})
+        if("${var}" MATCHES "^(VERSION_CODENAME)=(.*)$")
+          set(ubuntu_codename "${CMAKE_MATCH_2}")
+          configure_file(${PROJECT_SOURCE_DIR}/packages/deb/debian/control.${ubuntu_codename}
              ${PROJECT_BINARY_DIR}/control @ONLY
-        )
-      endif()
-    endforeach()
+          )
+        endif()
+      endforeach()
+    endif()
   else()
     configure_file(${PROJECT_SOURCE_DIR}/packages/deb/debian/rules.not-ros-support.in
 	 ${PROJECT_BINARY_DIR}/rules @ONLY


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1149 
## Identify the Bug

Link to #1149 


## Description of the Change

- 元々、cmake時にROS2を有効（-DROS2_ENABLE=ON）にしていない場合は問題ない
- cmake時にROS2を有効にした場合、cmakeは通るように修正した
- cmake時にROS2を有効にし、debパッケージ生成も有効（-DBUILD_RTM_LINUX_PKGS=ON）にした場合は、debian/control.{新しいOSのコードネーム}　ファイルが存在しない場合はcmakeが通らない・・・既存の定義で正常動作


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu24.04でROS2を有効にし、cmakeが通りビルドが始まることを確認した
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
