### PR TITLE
Raspbian用リポジトリの新しいGPG署名に対応

### DIFF
--- a/scripts/openrtm2_install_raspbian.sh
+++ b/scripts/openrtm2_install_raspbian.sh
@@ -6,7 +6,7 @@
 #         Nobu Kawauchi
 #
 
-VERSION=2.0.2.03
+VERSION=2.1.0.00
 FILENAME=openrtm2_install_raspbian.sh
 BIT=`getconf LONG_BIT`
 
@@ -347,7 +347,7 @@ check_reposerver()
 # リポジトリサーバ
 #---------------------------------------
 create_srclist () {
-  openrtm_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openrtm.key] http://$reposerver/pub/Linux/raspbian/ $code_name main"
+  openrtm_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openrtm-keyring.gpg] http://$reposerver/pub/Linux/raspbian/ $code_name main"
 }
 
 #---------------------------------------
@@ -371,11 +371,20 @@ update_source_list () {
       if [ ! -d /etc/apt/keyrings ]; then
         sudo mkdir -p /etc/apt/keyrings
       fi
-      sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key -O /etc/apt/keyrings/openrtm.key
+      sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://$reposerver/pub/openrtm-keyring.gpg -O /etc/apt/keyrings/openrtm-keyring.gpg
     fi
-  elif test "x$rtmsite2" != "x" &&
-       [ ! -e /etc/apt/keyrings/openrtm.key ]; then
-    sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://openrtm.org/pub/openrtm.key -O /etc/apt/keyrings/openrtm.key
+  elif [ ! -e /etc/apt/keyrings/openrtm-keyring.gpg ]; then
+    if test "x$rtmsite1" != "x" ; then
+      sudo sed -i.bak '/http:\/\/openrtm.org\/pub\/Linux\/raspbian\//d' /etc/apt/sources.list
+    fi
+    if test "x$rtmsite2" != "x" ; then
+      sudo rm /etc/apt/sources.list.d/openrtm.list
+    fi
+    echo $openrtm_repo | sudo tee /etc/apt/sources.list.d/openrtm.list > /dev/null
+    if [ ! -d /etc/apt/keyrings ]; then
+      sudo mkdir -p /etc/apt/keyrings
+    fi
+    sudo wget --secure-protocol=TLSv1_2 --no-check-certificate https://$reposerver/pub/openrtm-keyring.gpg -O /etc/apt/keyrings/openrtm-keyring.gpg
   fi
   
   if test "x$FORCE_YES" = "xtrue" ; then


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1188 
## Identify the Bug

Link to #1188 

- 今回GPG公開鍵が変更になり、鍵ファイル名変更に対応した
- openrtm.orgのリポジトリ情報の記載を/etc/apt/sources.list から /etc/apt/sources.list.d/openrtm.list へ変更したのは 2023/05/19
- これに対し、raspberry pi os のリリース日は以下の通り
  - bullseye ： 2022/04/07
  - bookworm ： 2023/10/11
- 上記からopenrtm.org設定が /etc/apt/sources.list に記載されている場合は該当行を削除し、新しいGPG公開鍵使用の設定を/etc/apt/sources.list.d/openrtm.list へ記載するように変更した

## Description of the Change

- bullseyeとbookwormの環境で、/etc/apt/sources.listに記載されている環境、/etc/apt/sources.list.d/openrtm.listに記載されている環境のそれぞれで問題ないことを確認した



## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
