### PR TITLE
openRTMNamesのRtORB対応

### DIFF
--- a/utils/openrtmNames/BindingIterator.cpp
+++ b/utils/openrtmNames/BindingIterator.cpp
@@ -59,11 +59,19 @@ namespace RTM
     b = new CosNaming::Binding;
     if (ret)
     {
+#ifndef ORB_IS_RTORB
       *b = bl[0];
+#else
+      b = &bl[0];
+#endif
     }
     else
     {
+#ifndef ORB_IS_RTORB
       b->binding_type = CosNaming::nobject;
+#else
+      b.ptr()->binding_type = CosNaming::nobject;
+#endif
     }
     return ret;
   }
@@ -108,7 +116,11 @@ namespace RTM
     m_list->length(bl->length() - how_many);
 
     for (CORBA::ULong i = 0; i < m_list->length(); i++) {
+#ifndef ORB_IS_RTORB
       m_list[i] = (*bl)[i + how_many];
+#else
+      m_list[i] = (*(bl.ptr()))[i + how_many];
+#endif
     }
 
     bl->length(how_many);

--- a/utils/openrtmNames/NamingContext.h
+++ b/utils/openrtmNames/NamingContext.h
@@ -8,6 +8,8 @@
 #include <omniORB4/Naming.hh>
 #elif defined(ORB_IS_TAO)
 #include <orbsvcs/CosNamingS.h>
+#elif defined(ORB_IS_RTORB)
+#include <CosName/CosNaming.h>
 #endif
 
 
@@ -270,7 +272,11 @@ namespace RTM
      * @endif
      */
     void list(CORBA::ULong how_many, CosNaming::BindingList_out bl,
+#ifndef ORB_IS_RTORB
         CosNaming::BindingIterator_out bi) override;
+#else
+        CosNaming::BindingIterator_ptr bi) override;
+#endif
 
     /*!
      * @if jp
@@ -360,6 +366,11 @@ namespace RTM
      */
     CORBA::Object_ptr resolve_str(const char* n) override;
 
+
+
+#ifdef ORB_IS_RTORB
+    CORBA::Boolean _is_a(const CORBA_char * id) override;
+#endif
     /*!
      * @if jp
      *

--- a/utils/openrtmNames/ObjectBinding.cpp
+++ b/utils/openrtmNames/ObjectBinding.cpp
@@ -182,7 +182,7 @@ namespace RTM
    */
   CORBA::Object_ptr ObjectBinding::get_object()
   {
-    return m_object.inout();
+    return m_object.out();
   }
   /*!
    * @if jp

--- a/utils/openrtmNames/OpenrtmNamesPlugin.cpp
+++ b/utils/openrtmNames/OpenrtmNamesPlugin.cpp
@@ -40,6 +40,7 @@ namespace OpenRTMNames
       std::cout << sior << std::endl;
 
 #ifndef ORB_IS_TAO
+#ifndef ORB_IS_RTORB
       CORBA::Object_var ins_obj = orb->resolve_initial_references("omniINSPOA");
 
       ins_poa = PortableServer::POA::_narrow(ins_obj);
@@ -48,6 +49,9 @@ namespace OpenRTMNames
       PortableServer::ObjectId_var id = PortableServer::string_to_ObjectId("NameService");
       ins_poa->activate_object_with_id(id.in(), m_nameservice);
 #else
+      root_poa->reinstall_object(m_nameservice, "NameService");
+#endif
+#else
       CORBA::Object_var obj = orb->resolve_initial_references("IORTable");
       adapter = IORTable::Table::_narrow(obj.in());
 
@@ -55,6 +59,7 @@ namespace OpenRTMNames
       adapter->bind("NameService", ior.in());
 #endif
     }
+#ifndef ORB_IS_RTORB
     catch (const CORBA::INITIALIZE& ex) {
 #ifdef ORB_IS_OMNIORB
       std::cerr << "Failed to initialise: " << ex.NP_minorString() << std::endl;
@@ -63,15 +68,22 @@ namespace OpenRTMNames
 #endif
       return;
     }
+#endif
     catch (CORBA::SystemException& ex) {
+#ifndef ORB_IS_RTORB
       std::cerr << "Caught CORBA::" << ex._name() << std::endl;
+#else
+      std::cerr << "Caught CORBA::" << ex.msg() << std::endl;
+#endif
       return;
     }
     catch (CORBA::Exception& ex) {
+#ifndef ORB_IS_RTORB
       std::cerr << "Caught CORBA::Exception: " << ex._name() << std::endl;
-      return;
+#else
+      std::cerr << "Caught CORBA::Exception: " << ex.msg() << std::endl;
+#endif
     }
-
 
   }
   ManagerActionListener::~ManagerActionListener()
@@ -89,6 +101,7 @@ namespace OpenRTMNames
 
 
 #ifndef ORB_IS_TAO
+#ifndef ORB_IS_RTORB
     CORBA::Object_var obj = m_manager->theORB()->resolve_initial_references("omniINSPOA");
 
     PortableServer::POA_var ins_poa = PortableServer::POA::_narrow(obj);
@@ -96,6 +109,7 @@ namespace OpenRTMNames
     id = ins_poa->servant_to_id(m_nameservice);
 
     ins_poa->deactivate_object(id.in());
+#endif
 #else
     CORBA::Object_var obj = m_manager.theORB()->resolve_initial_references("IORTable");
     IORTable::Table_var adapter = IORTable::Table::_narrow(obj.in());

--- a/utils/openrtmNames/OpenrtmNamesPlugin.h
+++ b/utils/openrtmNames/OpenrtmNamesPlugin.h
@@ -35,7 +35,12 @@ namespace OpenRTMNames
     void postReinit() override;
     void preReinit() override;
   private:
+#ifndef ORB_IS_RTORB
     PortableServer::Servant_var<RTM::NamingContext> m_nameservice;
+#else
+    RTM::NamingContext* m_nameservice = nullptr;
+#endif
+
     RTC::Manager* m_manager;
   };
 }


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

openRTMNamesをRtORBでビルドするとエラーになり、実行できても正常に動作しない。


## Description of the Change

以下の修正を行った。
- ネームサーバーをNameServiceの名前で活性化
- NamingContextクラスに_is_a関数追加
- その他、細かいエラーの修正

ビルド手順は以下の通り。

```
git clone https://github.com/OpenRTM/RtORB
cd RtORB
mkdir build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX=/home/xxxx/work/install
make
sudo make install
```

```
git clone https://github.com/OpenRTM/OpenRTM-aist
cd OpenRTM-aist
mkdir build
cd build
cmake .. -DCORBA=RtORB -DORB_ROOT=/home/xxxx/work/install -DCMAKE_INSTALL_PREFIX=/home/xxxx/work/install
make 
sudo make install
```


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
