### PR TITLE
Ubuntu22.04のDockerfile から HTTP_ENABLE オプションを削除

### DIFF
--- a/scripts/ubuntu_2204/Dockerfile
+++ b/scripts/ubuntu_2204/Dockerfile
@@ -3,7 +3,6 @@ FROM openrtm/devel-rtm:ubuntu22.04
 COPY OpenRTM-aist /root/OpenRTM-aist
 RUN cmake\
  -DSSL_ENABLE=ON\
- -DHTTP_ENABLE=ON\
  -DOBSERVER_ENABLE=ON\
  -DFLUENTBIT_ENABLE=ON\
  -DFLUENTBIT_ROOT=/usr/local\

--- a/scripts/ubuntu_2204/Dockerfile.package
+++ b/scripts/ubuntu_2204/Dockerfile.package
@@ -12,7 +12,6 @@ RUN apt-get update\
 COPY OpenRTM-aist /root/OpenRTM-aist
 RUN cmake\
  -DSSL_ENABLE=ON\
- -DHTTP_ENABLE=ON\
  -DOBSERVER_ENABLE=ON\
  -DFLUENTBIT_ENABLE=ON\
  -DFLUENTBIT_ROOT=/usr/local\


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

- #999 での修正ミス対応
- Ubuntu22.04環境で公式のomniORBパッケージをインストールした場合、バージョンは4.2.5となる
- HTTP通信はomniORB-4.3.0からサポートされた機能のため、4.2.5の環境では使用できない
- Dockerfile, Dockerfile.package に間違って追加してしまったHTTP_ENABLE オプションを削除した


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu22.04環境で修正したDockerfile, Dockerfile.package を使用したビルドOKを確認した
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
