### PR TITLE
Properties _dump() modification

### DIFF
--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -841,23 +841,25 @@ namespace coil
 
   void Properties::_dump(std::vector<std::string>& out, const Properties& curr, size_t index) const
   {
-      if (index != 0) out.emplace_back(indent(index) + "- " + curr.name);
+      std::string tmp;
+      if (index != 0) { tmp = indent(index) + "- " + curr.name; }
       if (curr.leaf.empty())
       {
-          if (!curr.set_value)
-          {
-              out.emplace_back(": " + curr.default_value);
-          }
-          else
-          {
-              out.emplace_back(": " + curr.value);
-          }
-          return;
+        if (!curr.set_value)
+        {
+          tmp += ": " + curr.default_value;
+        }
+        else
+        {
+          tmp += ": " + curr.value;
+        }
+        out.emplace_back(tmp);
+        return;
       }
-      if (index != 0) { out.emplace_back(""); }
+      if (index != 0) { out.emplace_back(tmp); }
       for (auto prop : curr.leaf)
       {
-          _dump(out, *prop, index + 1);
+        _dump(out, *prop, index + 1);
       }
   }
 } // namespace coil


### PR DESCRIPTION
## Identify the Bug

Properties::_dump() has a bug when the properties object dumps its contents of it; the results of its format and indentation have some errors as follows.

```
Feb 10 02:29:49.683 DEBUG: manager: corba.args: -ORBclientCallTimeOutPeriod 10000
Feb 10 02:29:49.683 DEBUG: manager: - config
Feb 10 02:29:49.683 DEBUG: manager: 
Feb 10 02:29:49.683 DEBUG: manager:   - version
Feb 10 02:29:49.683 DEBUG: manager: : 2.0.2
Feb 10 02:29:49.683 DEBUG: manager: - openrtm
Feb 10 02:29:49.683 DEBUG: manager: 
Feb 10 02:29:49.683 DEBUG: manager:   - name
Feb 10 02:29:49.683 DEBUG: manager: : OpenRTM-aist-2.0.2
Feb 10 02:29:49.683 DEBUG: manager:   - version
Feb 10 02:29:49.683 DEBUG: manager: : 2.0.2
Feb 10 02:29:49.683 DEBUG: manager: - manager
```

## Description of the Change

_dump()'s format and indentation bug have been fixed.

```
Feb 10 02:49:13.816 DEBUG: manager: corba.args: -ORBclientCallTimeOutPeriod 10000
Feb 10 02:49:13.816 DEBUG: manager: - config
Feb 10 02:49:13.816 DEBUG: manager:   - version: 2.1.0
Feb 10 02:49:13.816 DEBUG: manager: - openrtm
Feb 10 02:49:13.816 DEBUG: manager:   - name: OpenRTM-aist-2.1.0
Feb 10 02:49:13.816 DEBUG: manager:   - version: 2.1.0
Feb 10 02:49:13.816 DEBUG: manager: - manager

```


## Verification 
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
