### PR TITLE
Fluent Loggerによるログ収集時に出るlib data invalidワーニング対応

### DIFF
--- a/src/lib/coil/common/coil/Properties.cpp
+++ b/src/lib/coil/common/coil/Properties.cpp
@@ -851,7 +851,15 @@ namespace coil
         }
         else
         {
-          tmp += ": " + curr.value;
+          if (curr.name == "plugins")
+          {
+            std::string fname{coil::replaceString(curr.value, "\\", "\\\\\\\\")};
+            tmp += ": " + fname;
+          }
+          else
+          {
+            tmp += ": " + curr.value;
+          }
         }
         out.emplace_back(tmp);
         return;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1175 
## Identify the Bug

Link to #1175 


## Description of the Change
- conf内容は Properties::_dump() で出力させているので、ここでの処理を修正する
- confファイルではFluentBit.dllのフルパスを設定している（下記はソースからインストールしている環境）
  ```
  logger.plugins: C:\\localRTM0303\\2.1.0\\ext\\vc16\\logger\\FluentBit.dll
  ```
- _dump()処理では、plugins で指定された内容はフルパスであるという前提でデリミタを変更した
  - この時点で修正前はデリミタが \ マーク１つとなっているのでこれを４つへ変更
- Windowsの場合、フルパスのデリミタが / でも動作するようになった（#1167 のModuleManager.h修正により）
- Windows環境でデリミタが / の場合でも問題なく動作することを確認できた（後述）ので、Ubuntu環境でも問題ないと判断 
- 修正前は [input:lib:lib.0] lib data invalid ワーニングが大量に出力されていたが今回の修正にて一切出力されなくなり、Fluentd側へ送られるようになった


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 動作はソースからインストールした環境でサンプルRTCのConsoleInの起動で確認
- confファイルで指定しているフルパスのデリミタが \ でも / でも問題なくFluentd側へ送信される動作を確認した
- デリミタが \ の場合
  - RTCログには下記形式で出力される
  ```
  Mar 04 08:58:08.844 DEBUG: manager:   - plugins: C:\\\\localRTM0303\\\\2.1.0\\\\ext\\\\vc16\\\\logger\\\\FluentBit.dll
  ```
  - Fluentd側へはワーニングは出ずに送信される（タイムスタンプがRTCログと同じ、Mar 04 08:58:08.844である）
  ```
  2025-03-04 17:58:08.000000000 +0900 rtclog: {"time":"Mar 04 08:58:08.844","name":"manager","level":"DEBUG","pid":"7804","host":"DESKTOP-7H9OU5K","manager":"manager","message":"  - plugins: C:\\\\localRTM0303\\\\2.1.0\\\\ext\\\\vc16\\\\logger\\\\FluentBit.dll"}
  ```
- デリミタが / の場合
  - confファイルでは以下のように指定
  ```
  logger.plugins: C:/localRTM0303/2.1.0/ext/vc16/logger/FluentBit.dll
  ```
  - RTCログには下記形式で出力される
  ```
  Mar 04 08:47:51.889 DEBUG: manager:   - plugins: C:/localRTM0303/2.1.0/ext/vc16/logger/FluentBit.dll
  ```
  - Fluentd側へはワーニングは出ずに送信される（タイムスタンプがRTCログと同じ、Mar 04 08:47:51.889である）
  ```
  2025-03-04 17:47:51.000000000 +0900 rtclog: {"time":"Mar 04 08:47:51.889","name":"manager","level":"DEBUG","pid":"3568","host":"DESKTOP-7H9OU5K","manager":"manager","message":"  - plugins: C:/localRTM0303/2.1.0/ext/vc16/logger/FluentBit.dll"}
  ```
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
