### PR TITLE
一括インストールスクリプトでのPEP668によるpip installエラー対応

### DIFF
--- a/scripts/openrtm2_install_raspbian.sh
+++ b/scripts/openrtm2_install_raspbian.sh
@@ -6,7 +6,7 @@
 #         Nobu Kawauchi
 #
 
-VERSION=2.0.2.01
+VERSION=2.0.2.02
 FILENAME=openrtm2_install_raspbian.sh
 BIT=`getconf LONG_BIT`
 
@@ -580,16 +580,15 @@ install_proc()
   if test "x$arg_rtshell" = "xtrue" ; then
     select_opt_shl="[rtshell] install"
     install_packages python3-pip
-    if test "x$code_name" = "xbullseye"; then
-      rtshell_ret=`sudo python3 -m pip install rtshell-aist`
-    else
-      rtshell_ret=`sudo python3 -m pip install --break-system-packages rtshell-aist`
-    fi
+    rtshell_ret=`sudo python3 -m pip install rtshell-aist`
     if test "x$rtshell_ret" != "x"; then
       sudo rtshell_post_install -n
     else
       msg="\n[ERROR] Failed to install rtshell-aist."
-      tmp="$err_message$msg"
+      msg2="\nPlease add the following two lines to /etc/pip.conf and run the script again."
+      msg3="\n[global]"
+      msg4="\nbreak-system-packages = true"
+      tmp="$err_message$msg$msg2$msg3$msg4"
       err_message=$tmp
     fi
   fi

--- a/scripts/openrtm2_install_ubuntu.sh
+++ b/scripts/openrtm2_install_ubuntu.sh
@@ -14,7 +14,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.0.2.02
+VERSION=2.0.2.03
 FILENAME=openrtm2_install_ubuntu.sh
 
 #
@@ -680,7 +680,10 @@ install_proc()
       sudo rtshell_post_install -n
     else
       msg="\n[ERROR] Failed to install rtshell-aist."
-      tmp="$err_message$msg"
+      msg2="\nPlease add the following text to /etc/pip.conf and run the script again."
+      msg3="\n[global]"
+      msg4="\nbreak-system-packages = true"
+      tmp="$err_message$msg$msg2$msg3$msg4"
       err_message=$tmp
     fi
   fi
@@ -934,7 +937,9 @@ fi
 ESC=$(printf '\033')
 if test "x$OPT_UNINST" = "xtrue" &&
    test "x$arg_cxx" = "xtrue" &&
-   test "x$OPT_COREDEVEL" = "xfalse" ; then
+   test "x$OPT_COREDEVEL" = "xfalse" &&
+   test "x$code_name" != "xnoble" ; then
+  echo "code_name = "$code_name
   msg1='To use the log collection extension using the Fluentd logger,'
   msg2='please install Fluent Bit by following the steps on the following web page.'
   msg3='https://docs.fluentbit.io/manual/installation/linux/ubuntu'


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- sudoで実行する一括インストールスクリプトでのrtshellインストールがPEP668によりエラーになる
  - openrtm2_install_ubuntu.sh,  openrtm2_install_raspbian.sh
- エラー発生を確認している環境は、Ubuntu24.04,  Raspberry Pi OS bookworm

## Description of the Change

- OpenRTM-aistがサポートしている環境で、エラーになる・ならないが混在しているため、エラーになった場合は黄色文字で /etc/pip.conf に下記定義を追記する旨のメッセージを出すように変更した
```
[global]
break-system-packages = true
```
- raspbian用スクリプトは、実行環境のOSによりpip install コマンドにオプションを付ける・付けないを判断するように修正済みだったが、Ubuntuと同様にpip.confを利用するようにした

![openrtm2_install_ubuntu sh](https://github.com/user-attachments/assets/4e4878c5-b59c-4766-a913-798ca48b91c5)

- 今回の修正に加え、Ubuntu24.04ではFluentbitに対応していないため、Fluentbitのインストールを促すメッセージを表示しないようにした

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu24.04, Raspberry Pi OS bookworm環境で動作を確認した
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
