### PR TITLE
Ubuntu用リポジトリの新しいGPG署名に対応

### DIFF
--- a/scripts/openrtm2_install_ubuntu.sh
+++ b/scripts/openrtm2_install_ubuntu.sh
@@ -14,7 +14,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.1.0.00
+VERSION=2.1.0.01
 FILENAME=openrtm2_install_ubuntu.sh
 
 #
@@ -419,7 +419,7 @@ create_srclist () {
     echo $msg3
     exit
   fi
-  openrtm_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openrtm.key] http://$reposerver/pub/Linux/ubuntu/ $code_name main"
+  openrtm_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openrtm-keyring.gpg] http://$reposerver/pub/Linux/ubuntu/ $code_name main"
   fluent_repo="deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/$code_name $code_name main"
 }
 
@@ -444,11 +444,12 @@ update_source_list () {
       if [ ! -d /etc/apt/keyrings ]; then
         sudo mkdir -p /etc/apt/keyrings
       fi
-      sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key -O /etc/apt/keyrings/openrtm.key
+      sudo wget --secure-protocol=TLSv1_2 --no-check-certificate http://$reposerver/pub/openrtm-keyring.gpg -O /etc/apt/keyrings/openrtm-keyring.gpg
     fi
-  elif test "x$rtmsite2" != "x" &&
-       [ ! -e /etc/apt/keyrings/openrtm.key ]; then
-    sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key -O /etc/apt/keyrings/openrtm.key
+  elif [ ! -e /etc/apt/keyrings/openrtm-keyring.gpg ]; then
+    sudo rm /etc/apt/sources.list.d/openrtm.list
+    echo $openrtm_repo | sudo tee /etc/apt/sources.list.d/openrtm.list > /dev/null
+    sudo wget --secure-protocol=TLSv1_2 --no-check-certificate http://$reposerver/pub/openrtm-keyring.gpg -O /etc/apt/keyrings/openrtm-keyring.gpg
   fi
   fluentsite=`apt-cache policy | grep "https://packages.fluentbit.io"`
   if test "x$fluentsite" = "x" &&


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1186 
## Identify the Bug

Link to #1186 


## Description of the Change

- Ubuntu用パッケージリポジトリの署名を新しいGPGキー使用に変更したので、それに対応した
- 変更後の動作確認
  - OpenRTMを初めてインストールする環境（含：Ubuntu24.04）では修正後の openrtm2_install_ubuntu.sh を使用すれば問題なくインストールできる
  - 既にOpenRTM2.0.2版をインストール済み環境で、apt update を実行すると、openrtm.org リポジトリに対してエラーが表示されるが、update動作に影響はない。ただし、このままでは次のOpenRTMバージョンがリリースされた時に、apt upgrade では更新できないので、新しい openrtm2_install_ubuntu.sh は一度実行する必要がある

- GPG鍵更新に関する詳細はRedmine参照
https://openrtm.org/redmine/projects/openrtm-web/wiki/GPG鍵をRSA4096bitで作り直す

## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 新しいGPG鍵で署名したテスト用サーバを使用して動作を確認
  - 新規にOpenRTMをインストールするUbuntu22.04, 24.04 環境
  - 既に古いGPG鍵で署名されたOpenRTMをインストール済みのUbuntu24.04環境
    - GPG署名が更新されているので、インストール済みパッケージが再インストールされる
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
