### PR TITLE
Fluent Loggerによるログ収集時に同じ内容が2回出力される不具合修正

### DIFF
--- a/src/ext/logger/fluentbit_stream/rtc.fluentbit_stream.conf.in
+++ b/src/ext/logger/fluentbit_stream/rtc.fluentbit_stream.conf.in
@@ -8,4 +8,6 @@ logger.logstream.fluentd.output0.plugin: forward
 logger.logstream.fluentd.output0.conf.match:*
 
 logger.logstream.fluentd.input0.plugin: lib
-logger.logstream.fluentd.input0.tag: openrtm.example
+logger.logstream.fluentd.input0.conf.tag: rtclog
+
+logger.logstream.fluentd.option.log_level:off


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1171 
## Identify the Bug

Link to #1171 


## Description of the Change

- 同じログが2回出力されていた不具合修正内容
  - 原因はFluentBitStream::init関数の最初のif文にあった
  - confファイルには input0 と記述しているが、if文の比較で input定義は無いとみなされ余計にcreateInputStream関数を実行していた
  - このif文を丸ごと削除で対応し、inputプラグインの lib と tag: rtclog が定義されていない場合のデフォルト値指定は他の場所へ移動させた
- API: flb_input_property_check(), flb_output_property_check()のオプションチェック処理を外す
  - FluentBit 1.9 と違い、v3(3.1.10と3.2.6で確認）ではエラーが出るようになった
  - このチェックでエラーになっても動作しているので、このオプションチェック処理は一応残すとしてコメントアウトした
  - エラーとして下記が出力される
  ```
  [2025/02/20 11:35:00] [error] [config] forward: unknown configuration property 'match'. The following properties are allowed: time_as_integer, retain_metadata_in_forward_mode, shared_key, self_hostname, empty_shared_key, send_options, require_ack_response, username, password, unix_path, upstream, tag, compress, fluentd_compat, and add_option.
  Unknown property for "forward" plugin: match: *
  Unknown property for "lib" plugin: tag: rtclog
  ```
- rtc.fluentbit_stream.conf.inの修正
  - 今回の動作確認で、tag指定する際にconf文字列が抜けていたので追加した
  - tagはソースでrtclogとしているので、conf文での指定が openrtm.example では下記ワーニングにて出力されないので rtclog へ修正した
    ```
    2025-02-19 16:06:03 +0900 [warn]: #0 no patterns matched tag="openrtm.example"
    ```
  - ログレベルをoffにするオプションを追加
    - Windows環境で、FluentBit3.1.10と最新版の3.2.6で確認したが、flb_lib_push でデータを送る都度下記ワーニングが出ることを解決できなかった
      ```
      [2025/02/12 11:05:17] [ warn] [input:lib:lib.0] lib data invalid
      ```
    - このワーニングが大量に出ていてもログはFluentd側へ送られているが確認しづらいため、ワーニングを出さないように 下記を追加した
      ```
      logger.logstream.fluentd.option.log_level:off
      ```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- WindowsでOpenRTMはmsiでインストールしておらずソースビルドからインストールした環境で確認
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
