### PR TITLE
create_component関数でRTCが起動できない場合がある問題の修正

### DIFF
--- a/src/lib/rtm/Manager.h
+++ b/src/lib/rtm/Manager.h
@@ -467,7 +467,7 @@ namespace RTC
      * @return 終了コード
      *         RTC::RTC_OK 正常終了
      *         RTC::RTC_ERROR ロード失敗・不明なエラー
-     *         RTC::PRECONDITION_NOT_MET 設定にり許可されない操作
+     *         RTC::PRECONDITION_NOT_MET 設定により許可されない操作
      *         RTC::BAD_PARAMETER 不正なパラメータ
      * 
      * @else
@@ -488,6 +488,44 @@ namespace RTC
      * @endif
      */
     ReturnCode_t load(const std::string& fname, const std::string& initfunc);
+
+    /*!
+     * @if jp
+     * @brief [CORBA interface] モジュールのロード
+     *
+     * 指定したコンポーネントのモジュールをロードするとともに、
+     * 指定した初期化関数を実行する。
+     *
+     * @param prop   module_file_name: モジュールファイル名
+     *               module_file_path: モジュールファイルのパス
+     *               language: プログラミング言語
+     * @param initfunc 初期化関数名
+     * @return 終了コード
+     *         RTC::RTC_OK 正常終了
+     *         RTC::RTC_ERROR ロード失敗・不明なエラー
+     *         RTC::PRECONDITION_NOT_MET 設定により許可されない操作
+     *         RTC::BAD_PARAMETER 不正なパラメータ
+     *
+     * @else
+     *
+     * @brief [CORBA interface] Load module
+     *
+     * Load specified module (shared library, DLL etc..),
+     * and invoke initialize function.
+     *
+     * @param prop   module_file_name: module file name
+     *               module_file_path: module file path
+     *               language: programming language
+     * @param initfunc The initialize function name
+     * @return Return code
+     *         RTC::RTC_OK Normal return
+     *         RTC::RTC_ERROR Load failed, or unknown error
+     *         RTC::PRECONDITION_NOT_MET Not allowed operation by conf
+     *         RTC::BAD_PARAMETER Invalid parameter
+     *
+     * @endif
+     */
+    ReturnCode_t load(coil::Properties &prop, const std::string& initfunc);
 
     /*!
      * @if jp
@@ -1393,6 +1431,27 @@ namespace RTC
      * @endif
      */
     std::string createORBOptions();
