### PR TITLE
スレーブマネージャ起動時にrtc.confを指定できるようにする

### DIFF
--- a/src/lib/rtm/ManagerServant.cpp
+++ b/src/lib/rtm/ManagerServant.cpp
@@ -1219,6 +1219,15 @@ namespace RTM
 
         std::string lang_path_key("manager.modules.");
         lang_path_key += lang + ".load_paths";
+        if (param.find("config_file") != param.end())
+          {
+            rtcd_cmd += " -f \"" + coil::escape(param["config_file"]) + "\"";
+          }
+        else if (prop.findNode("config_file"))
+          {
+            rtcd_cmd += " -f \"" + coil::escape(prop["config_file"]) + "\"";
+          }
+
         rtcd_cmd += " -o \"manager.modules.load_path:" + coil::escape(prop["manager.modules.load_path"]) + "\"";
         rtcd_cmd += " -o \"" + lang_path_key + ":" + coil::escape(prop[lang_path_key]) + "\"";
         
@@ -1383,6 +1392,15 @@ namespace RTM
           {
             RTC_WARN(("rtcd command name not found. Default rtcd is used."));
             rtcd_cmd = "rtcd";
+          }
+
+        if (param.find("config_file") != param.end())
+          {
+            rtcd_cmd += " -f \"" + coil::escape(param["config_file"]) + "\"";
+          }
+        else if (prop.findNode("config_file"))
+          {
+            rtcd_cmd += " -f \"" + coil::escape(prop["config_file"]) + "\"";
           }
         rtcd_cmd += " -o \"corba.master_manager:" + mgrstr + "\"";
         rtcd_cmd += " -d ";


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- #1152


## Description of the Change

create_component関数の引数で`ConsoleIn?config_file=rtc2.conf`のように`config_file`のオプションで指定できる。ただし、既に起動済みのマネージャでRTCを実行する場合は無効になる。
オプションの指定が無い場合、マスターマネージャのrtc.confが指定される。


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
