### PR TITLE
WindowsのFluentBit v3.1.10利用環境でRTCを起動できない不具合修正

### DIFF
--- a/src/ext/logger/fluentbit_stream/FluentBit.cpp
+++ b/src/ext/logger/fluentbit_stream/FluentBit.cpp
@@ -56,8 +56,6 @@ namespace RTC
 
   bool FluentBitStream::init(const coil::Properties& prop)
   {
-    flb_stop(s_flbContext);
-
     // Default lib-input setting
     if(prop.findNode("input") == nullptr)
     {

--- a/src/lib/rtm/ModuleManager.h
+++ b/src/lib/rtm/ModuleManager.h
@@ -786,7 +786,7 @@ namespace RTC
         std::string file_path = coil::replaceString(
           dllentity->properties.getProperty("file_path"), "\\", "/");
         file_path = coil::replaceString(file_path, "//", "/");
-        return m_filepath == dllentity->properties.getProperty("file_path");
+        return m_filepath == file_path;
       }
     };
     /*!


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #1165 
Fluent Loggerによるログ収集動作確認時に判明した不具合で、Issueに記したreturn文の修正だけでなく、FluentBit.cppのinit関数で呼び出していたflb_stop文を削除したので、PRをこのタイトルにした。


## Description of the Change

- Ubuntu22.04 (Fluent Bit,  Fluentd 共に v1.9.10) 環境では flb_stop 処理が入っていても問題なくRTCを起動できる
- Windows11 (Fluent Bit v3.1.10, Fluentd(fluent-package  LTS v5.0.5)) 環境では flb_stop 処理で落ちていたため削除した


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- Ubuntu22.04 (Fluent Bit,  Fluentd 共に v1.9.10) 環境用に修正ソースからdebパッケージを生成・インストールしての動作はOKだった。つまり、flb_stopを削除して問題なかった。確認手順は以下の通り。
  - td-agent-bitは停止しておく
    ```
    sudo systemctl stop td-agent-bit.service
    ```
  - td-agent-bit実行ターミナルにログが出るように指定して起動する
    ```
    /opt/td-agent-bit/bin/td-agent-bit -i forward -F stdout -m '*' -o null 
    ```
  - libfluent-bit.soをプリロードしてConsoleIn、ConsoleOutを実行する
    ```
    export LD_PRELOAD=/usr/lib/td-agent-bit/libfluent-bit.so
    ./ConsoleInComp -f  rtc.fluentbit_stream.conf
    ./ConsoleOutComp -f  rtc.fluentbit_stream.conf
    ```
  - ★注意：LD_LIBRARY_PATHで指定してRTCを実行すると、allocate memoryエラーになるため、LD_PRELOAD指定が必要となる
    ```    
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/td-agent-bit
    ```
    - allocate memoryエラーはRTCのログで確認できる
      ```
      Jan 08 08:50:36.682 ERROR: ModuleManager: Module file /usr/lib/x86_64-linux-gnu/openrtm-2.1/logger/FluentBit.so load failed: /usr/lib/td-agent-bit/libfluent-bit.so: cannot allocate memory in static TLS block
      ```
  - td-agent-bitターミナルのログ確認・・・ConsoleOut0.inとConsoleIn0.outのactivate connectorログ抜粋
    ```
    [772] rtclog: [1736324211.000000000, {"time"=>"Jan 08 08:16:51.870", "name"=>"in", "level"=>"DEBUG", "pid"=>"30234", "host"=>"ubuntu2204-2", "manager"=>"manager", "message"=>"deactivate connector: ConsoleOut0.in_ConsoleIn0.out b0201c8d-07ea-4978-870c-693f003a6a27"}]
    ```
- Windows  (Fluent Bit v3.1.10, Fluentd(fluent-package  LTS v5.0.5))  は修正ソースからRC版msi（OpenRTM-aist-2.1.0-RC250108_x86_64.msi）を生成・インストールし、ConsoleIn、ConsoleOutでUbuntu22.04環境と内容が同じrtc.fluentbit_stream.confを指定して動作を確認した
  - logger.plugins: C:\\Program Files\\OpenRTM-aist\\2.1.0\\ext\\vc16\\logger\\FluentBit.dll
  - 結果はNG.　２つのRTCのポート間を接続すると「接続に失敗しました」のダイアログが出てConsoleInが落ちてゾンビとなった
  - この確認はFluentdをデフォルトの設定で起動して行った（下記ステータスはPowershellを管理者で実行して確認）
    ```
    > Start-Service fluentdwinsvc
    > Get-Service fluentdwinsvc

    Status   Name               DisplayName
    ------   ----               -----------
    Running  fluentdwinsvc      Fluentd Windows Service
    ```
  - ConsoleOutのログにエラーが出ていた（InPortBase.cppが出力している）
    ```
    Jan 10 02:36:23.295 ERROR: in: connector.size should be 0 in InPortBase's dtor.
    ```
  - Fluent Bitの定義が記載されていないrtc.conf使用時は接続動作は問題ない
  - RTCは起動できるようになったということで、今回のIssue問題は解決と判断し、上記エラーは別Issueとする
