### PR TITLE
Fluentロガー利用時データのバッファサイズ超え対応

### DIFF
--- a/src/ext/logger/fluentbit_stream/FluentBit.h
+++ b/src/ext/logger/fluentbit_stream/FluentBit.h
@@ -32,14 +32,6 @@
 #include <coil/stringutil.h>
 #include <rtm/LogstreamBase.h>
 
-#ifndef LINE_MAX
-#define LINE_MAX  1024
-#endif
-
-#ifndef BUFFER_LEN
-#define BUFFER_LEN LINE_MAX
-#endif
-
 namespace RTC
 {
   /*!
@@ -78,12 +70,9 @@ namespace RTC
     void write(int level, const std::string &name, const std::string &date, const std::string &mes) override;
 
   protected:
-    std::streamsize pushLogger(int level, const std::string &name, const std::string &date, const char* mes);
+    std::streamsize pushLogger(int level, const std::string &name, const std::string &date, const std::string &mes);
 
   private:
-    char m_buf[BUFFER_LEN];
-    size_t m_pos{0};
-
     using FlbHandler = int;
 
     std::vector<FlbHandler> m_flbIn;

--- a/src/ext/logger/fluentbit_stream/fluentbit.conf
+++ b/src/ext/logger/fluentbit_stream/fluentbit.conf
@@ -39,6 +39,10 @@ logger.logstream.fluentd.output0.conf.match: *
 logger.logstream.fluentd.output1.plugin: stdout
 logger.logstream.fluentd.output1.conf.match: cpu
 
+# Output example (retry_limit)
+# Off to disable retries entirely.
+logger.logstream.fluentd.output2.conf.retry_limit:Off
+
 # Input example (CPU)
 logger.logstream.fluentd.input0.plugin: cpu
 logger.logstream.fluentd.input0.conf.tag: cpu

--- a/src/ext/logger/fluentbit_stream/rtc.fluentbit_stream.conf.in
+++ b/src/ext/logger/fluentbit_stream/rtc.fluentbit_stream.conf.in
@@ -6,6 +6,7 @@ logger.plugins: @FLUENTPLUGIN_PATH@
 
 logger.logstream.fluentd.output0.plugin: forward
 logger.logstream.fluentd.output0.conf.match:*
+logger.logstream.fluentd.output0.conf.retry_limit:Off
 
 logger.logstream.fluentd.input0.plugin: lib
 logger.logstream.fluentd.input0.conf.tag: rtclog


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1182 
## Identify the Bug

Link to #1182 

## Description of the Change

- バッファを char tmp[1024]と固定長で定義していたが、std::ostringstream利用へ変更
- 外部から呼び出されるFluentBitStream::write関数と、flb_lib_pushを実行する内部関数FluentBitStream::pushLoggerを修正
- flb_lib_pushへ渡す場合、JSON形式が正しくないと送信できない
  - R"()"を使うとエスケープ無しで記述できるのだが正しいJSON形式で定義できない場合の間違いが見つけづらい
  - 今回はR"()"は使わないが、送る文字列をパーツに分け、エスケープ処理をほとんど意識せずに書けるようにした 
- confファイルに retry_limit:Off を追加
  - この設定は、出力先へのログ送信に失敗した時、 リトライを一切しない（失敗したら即捨てる）

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Windows環境での修正確認・・・OK
  - ソースからインストールし、SeqIn(rtc.conf指定）とSeqOut(rtc.fluentbit_stream.conf指定）との接続動作で問題なくFluentログが流れることを確認
  - これまでエラーとなっていたデータ長のinport_iorも問題なく送信されることを確認
- Ubuntu24.04環境での動作確認・・・OK
  - Ubuntu上ではこれまでも問題なかったが、修正ソースから生成したdebパッケージでインストールした環境でもWindowsと同様のRTC接続動作が問題なかったことを確認
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