+
+    /*!
+     * @if jp
+     * @brief giopからはじまるORBエンドポイントでの指定した場合にtrue、
+     * それ以外(例えばホスト名:ポート番号の指定)の場合はfalseを返す。
+     *
+     *
+     * @param endpoint エンドポイント
+     *
+     * @return エンドポイントの指定方法
+     *
+     * @else
+     * @brief 
+     *
+     * @param endpoint 
+     *
+     * @return
+     *
+     * @endif
+     */
+    static bool isORBEndPoint(const std::string& endpoint);
 
     /*!
      * @if jp

--- a/src/lib/rtm/ModuleManager.cpp
+++ b/src/lib/rtm/ModuleManager.cpp
@@ -96,70 +96,92 @@ namespace RTC
   std::string ModuleManager::load(const std::string& file_name)
   {
     RTC_TRACE(("load(fname = %s)", file_name.c_str()));
-    if (file_name.empty()) throw InvalidArguments("Invalid file name.");
+    coil::Properties prop;
+    prop["module_file_name"] = file_name;
+    return load(prop);
+  }
+
+  /*!
+   * @if jp
+   * @brief モジュールのロード
+   * @else
+   * @brief Load the module
+   * @endif
+   */
+  std::string ModuleManager::load(coil::Properties& prop)
+  {
+    RTC_TRACE(("load(filename = %s, filepath = %s, language = %s)", 
+      prop["module_file_name"].c_str(), prop["module_file_path"].c_str(), prop["language"].c_str()));
+    std::string file_name(prop["module_file_name"]);
+    std::string file_path(prop["module_file_path"]);
+    if (file_name.empty())
+      throw InvalidArguments("Invalid file name.");
 
     if (coil::isURL(file_name))
+    {
+      if (!m_downloadAllowed)
       {
-        if (!m_downloadAllowed)
-          {
-            RTC_ERROR(("Downloading module is not allowed."));
-            throw NotAllowedOperation("Downloading module is not allowed.");
-          }
-        else
-          {
-            throw NotFound("Not implemented.");
-          }
+        RTC_ERROR(("Downloading module is not allowed."));
+        throw NotAllowedOperation("Downloading module is not allowed.");
       }
+      else
+      {
+        throw NotFound("Not implemented.");
+      }
+    }
 
     // Find local file from load path or absolute directory
-    std::string file_path;
     if (coil::isAbsolutePath(file_name))
+    {
+      if (!m_absoluteAllowed)
       {
-        if (!m_absoluteAllowed)
-          {
-            RTC_ERROR(("Absolute path is not allowed"));
-            throw NotAllowedOperation("Absolute path is not allowed");
-          }
-        else
-          {
-            file_path = file_name;
-          }
+        RTC_ERROR(("Absolute path is not allowed"));
+        throw NotAllowedOperation("Absolute path is not allowed");
       }
-    else
+      else
       {
-        coil::vstring paths(coil::split(Manager::instance().getConfig()["manager.modules.C++.load_paths"], ","));
-        paths.insert(paths.end(), m_loadPath.begin(), m_loadPath.end());
-
-        file_path = findFile(file_name, paths);
+        file_path = file_name;
       }
+    }
+    else if (file_path.empty())
+    {
+      StringVector paths;
+      for (size_t i = 0; i < m_loadPath.size(); i++)
+      {
+        paths.emplace_back(coil::replaceEnv(m_loadPath[i]));
+      }
+      file_path = findFile(file_name, paths);
+    }
 
-    // Now file_name is valid full path to moduleW
+    // Now file_name is valid full path to module
     if (file_path.empty() || !fileExist(file_path))
-      {
-        RTC_ERROR(("Module file not found: %s", file_name.c_str()));
-        throw FileNotFound(file_name);
-      }
+    {
+      RTC_ERROR(("Module file not found: %s", file_name.c_str()));
+      throw FileNotFound(file_name);
+    }
 
-    DLLEntity* dll(new DLLEntity());
+    DLLEntity *dll(new DLLEntity());
 
-    int retval =  dll->dll.open(file_path.c_str());
+    int retval = dll->dll.open(file_path.c_str());
     if (retval != 0)
-      {
-        RTC_ERROR(("Module file %s load failed: %s",
-                   file_path.c_str(), dll->dll.error()));
-        delete dll;
-        throw Error("DLL open failed.");
-      }
+    {
+      RTC_ERROR(("Module file %s load failed: %s",
+        file_path.c_str(), dll->dll.error()));
+      delete dll;
+      throw Error("DLL open failed.");
+    }
     dll->properties["file_path"] = file_path;
     bool ret = m_modules.registerObject(dll);
     if (!ret)
-      {
-        RTC_ERROR(("Module registration failed: %s", file_path.c_str()));
-        delete dll;
-      }
+    {
+      RTC_ERROR(("Module registration failed: %s", file_path.c_str()));
+      delete dll;
+    }
 
     return file_path;
   }
