### PR TITLE
Ubuntu24.04用Dockerfile.devel-rtm更新

### DIFF
--- a/scripts/ubuntu_2404/Dockerfile.devel-rtm
+++ b/scripts/ubuntu_2404/Dockerfile.devel-rtm
@@ -10,23 +10,20 @@ RUN apt update\
  flex\
  bison\
  libyaml-dev\
- libssl-dev
+ libssl-dev\
+ patch
 
 # downlaod fluent-bit.
+COPY fluent-bit-3.2.7-ubuntu.patch /root/fluent-bit-3.2.7-ubuntu.patch
 RUN mkdir /root/fluent-bit
-RUN wget -O - https://github.com/fluent/fluent-bit/archive/refs/tags/v3.0.7.tar.gz\
- | tar xfz - -C /root/fluent-bit --strip-components 1
+RUN wget -O - https://github.com/fluent/fluent-bit/archive/refs/tags/v3.2.7.tar.gz\
+ | tar xfz - -C /root/fluent-bit --strip-components 1\
+ && patch -p1 -d /root/fluent-bit < /root/fluent-bit-3.2.7-ubuntu.patch
 RUN sed  -i -e 's/jemalloc-5.3.0\/configure/jemalloc-5.3.0\/configure --disable-initial-exec-tls/g' /root/fluent-bit/CMakeLists.txt
 
 # build fluent-bit.
-RUN cmake -DFLB_DEBUG=Off\
- -DFLB_TRACE=Off\
- -DFLB_JEMALLOC=On\
- -DFLB_TLS=On\
- -DFLB_SHARED_LIB=On\
+RUN cmake -DFLB_TRACE=Off\
  -DFLB_EXAMPLES=Off\
- -DFLB_HTTP_SERVER=On\
- -DFLB_IN_SYSTEMD=On\
  -DFLB_OUT_KAFKA=On\
  -DCMAKE_BUILD_TYPE=Release\
  -DCMAKE_INSTALL_PREFIX=/tmp/flb/install\
@@ -35,13 +32,15 @@ RUN cmake -DFLB_DEBUG=Off\
 RUN cmake --build /tmp/flb/build --target install/strip -- -j$(nproc)
 
 # install header files.
-RUN cp -r /tmp/flb/build/include/jemalloc\
- /root/fluent-bit/lib/cfl/include/cfl\
+RUN cp -r /root/fluent-bit/lib/cfl/include/cfl\
  /root/fluent-bit/lib/cfl/lib/xxhash/*.h\
  /root/fluent-bit/lib/msgpack-*/include/msgpack.h\
  /root/fluent-bit/lib/msgpack-*/include/msgpack\
  /root/fluent-bit/lib/ctraces/lib/mpack/src/mpack\
+ /root/fluent-bit/lib/ctraces/include/ctraces\
  /root/fluent-bit/lib/c-ares-*/include/*.h\
+ /root/fluent-bit/lib/monkey/mk_core/deps/libevent/include/*.h\
+ /root/fluent-bit/lib/monkey/mk_core/deps/libevent/include/event2\
  /tmp/flb/install/include/
 RUN cp -r /tmp/flb/build/lib/c-ares-*/ares_build.h\
  /tmp/flb/build/lib/c-ares-*/ares_config.h\
@@ -49,8 +48,19 @@ RUN cp -r /tmp/flb/build/lib/c-ares-*/ares_build.h\
  /root/fluent-bit/lib/cmetrics/include/prometheus_remote_write\
  /root/fluent-bit/lib/ctraces/include/ctraces\
  /tmp/flb/install/include/
-RUN cp /tmp/flb/build/lib/monkey/include/monkey/mk_core/mk_core_info.h\
+RUN cp -r /root/fluent-bit/lib/monkey/include/monkey/mk_core/external\
+ /tmp/flb/build/lib/monkey/include/monkey/mk_core/mk_core_info.h\
  /tmp/flb/install/include/monkey/mk_core/
