### PR TITLE
CMakeのワーニング対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (OpenRTM_aist
 	VERSION 2.1.0
@@ -347,11 +347,13 @@ elseif(CORBA STREQUAL "omniORB")
 			if((NOT (${library} STREQUAL "optimized")) AND (NOT (${library} STREQUAL "debug")))
 				string(REPLACE "_rt" "*" dll "${library}")
 				file(GLOB OMNIORB_DLLS "${OMNIORB_BINARY_DIR}/${dll}.dll")
-				install(PROGRAMS ${OMNIORB_DLLS} DESTINATION ${ORB_INSTALL_DIR}/bin/${ARCH_NAME} COMPONENT corbalib)
+				cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/bin/${ARCH_NAME}")
+				install(PROGRAMS ${OMNIORB_DLLS} DESTINATION "${_dest}" COMPONENT corbalib)
 				file(GLOB OMNIORB_PDBS "${OMNIORB_BINARY_DIR}/${dll}.pdb")
-				install(PROGRAMS ${OMNIORB_PDBS} DESTINATION ${ORB_INSTALL_DIR}/bin/${ARCH_NAME} COMPONENT corbalib)
+				install(PROGRAMS ${OMNIORB_PDBS} DESTINATION "${_dest}" COMPONENT corbalib)
 				
-				install(PROGRAMS "${ORB_LINK_DIR}/${library}.lib" DESTINATION ${ORB_INSTALL_DIR}/lib/${ARCH_NAME} COMPONENT corbalib)
+				cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/lib/${ARCH_NAME}")
+				install(PROGRAMS "${ORB_LINK_DIR}/${library}.lib" DESTINATION "${_dest}" COMPONENT corbalib)
 			endif()
 		endforeach()
 
@@ -372,7 +374,8 @@ elseif(CORBA STREQUAL "omniORB")
 		foreach(file_path ${OMNIORB_HEADERFILES})
 			get_filename_component(dir_path "${file_path}" DIRECTORY)
 			string(REPLACE "${ORB_ROOT}/include" "" file "${dir_path}")
-			install(FILES ${file_path} DESTINATION ${ORB_INSTALL_DIR}/include/${file} COMPONENT corbalib)
+			cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/include/${file}")
+			install(FILES ${file_path} DESTINATION "${_dest}" COMPONENT corbalib)
 		endforeach()
 
 
@@ -383,17 +386,21 @@ elseif(CORBA STREQUAL "omniORB")
 		foreach(file_path ${OMNIORB_IDLFILES})
 			get_filename_component(dir_path "${file_path}" DIRECTORY)
 			string(REPLACE "${ORB_ROOT}/idl" "" file "${dir_path}")
-			install(FILES ${file_path} DESTINATION ${ORB_INSTALL_DIR}/idl/${file} COMPONENT corbalib)
+			cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/idl/${file}")
+			install(FILES ${file_path} DESTINATION "${_dest}" COMPONENT corbalib)
 		endforeach()
 
 		file(GLOB OMNIORB_SCRIPTS "${ORB_ROOT}/bin/scripts/*.py")
 		
-		install(FILES ${OMNIORB_SCRIPTS} DESTINATION ${ORB_INSTALL_DIR}/bin/scripts COMPONENT corbalib)
-		install(DIRECTORY ${ORB_ROOT}/lib/python/omniidl DESTINATION ${ORB_INSTALL_DIR}/lib/python/ COMPONENT corbalib FILES_MATCHING PATTERN "*.py" PATTERN "__pycache__" EXCLUDE)
-		install(DIRECTORY ${ORB_ROOT}/lib/python/omniidl_be DESTINATION ${ORB_INSTALL_DIR}/lib/python/ COMPONENT corbalib FILES_MATCHING PATTERN "*.py" PATTERN "__pycache__" EXCLUDE)
+		cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/bin/scripts")
+		install(FILES ${OMNIORB_SCRIPTS} DESTINATION "${_dest}" COMPONENT corbalib)
+		cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/lib/python/")
+		install(DIRECTORY ${ORB_ROOT}/lib/python/omniidl DESTINATION "${_dest}" COMPONENT corbalib FILES_MATCHING PATTERN "*.py" PATTERN "__pycache__" EXCLUDE)
+		install(DIRECTORY ${ORB_ROOT}/lib/python/omniidl_be DESTINATION "${_dest}" COMPONENT corbalib FILES_MATCHING PATTERN "*.py" PATTERN "__pycache__" EXCLUDE)
 
-		install(PROGRAMS ${ORB_ROOT}/bin/${ARCH_NAME}/omniidl.exe DESTINATION ${ORB_INSTALL_DIR}/bin/${ARCH_NAME} COMPONENT corbalib)
-		install(PROGRAMS ${ORB_ROOT}/bin/${ARCH_NAME}/omniNames.exe DESTINATION ${ORB_INSTALL_DIR}/bin/${ARCH_NAME} COMPONENT corbalib)
+		cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/bin/${ARCH_NAME}")
+		install(PROGRAMS ${ORB_ROOT}/bin/${ARCH_NAME}/omniidl.exe DESTINATION "${_dest}" COMPONENT corbalib)
+		install(PROGRAMS ${ORB_ROOT}/bin/${ARCH_NAME}/omniNames.exe DESTINATION "${_dest}" COMPONENT corbalib)
 
 
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 
 project (docs

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(UNIX)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rtc.conf.sample ${CMAKE_CURRENT_SOURCE_DIR}/rtc.conf.sample2 COPYONLY)

--- a/examples/Analyzer/CMakeLists.txt
+++ b/examples/Analyzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 project (Analyzer
 	VERSION ${RTM_VERSION}

--- a/examples/AutoTest/CMakeLists.txt
+++ b/examples/AutoTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 project (AutoTest
 	VERSION ${RTM_VERSION}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 function(examples_build target)
 	cmake_parse_arguments(EB

--- a/examples/Composite/CMakeLists.txt
+++ b/examples/Composite/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 project (Composite
 	VERSION ${RTM_VERSION}

--- a/examples/ConfigSample/CMakeLists.txt
+++ b/examples/ConfigSample/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 set(target ConfigSample)
 project (${target}
 	VERSION ${RTM_VERSION}

--- a/examples/ConsoleIn/CMakeLists.txt
+++ b/examples/ConsoleIn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   set(srcs src/ConsoleIn.cpp include/ConsoleIn/ConsoleIn.h)

--- a/examples/ConsoleOut/CMakeLists.txt
+++ b/examples/ConsoleOut/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   set(srcs src/ConsoleOut.cpp include/ConsoleOut/ConsoleOut.h)

--- a/examples/Controller/CMakeLists.txt
+++ b/examples/Controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   set(srcs src/Controller.cpp include/Controller/Controller.h)

--- a/examples/ExtTrigger/CMakeLists.txt
+++ b/examples/ExtTrigger/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 project (ExtTrigger
 	VERSION ${RTM_VERSION}

--- a/examples/HelloWorld/CMakeLists.txt
+++ b/examples/HelloWorld/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 set(target HelloRTWorld)
 project (${target}
 	VERSION ${RTM_VERSION}

--- a/examples/Motor/CMakeLists.txt
+++ b/examples/Motor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   set(srcs src/Motor.cpp include/Motor/Motor.h)

--- a/examples/MyServiceConsumer/CMakeLists.txt
+++ b/examples/MyServiceConsumer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   add_subdirectory(idl)

--- a/examples/MyServiceProvider/CMakeLists.txt
+++ b/examples/MyServiceProvider/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   add_subdirectory(idl)

--- a/examples/Sensor/CMakeLists.txt
+++ b/examples/Sensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   set(srcs src/Sensor.cpp include/Sensor/Sensor.h)

--- a/examples/SeqIn/CMakeLists.txt
+++ b/examples/SeqIn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   set(srcs src/SeqIn.cpp include/SeqIn/SeqIn.h)

--- a/examples/SeqOut/CMakeLists.txt
+++ b/examples/SeqOut/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 if(OpenRTM_aist_BINARY_DIR)
   set(srcs src/SeqOut.cpp include/SeqOut/SeqOut.h)

--- a/examples/Serializer/CMakeLists.txt
+++ b/examples/Serializer/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 
 project (SerializerSample

--- a/examples/StaticFsm/CMakeLists.txt
+++ b/examples/StaticFsm/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 project (StaticFSM
 	VERSION ${RTM_VERSION}

--- a/examples/StringIO/CMakeLists.txt
+++ b/examples/StringIO/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 project (StringIO
 	VERSION ${RTM_VERSION}

--- a/examples/Templates/CMakeLists.txt
+++ b/examples/Templates/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 file(GLOB XML_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.xml")
 foreach(file_path ${XML_FILES})

--- a/examples/Throughput/CMakeLists.txt
+++ b/examples/Throughput/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.5.1)
+﻿cmake_minimum_required (VERSION 3.16)
 
 project (Throughput
 	VERSION ${RTM_VERSION}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 add_subdirectory(lib)
 set(EXTLIB_ENABLE TRUE CACHE BOOL "set EXTLIB_ENABLE ")

--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 add_subdirectory(sdo)
 add_subdirectory(local_service)

--- a/src/ext/ec/CMakeLists.txt
+++ b/src/ext/ec/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(NOT CORBA MATCHES "RtORB")
 	add_subdirectory(logical_time)

--- a/src/ext/ec/logical_time/CMakeLists.txt
+++ b/src/ext/ec/logical_time/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (LogicalTimeTriggeredEC
 	VERSION ${RTM_VERSION}

--- a/src/ext/ec/rtpreempt/CMakeLists.txt
+++ b/src/ext/ec/rtpreempt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (RTPreemptEC
 	VERSION ${RTM_VERSION}

--- a/src/ext/http/CMakeLists.txt
+++ b/src/ext/http/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
+
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
 
 project (HTTPTransport
 	VERSION ${RTM_VERSION}

--- a/src/ext/interrupt_task/CMakeLists.txt
+++ b/src/ext/interrupt_task/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 
 

--- a/src/ext/local_service/nameservice_file/CMakeLists.txt
+++ b/src/ext/local_service/nameservice_file/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (FileNameservice
 	VERSION ${RTM_VERSION}

--- a/src/ext/logger/CMakeLists.txt
+++ b/src/ext/logger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 
 set(FLUENTBIT_ENABLE FALSE CACHE BOOL "set FLUENTBIT_ENABLE")

--- a/src/ext/logger/fluentbit_stream/CMakeLists.txt
+++ b/src/ext/logger/fluentbit_stream/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 set(FLUENTBIT_ROOT ${FLUENTBIT_ROOT} CACHE PATH "set FLUENTBIT_ROOT")
 if(NOT FLUENTBIT_ROOT)

--- a/src/ext/sdo/CMakeLists.txt
+++ b/src/ext/sdo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 add_subdirectory(logger)
 add_subdirectory(extended_fsm)

--- a/src/ext/sdo/extended_fsm/CMakeLists.txt
+++ b/src/ext/sdo/extended_fsm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (ExtendedFsmServiceProvider
 	VERSION ${RTM_VERSION}

--- a/src/ext/sdo/fsm4rtc_observer/CMakeLists.txt
+++ b/src/ext/sdo/fsm4rtc_observer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (FSMComponentObserverConsumer
 	VERSION ${RTM_VERSION}

--- a/src/ext/sdo/logger/CMakeLists.txt
+++ b/src/ext/sdo/logger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (LoggerConsumer
 	VERSION ${RTM_VERSION}

--- a/src/ext/sdo/observer/CMakeLists.txt
+++ b/src/ext/sdo/observer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (ComponentObserverConsumer
 	VERSION ${RTM_VERSION}

--- a/src/ext/ssl/CMakeLists.txt
+++ b/src/ext/ssl/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
+
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
 
 project (SSLTransport
 	VERSION ${RTM_VERSION}

--- a/src/ext/transport/CMakeLists.txt
+++ b/src/ext/transport/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 set(ROS_ENABLE OFF CACHE BOOL "set ROS_ENABLE")
 

--- a/src/ext/transport/FastRTPS/CMakeLists.txt
+++ b/src/ext/transport/FastRTPS/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (FastRTPSTransport
 	VERSION ${RTM_VERSION}

--- a/src/ext/transport/OpenSplice/CMakeLists.txt
+++ b/src/ext/transport/OpenSplice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (OpenSpliceTransport
 	VERSION ${RTM_VERSION}

--- a/src/ext/transport/ROS2Transport/CMakeLists.txt
+++ b/src/ext/transport/ROS2Transport/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project (ROS2Transport
 	VERSION ${RTM_VERSION}

--- a/src/ext/transport/ROSTransport/CMakeLists.txt
+++ b/src/ext/transport/ROSTransport/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (ROSTransport
 	VERSION ${RTM_VERSION}

--- a/src/ext/transport/SSMTransport/CMakeLists.txt
+++ b/src/ext/transport/SSMTransport/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (SSMTransport
 	VERSION ${RTM_VERSION}

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 add_subdirectory(coil)
 add_subdirectory(rtm)

--- a/src/lib/coil/CMakeLists.txt
+++ b/src/lib/coil/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 project (${COIL_PROJECT_NAME}
 	VERSION ${RTM_VERSION}
 	LANGUAGES CXX)

--- a/src/lib/hrtm/CMakeLists.txt
+++ b/src/lib/hrtm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(WIN32)
 	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/lib/rtm/CMakeLists.txt
+++ b/src/lib/rtm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (${RTM_PROJECT_NAME}
 	VERSION ${RTM_VERSION}

--- a/src/lib/rtm/ext/CMakeLists.txt
+++ b/src/lib/rtm/ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(NOT CORBA MATCHES "RtORB")
 	add_subdirectory(rtmCamera)

--- a/src/lib/rtm/ext/rtmCamera/CMakeLists.txt
+++ b/src/lib/rtm/ext/rtmCamera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(WIN32)
 	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/lib/rtm/ext/rtmManipulator/CMakeLists.txt
+++ b/src/lib/rtm/ext/rtmManipulator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(WIN32)
 	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/lib/rtm/idl/CMakeLists.txt
+++ b/src/lib/rtm/idl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (${RTCSKEL_PROJECT_NAME}
 	VERSION ${RTM_VERSION}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 add_subdirectory(rtcd)
 add_subdirectory(rtcprof)

--- a/utils/cmake/CMakeLists.txt
+++ b/utils/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 project (OpenRTMCMake
 	VERSION 2.1.0

--- a/utils/environment-setup-scripts/CMakeLists.txt
+++ b/utils/environment-setup-scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 set(target environment-setup-scripts)
 project (${target}
 	VERSION ${RTM_VERSION}

--- a/utils/openrtmNames/CMakeLists.txt
+++ b/utils/openrtmNames/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
+
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
+
 set(target openrtmNames)
 project (${target}
 	VERSION ${RTM_VERSION}

--- a/utils/rtc-template/CMakeLists.txt
+++ b/utils/rtc-template/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 
 if(UNIX)

--- a/utils/rtcd/CMakeLists.txt
+++ b/utils/rtcd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 set(target rtcd2)
 project (${target}
 	VERSION ${RTM_VERSION}

--- a/utils/rtcprof/CMakeLists.txt
+++ b/utils/rtcprof/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 set(target rtcprof2)
 project (${target}
 	VERSION ${RTM_VERSION}

--- a/utils/rtm-config/CMakeLists.txt
+++ b/utils/rtm-config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 # Variable definitions
 set(INSTALL_INCLUDE_DIR include)

--- a/utils/rtm-naming/CMakeLists.txt
+++ b/utils/rtm-naming/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(CORBA STREQUAL "ORBexpress")
 elseif(CORBA STREQUAL "omniORB")

--- a/utils/rtm-skelwrapper/CMakeLists.txt
+++ b/utils/rtm-skelwrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.1)
+cmake_minimum_required (VERSION 3.16)
 
 if(BUILD_RTM_LINUX_PKGS)
   set(CMAKE_INSTALL_PREFIX "/usr")


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1199 
## Identify the Bug

Link to #1199 


## Description of the Change
- (1)Policy CMP0144への対応
  - find_packageで指定しているパッケージ名が全て大文字になっていないという指摘
  - 指摘されている部分は、find_package(OpenSSL REQUIRED)　だが、現時点でFindOpenSSL.cmakeが大文字のパッケージ名OPENSSLに対応していないため、cmake_policyでこのワーニングを抑制した
    ```
    if(POLICY CMP0144)
      cmake_policy(SET CMP0144 NEW)
    endif()
    ```
- (2)Policy CMP0177への対応
  - install()のDESTINATION の文字列が正規化前後で変わる可能性（例: 末尾の /、//、./、../ が混入）があるとワーニングが出る
  - ワーニングが出ない書き方に変更した
    ```
    install(PROGRAMS ${OMNIORB_DLLS} DESTINATION ${ORB_INSTALL_DIR}/bin/${ARCH_NAME} COMPONENT corbalib)
          ↓
    cmake_path(SET _dest NORMALIZE "${ORB_INSTALL_DIR}/bin/${ARCH_NAME}")
    install(PROGRAMS ${OMNIORB_DLLS} DESTINATION "${_dest}" COMPONENT corbalib)
    ```
- (3)「Compatibility with CMake < 3.10 will be removed from a future version of CMake.」への対応
  - cmake_minimum_required(VERSION 3.5.1) の部分を指摘されている
  - RTCBのテンプレートと同様の下記定義に変更した
    ```
    cmake_minimum_required(VERSION 3.16)
    ```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Windows環境でワーニングが出ないことを確認
- Windows環境でソースからインストールしたディレクトリで、install文で指定しているファイルの存在を確認
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
