### PR TITLE
Azure Pipelines、Windows環境でのOpenRTM2.1.0版でエラーになる問題の修正

### DIFF
--- a/.azure-pipelines/openrtm-build-environment.yml
+++ b/.azure-pipelines/openrtm-build-environment.yml
@@ -14,7 +14,7 @@ parameters:
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.8'
+    versionSpec: '3.12'
     addToPath: true
     architecture: 'x64'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ pr:
     - utils/
 
 variables:
-  omniorb: omniORB-4.3.2-x64-vc14-py38
+  omniorb: omniORB-4.3.2-x64-vc16-py312
   omniorbUrl: https://openrtm.org/pub/omniORB/win32/omniORB-4.3.2
   ros2: ros2-jazzy-20240705-windows-release-amd64
   ros2Url: https://github.com/ros2/ros2/releases/download/release-jazzy-20240705/
@@ -66,7 +66,7 @@ jobs:
           workingDirectory: 'build'
           cmakeArgs:
             -A x64
-            -DRTM_VC_VER=vc14
+            -DRTM_VC_VER=vc16
             -DCORBA=omniORB
             -DORB_ROOT=$(Pipeline.Workspace)\$(omniorb)
             -DOBSERVER_ENABLE=ON
@@ -107,7 +107,7 @@ jobs:
             -DCMAKE_CXX_COMPILER:FILEPATH="$(vcPath)\Tools\Llvm\bin\clang-cl.exe" ^
             -DCMAKE_LINKER:FILEPATH="$(vcPath)\Tools\Llvm\bin\lld-link.exe" ^
             -DCMAKE_BUILD_TYPE=Release ^
-            -DRTM_VC_VER=vc14 ^
+            -DRTM_VC_VER=vc16 ^
             -DCORBA=omniORB ^
             -DORB_ROOT=$(Pipeline.Workspace)\$(omniorb) ^
             -DOBSERVER_ENABLE=ON ^

--- a/src/lib/coil/common/coil/ClockManager.cpp
+++ b/src/lib/coil/common/coil/ClockManager.cpp
@@ -18,7 +18,7 @@
 
 #include <coil/ClockManager.h>
 #include <mutex>
-
+#include <chrono>
 #include <string>
 
 namespace coil


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1177 
## Identify the Bug

Link to #1177 

## Description of the Change

- omniORBのバイナリは、omniORB-4.3.2-x64-vc16-py312 を使用するように変更したが、以下のエラーが出た
- ClockManager.cpp でのエラー
  ```
  src\lib\coil\common\coil\ClockManager.cpp(37,25): Error C2039: 'system_clock': is not a member of 'std::chrono'
  src\lib\coil\common\coil\ClockManager.cpp(37,25): Error C3083: 'system_clock': the symbol to the left of a '::' must be a type
  src\lib\coil\common\coil\ClockManager.cpp(37,39): Error C2039: 'now': is not a member of 'std::chrono'
  src\lib\coil\common\coil\ClockManager.cpp(37,39): Error C3861: 'now': identifier not found
  ```
  - これは ClockManager.cpp へ #include <chrono> を追加することで解決した
- ROS2Transportでのエラー
  ```
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(241,5): Error MSB8066: Custom build for 'D:\a\1\s\build\CMakeFiles\d42d43adc07d3d0fdc8aa12e19b486a2\ROS2Transport_uninstall.rule;D:\a\1\s\src\ext\transport\ROS2Transport\CMakeLists.txt' exited with code 1.
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): Error MSB8066: Custom build for 'D:\a\1\s\build\CMakeFiles\d42d43adc07d3d0fdc8aa12e19b486a2\ROS2Transport_uninstall.rule;D:\a\1\s\src\ext\transport\ROS2Transport\CMakeLists.txt' exited with code 1.
  ```
  - これは前回から出ているエラー
  - Windows環境用OpenRTM2.1.0版ではROS2をサポートしていないので、このエラーは後回しとして後日確認する予定
- Clang静的解析エラー
  ```
  D:\a\1\s\src\lib\coil\common\coil\Properties.cpp(313,35): error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
    313 |     for (size_t i = 0; i < num && defaults[i][0] != '\0' ; i += 2)
        |                                   ^~~~~~~~
  D:\a\1\s\src\lib\coil\common\coil\Properties.cpp(315,39): error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
    315 |         setDefault(eraseBothEndsBlank(defaults[i]),
        |                                       ^~~~~~~~
  D:\a\1\s\src\lib\coil\common\coil\Properties.cpp(316,39): error: unsafe buffer access [-Werror,-Wunsafe-buffer-usage]
    316 |                    eraseBothEndsBlank(defaults[i + 1]));
        |                                       ^~~~~~~~
  ```
  - これの対策として下記を試したが解決しなかった
    - defaults == nullptr のチェックを 最初に実施 して nullptr の可能性を排除
    - defaults[i] のアクセスを const char* key = defaults[i]; に代えて、変数に格納してからチェック
    - key[0] != '\0' の条件を nullptr チェックの後にすることで、NULL 参照を防止
  - const char* 配列ではなく、std::vector<std::string> の使用が求められているのかもしれないが、これを変更すると影響が大きいためこのままとした
    ```
    void Properties::setDefaults(const char* const defaults[], size_t num)
         ↓
    void Properties::setDefaults(const std::vector<std::string>& defaults)
    ```

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