+
+
 
   /*!
    * @if jp
@@ -181,8 +203,34 @@ namespace RTC
         throw InvalidOperation("Invalid file name");
       }
 
-    void (*initfptr)(Manager*);
-    *reinterpret_cast<void**>(&initfptr) = this->symbol(name, init_func);
+    void (*initfptr)(Manager *);
+    *reinterpret_cast<void **>(&initfptr) = this->symbol(name, init_func);
+    (*initfptr)(&(Manager::instance()));
+
+    return name;
+  }
+  /*!
+   * @if jp
+   * @brief モジュールのロード、初期化
+   * @else
+   * @brief Load and initialize the module
+   * @endif
+   */
+  std::string ModuleManager::load(coil::Properties& prop,
+    const std::string& init_func)
+  {
+    RTC_TRACE(("load(filename = %s, filepath = %s, language = %s, init_func = %s)", 
+      prop["module_file_name"].c_str(), prop["module_file_path"].c_str(), prop["language"].c_str(), init_func.c_str()));
+    std::string name;
+    name = load(prop);
+
+    if (name.empty())
+    {
+      throw InvalidOperation("Invalid file name");
+    }
+
+    void(*initfptr)(Manager *);
+    *reinterpret_cast<void **>(&initfptr) = this->symbol(name, init_func);
     (*initfptr)(&(Manager::instance()));
 
     return name;

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -274,6 +274,59 @@ namespace RTC
      * @endif
      */
     std::string load(const std::string& file_name);
+    /*!
+     * @if jp
+     *
+     * @brief モジュールのロード
+     *
+     * file_name をDLL もしくは共有ライブラリとしてロードする。
+     * file_name は既定のロードパス (manager.modules.load_path) に対する
+     * 相対パスで指定する。
+     * ただし、module_file_pathが設定されている場合には module_file_path の
+     * パスのライブラリをロードする。
+     *
+     * Property manager.modules.abs_path_allowed が yes の場合、
+     * ロードするモジュールを絶対パスで指定することができる。<br>
+     * Property manager.modules.download_allowed が yes の場合、
+     * ロードするモジュールをURLで指定することができる。
+     *
+     * module_file_name は絶対パスで指定することができる。
+     * manager.modules.abs_path_allowd が no の場合、
+     * 既定のモジュールロードパスから、file_name のモジュールを探しロードする。
+     *
+     * @param prop   module_file_name: モジュールファイル名
+     *               module_file_path: モジュールいファイルのパス
+     *               language: プログラミング言語
+     *
+     * @return 指定したロード対象モジュール名
+     *
+     * @else
+     *
+     * @brief Load the module
+     *
+     * Load file_name as DLL or a shared liblary.
+     * The file_name is specified by the relative path to default load
+     * path (manager.modules.load_path).
+     *
+     * If Property manager.modules.abs_path_allowed is yes,
+     * the load module can be specified by the absolute path.<br>
+     * If Property manager.modules.download_allowed is yes,
+     * the load module can be specified with URL.
+     *
+     * The module_file_name can be specified by the absolute path.
+     * If manager.modules.abs_path_allowed is no, module of file_name
+     * will be searched from the default module load path and loaded.
+     *
+     * @param prop   module_file_name: module file name
+     *               module_file_path: module file path
+     *               language: programming language
+     *
+     * @return Name of module for the specified load
+     *
+     * @endif
+     */
+    std::string load(coil::Properties& prop);
+
 
     /*!
      * @if jp
@@ -304,6 +357,40 @@ namespace RTC
      */
     std::string load(const std::string& file_name,
                      const std::string& init_func);
+    /*!
+     * @if jp
+     *
+     * @brief モジュールのロード、初期化
+     *
+     * 指定したファイルをDLL もしくは共有ライブラリとしてロードするとともに、
+     * 指定した初期化用オペレーションを実行する。
+     *
+     * @param prop   module_file_name: モジュールファイル名
+     *               module_file_path: モジュールいファイルのパス
+     *               language: プログラミング言語
+     * @param init_func 初期化処理用オペレーション
+     *
+     * @return 指定したロード対象モジュール名
+     *
+     * @else
+     *
+     * @brief Load and intialize the module
+     *
+     * Load the specified file as DLL or a shared library, and execute operation
+     * for specified initialization.
+     *
+     * @param prop   module_file_name: module file name
+     *               module_file_path: module file path
+     *               language: programming language
+     * @param init_func Operation for initialization
+     *
+     * @return Name of module for the specified load
+     *
+     * @endif
+     */
+    std::string load(coil::Properties& prop,
+        const std::string& init_func);
+
 
     /*!
      * @if jp


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

#1138 の修正で同一名で別のパスのモジュールを区別できるようにしたが、修正ミスによりモジュールの相対パス(例：`Components/C++/ConsoleIn.dll`)にモジュール探索パス(例：`Components/C++`)を追加したパス(`Components/C++/Components/C++/ConsoleIn.dll`)のモジュールの存在確認をするバグが発生している。


## Description of the Change

getLoadableModules関数で取得したモジュールの情報(coil::Properties)には、`module_file_name`、`module_file_path`、`language`があり、load関数に`module_file_path`のパスをそのまま渡すと今回の問題が発生するため、coil::Propertiesを渡すload関数を定義して対応した。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