+RUN cp /root/fluent-bit/lib/monkey/include/monkey/*.h\
+ /tmp/flb/build/lib/monkey/include/monkey/mk_info.h\
+ /tmp/flb/install/include/monkey/
+RUN mkdir -p /tmp/flb/install/deps/rbtree\
+ && cp /root/fluent-bit/lib/monkey/deps/rbtree/rbtree.h\
+ /tmp/flb/install/deps/rbtree/
+RUN mkdir /tmp/flb/install/include/nghttp2\
+ && cp /root/fluent-bit/lib/nghttp2/lib/includes/nghttp2/nghttp2.h\
+ /tmp/flb/build/lib/nghttp2/lib/includes/nghttp2/nghttp2ver.h\
+ /tmp/flb/install/include/nghttp2/
 
 ############################################################
 FROM ubuntu:24.04 as rtm-build

--- a/scripts/ubuntu_2404/fluent-bit-3.2.7-ubuntu.patch
+++ b/scripts/ubuntu_2404/fluent-bit-3.2.7-ubuntu.patch
@@ -1,0 +1,379 @@
+diff -ruN fluent-bit-3.2.7-org/include/fluent-bit/flb_input.h fluent-bit-3.2.7-new/include/fluent-bit/flb_input.h
+--- fluent-bit-3.2.7-org/include/fluent-bit/flb_input.h	2025-02-28 10:17:56.144317192 +0900
++++ fluent-bit-3.2.7-new/include/fluent-bit/flb_input.h	2025-03-19 13:33:01.026005085 +0900
+@@ -549,9 +549,9 @@
+ {
+     struct flb_libco_in_params *params;
+ 
+-    params = pthread_getspecific(libco_in_param_key);
++    params = (struct flb_libco_in_params *)pthread_getspecific(libco_in_param_key);
+     if (params == NULL) {
+-        params = flb_calloc(1, sizeof(struct flb_libco_in_params));
++        params = (struct flb_libco_in_params *)(struct flb_libco_in_params *)flb_calloc(1, sizeof(struct flb_libco_in_params));
+         if (params == NULL) {
+             flb_errno();
+             return;
+@@ -573,9 +573,9 @@
+     struct flb_coro *coro;
+     struct flb_libco_in_params *params;
+ 
+-    params = pthread_getspecific(libco_in_param_key);
++    params = (struct flb_libco_in_params *)pthread_getspecific(libco_in_param_key);
+     if (params == NULL) {
+-        params = flb_calloc(1, sizeof(struct flb_libco_in_params));
++        params = (struct flb_libco_in_params *)flb_calloc(1, sizeof(struct flb_libco_in_params));
+         if (params == NULL) {
+             flb_errno();
+             return;
+diff -ruN fluent-bit-3.2.7-org/include/fluent-bit/flb_output.h fluent-bit-3.2.7-new/include/fluent-bit/flb_output.h
+--- fluent-bit-3.2.7-org/include/fluent-bit/flb_output.h	2025-02-28 10:17:56.148319194 +0900
++++ fluent-bit-3.2.7-new/include/fluent-bit/flb_output.h	2025-03-19 14:42:59.271016216 +0900
+@@ -753,7 +753,7 @@
+             }
+ 
+             records = flb_mp_count(p_buf, p_size);
+-            tmp = flb_event_chunk_create(evc->type, records, evc->tag, flb_sds_len(evc->tag), p_buf, p_size);
++            tmp = flb_event_chunk_create(evc->type, records, evc->tag, flb_sds_len(evc->tag), (char *)p_buf, p_size);
+             if (!tmp) {
+                 flb_coro_destroy(coro);
+                 flb_free(out_flush);
+@@ -822,7 +822,7 @@
+                     if ((serialization_buffer_offset +
+                          serialized_context_size) > p_size) {
+                         resized_serialization_buffer = \
+-                            flb_realloc(p_buf, p_size + serialized_context_size);
++                            (char *)flb_realloc(p_buf, p_size + serialized_context_size);
+ 
+                         if (resized_serialization_buffer == NULL) {
+                             cmt_encode_msgpack_destroy(serialized_context_buffer);
+@@ -860,7 +860,7 @@
+                                                 0,
+                                                 evc->tag,
+                                                 flb_sds_len(evc->tag),
+-                                                p_buf,
++                                                (char *)p_buf,
+                                                 p_size);
+ 
+             if (out_flush->processed_event_chunk == NULL) {
+@@ -919,7 +919,7 @@
+                     if ((serialization_buffer_offset +
+                          serialized_context_size) > p_size) {
+                         resized_serialization_buffer = \
+-                            flb_realloc(p_buf, p_size + serialized_context_size);
++                            (char *)flb_realloc(p_buf, p_size + serialized_context_size);
+ 
+                         if (resized_serialization_buffer == NULL) {
+                             ctr_encode_msgpack_destroy(serialized_context_buffer);
+@@ -957,7 +957,7 @@
+                                                 0,
+                                                 evc->tag,
+                                                 flb_sds_len(evc->tag),
+-                                                p_buf,
++                                                (char *)p_buf,
+                                                 p_size);
+ 
+             if (out_flush->processed_event_chunk == NULL) {
+diff -ruN fluent-bit-3.2.7-org/lib/ctraces/lib/mpack/src/mpack/mpack.h fluent-bit-3.2.7-new/lib/ctraces/lib/mpack/src/mpack/mpack.h
+--- fluent-bit-3.2.7-org/lib/ctraces/lib/mpack/src/mpack/mpack.h	2025-02-28 10:17:56.184337193 +0900
++++ fluent-bit-3.2.7-new/lib/ctraces/lib/mpack/src/mpack/mpack.h	2025-02-28 10:50:59.803707566 +0900
+@@ -3275,120 +3275,120 @@
+     mpack_write_i8(writer, value);
+ }
+ 
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, int16_t value) {
+-    mpack_write_i16(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, int32_t value) {
+-    mpack_write_i32(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, int64_t value) {
+-    mpack_write_i64(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint8_t value) {
+-    mpack_write_u8(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint16_t value) {
+-    mpack_write_u16(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint32_t value) {
+-    mpack_write_u32(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint64_t value) {
+-    mpack_write_u64(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, bool value) {
+-    mpack_write_bool(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, float value) {
+-    mpack_write_float(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, double value) {
+-    mpack_write_double(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, char *value) {
+-    mpack_write_cstr_or_nil(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write(mpack_writer_t* writer, const char *value) {
+-    mpack_write_cstr_or_nil(writer, value);
+-}
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, int16_t value) {
++//    mpack_write_i16(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, int32_t value) {
++//    mpack_write_i32(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, int64_t value) {
++//    mpack_write_i64(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint8_t value) {
++//    mpack_write_u8(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint16_t value) {
++//    mpack_write_u16(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint32_t value) {
++//    mpack_write_u32(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint64_t value) {
++//    mpack_write_u64(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, bool value) {
++//    mpack_write_bool(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, float value) {
++//    mpack_write_float(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, double value) {
++//    mpack_write_double(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, char *value) {
++//    mpack_write_cstr_or_nil(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write(mpack_writer_t* writer, const char *value) {
++//    mpack_write_cstr_or_nil(writer, value);
++//}
+ 
+ /* C++ generic write for key-value pairs */
+ 
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int8_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_i8(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int16_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_i16(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int32_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_i32(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int64_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_i64(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint8_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_u8(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint16_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_u16(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint32_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_u32(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint64_t value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_u64(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, bool value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_bool(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, float value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_float(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, double value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_double(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, char *value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_cstr_or_nil(writer, value);
+-}
+-
+-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, const char *value) {
+-    mpack_write_cstr(writer, key);
+-    mpack_write_cstr_or_nil(writer, value);
+-}
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int8_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_i8(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int16_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_i16(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int32_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_i32(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int64_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_i64(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint8_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_u8(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint16_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_u16(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint32_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_u32(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint64_t value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_u64(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, bool value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_bool(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, float value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_float(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, double value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_double(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, char *value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_cstr_or_nil(writer, value);
++//}
++//
++//MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, const char *value) {
++//    mpack_write_cstr(writer, key);
++//    mpack_write_cstr_or_nil(writer, value);
++//}
+ 
+ /**
+  * @}
+diff -ruN fluent-bit-3.2.7-org/lib/monkey/deps/rbtree/rbtree.h fluent-bit-3.2.7-new/lib/monkey/deps/rbtree/rbtree.h
+--- fluent-bit-3.2.7-org/lib/monkey/deps/rbtree/rbtree.h	2025-02-28 10:17:56.784637213 +0900
++++ fluent-bit-3.2.7-new/lib/monkey/deps/rbtree/rbtree.h	2025-03-19 17:01:47.396114992 +0900
+@@ -401,6 +401,8 @@
+     if (x->right != NULL) {
+         __rb_tree_find_minimum(x->right, successor);
+         goto done;
++done:
++    return ret;
+     }
+ 
+     struct rb_tree_node *y = x->parent;
+@@ -412,8 +414,6 @@
+ 
+     *successor = y;
+ 
+-done:
+-    return ret;
+ }
+ 
+ /**
+@@ -434,6 +434,8 @@
+     if (x->left != NULL) {
+         __rb_tree_find_maximum(x->left, pred);
+         goto done;
++done:
++    return ret;
+     }
+ 
+     struct rb_tree_node *y = x->parent;
+@@ -445,8 +447,6 @@
+ 
+     *pred = y;
+ 
+-done:
+-    return ret;
+ }
+ 
+ /**@} rb_functions */
+diff -ruN fluent-bit-3.2.7-org/lib/monkey/include/monkey/mk_stream.h fluent-bit-3.2.7-new/lib/monkey/include/monkey/mk_stream.h
+--- fluent-bit-3.2.7-org/lib/monkey/include/monkey/mk_stream.h	2025-02-28 10:17:56.784637213 +0900
++++ fluent-bit-3.2.7-new/lib/monkey/include/monkey/mk_stream.h	2025-03-19 14:34:30.615003390 +0900
+@@ -156,7 +156,7 @@
+     struct mk_iov *iov;
+ 
+     if (!in) {
+-        in = mk_mem_alloc(sizeof(struct mk_stream_input));
++        in = (struct mk_stream_input *)mk_mem_alloc(sizeof(struct mk_stream_input));
+         if (!in) {
+             return -1;
+         }
+@@ -175,7 +175,7 @@
+     in->stream       = stream;
+ 
+     if (type == MK_STREAM_IOV) {
+-        iov = buffer;
++        iov = (struct mk_iov *)buffer;
+         in->bytes_total = iov->total_len;
+     }
+     else {
+@@ -272,7 +272,7 @@
+      * used by Monkey core, at the moment the only caller is the CGI plugin.
+      */
+     if (!stream) {
+-        stream = mk_mem_alloc(sizeof(struct mk_stream));
++        stream = (struct mk_stream *)mk_mem_alloc(sizeof(struct mk_stream));
+         if (!stream) {
+             return NULL;
+         }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1180 
## Identify the Bug

Link to #1180 

## Description of the Change

- OpenRTMのソースビルドが通るためにはFluentbitソースの修正が必要のため、修正patchを用意した
  - fluent-bit-3.2.7-ubuntu.patch
  - Dockerfile.devel-rtmを使用してdocker buildを実行すればpatchが当てられたソースを使ってビルドされる
  - Fluentbitソースビルド時のcmakeオプションはデフォルトと同じ指定は外した
  - Fluentbitのdebパッケージバージョンは短い間隔（2週間程度）の更新が相次いている
  - この修正ではFluentbit v3.2.7 を利用する
  ```
  $ cp OpenRTM-aist/scripts/ubuntu_2404/Dockerfile.devel-rtm .
  $ sudo docker build -f Dockerfile.devel-rtm -t openrtm/devel-rtm:ubuntu24.04 .
  ```

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- この修正から作成したdockerイメージ openrtm/devel-rtm:ubuntu24.04 を使用し、OpenRTM2.1.0版のdebパッケージが生成できることを確認した（amd64, arm64の各環境にて）
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
