### PR TITLE
データポート接続時にコネクタプロファイルからプロバイダのオブジェクトリファレンスが消えるバグの修正

### DIFF
--- a/src/lib/rtm/InPortBase.cpp
+++ b/src/lib/rtm/InPortBase.cpp
@@ -1136,7 +1136,7 @@ namespace RTC
 
       node << portprop;
 
-      NVUtil::copyFromProperties(connector_profile.properties, prop);
+      NVUtil::mergeFromProperties(connector_profile.properties, prop);
 
       std::string _str = node["fan_in"];
       unsigned int value = 100;

--- a/src/lib/rtm/NVUtil.cpp
+++ b/src/lib/rtm/NVUtil.cpp
@@ -113,6 +113,56 @@ namespace NVUtil
       }
   }
 
+
+  /*!
+   * @if jp
+   * @brief Properties を NVList へマージする
+   * @else
+   * @brief Merge the properties to NVList
+   * @endif
+   */
+#ifndef ORB_IS_RTORB
+  void mergeFromProperties(SDOPackage::NVList& nv, const coil::Properties& prop)
+#else  // ORB_IS_RTORB
+  void mergeFromProperties(SDOPackage_NVList& nv, const coil::Properties& prop)
+#endif  // ORB_IS_RTORB
+  {
+    std::vector<std::string> keys;
+    keys = prop.propertyNames();
+#ifndef ORB_IS_RTORB
+    SDOPackage::NVList nve;
+#else  // ORB_IS_RTORB
+    SDOPackage_NVList nve;
+#endif  // ORB_IS_RTORB
+    nve.length(static_cast<CORBA::ULong>(keys.size()));
+
+    CORBA::ULong nsize(0);
+    for (CORBA::ULong i = 0; i < nv.length(); ++i)
+      {
+        if (prop.findNode(static_cast<const char*>(nv[i].name)) == nullptr)
+          {
+            nve[nsize] = nv[i];
+            nsize++;
+          }
+      }
+
+    CORBA::ULong ksize(static_cast<CORBA::ULong>(keys.size()));
+    CORBA::ULong len(ksize + nsize);
+    nv.length(len);
+
+    for (CORBA::ULong i = 0; i < ksize; ++i)
+      {
+        nv[i].name = CORBA::string_dup(keys[i].c_str());
+        nv[i].value <<= prop[keys[i]].c_str();
+      }
+
+    for (CORBA::ULong i = 0; i < nsize; ++i)
+      {
+        nv[i+ ksize] = nve[i];
+      }
+
+  }
+
   /*!
    * @if jp
    * @brief NVList を Properties へコピーする

--- a/src/lib/rtm/NVUtil.h
+++ b/src/lib/rtm/NVUtil.h
@@ -262,6 +262,35 @@ namespace NVUtil
   /*!
    * @if jp
    *
+   * @brief Properties を NVList にマージする
+   *
+   * このオペレーションは Properties を NVList へマージする。
+   * NVList の value は全て CORBA::string 型としてマージする。
+   *
+   * @param nv Properties の値を格納する NVList
+   * @param prop コピー元の Properties
+   *
+   * @else
+   *
+   * @brief Merge the properties to NVList
+   *
+   * This operation merges the properties into NVList.
+   * All NVList's values are copied as CORBA::string.
+   *
+   * @param nv NVList to store properties values
+   * @param prop Properties that is merged from
+   *
+   * @endif
+   */
+#ifndef ORB_IS_RTORB
+  void mergeFromProperties(SDOPackage::NVList& nv, const coil::Properties& prop);
+#else  // ORB_IS_RTORB
+  void mergeFromProperties(SDOPackage_NVList& nv, const coil::Properties& prop);
+#endif  // ORB_IS_RTORB
+
+  /*!
+   * @if jp
+   *
    * @brief NVList を Properties へコピーする
    *
    * このオペレーションは NVList を Properties へコピーする。

--- a/src/lib/rtm/OutPortBase.cpp
+++ b/src/lib/rtm/OutPortBase.cpp
@@ -1154,7 +1154,7 @@ namespace RTC
     node << portprop;
 
 
-    NVUtil::copyFromProperties(connector_profile.properties, prop);
+    NVUtil::mergeFromProperties(connector_profile.properties, prop);
 
     std::string _str = node["fan_out"];
     unsigned int value = 100;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

NVListからPropertiesに変換すると、valueの要素が文字列に変換できない場合にPropertiesが消えるため、データポート接続時にInPortCdrProvider、OutPortCdrProviderのオブジェクトリファレンスが消える問題が発生する。



## Description of the Change

NVListにPropertiesを追加するmergeFromProperties関数により、変換前のNVListに格納しているオブジェクトリファレンスはそのまま残るようにした。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
