### PR TITLE
一括インストールスクリプトでのopenrtm.list.disabled存在時不具合の修正

### DIFF
--- a/scripts/openrtm2_install_raspbian.sh
+++ b/scripts/openrtm2_install_raspbian.sh
@@ -6,7 +6,7 @@
 #         Nobu Kawauchi
 #
 
-VERSION=2.1.0.01
+VERSION=2.1.0.02
 FILENAME=openrtm2_install_raspbian.sh
 BIT=`getconf LONG_BIT`
 
@@ -361,7 +361,11 @@ create_srclist () {
 #---------------------------------------
 update_source_list () {
   rtmsite1=`grep $reposerver /etc/apt/sources.list`
-  rtmsite2=`grep -r $reposerver /etc/apt/sources.list.d`
+  if test -f "/etc/apt/sources.list.d/openrtm.list"; then
+    rtmsite2=`grep $reposerver /etc/apt/sources.list.d/openrtm.list`
+  else
+    rtmsite2=""
+  fi
   if test "x$rtmsite1" = "x" &&
      test "x$rtmsite2" = "x" ; then
     echo $msg4

--- a/scripts/openrtm2_install_ubuntu.sh
+++ b/scripts/openrtm2_install_ubuntu.sh
@@ -14,7 +14,7 @@
 # = OPT_UNINST   : uninstallation
 #
 
-VERSION=2.1.0.03
+VERSION=2.1.0.04
 FILENAME=openrtm2_install_ubuntu.sh
 
 #
@@ -432,7 +432,11 @@ create_srclist () {
 #---------------------------------------
 update_source_list () {
   rtmsite1=`grep $reposerver /etc/apt/sources.list`
-  rtmsite2=`grep -r $reposerver /etc/apt/sources.list.d`
+  if test -f "/etc/apt/sources.list.d/openrtm.list"; then
+    rtmsite2=`grep $reposerver /etc/apt/sources.list.d/openrtm.list`
+  else
+    rtmsite2=""
+  fi
   if test "x$rtmsite1" = "x" &&
      test "x$rtmsite2" = "x" ; then
     echo $msg4
@@ -461,12 +465,15 @@ update_source_list () {
     sudo wget --secure-protocol=TLSv1_2 --no-check-certificate http://$reposerver/pub/openrtm-keyring.gpg -O /etc/apt/keyrings/openrtm-keyring.gpg
   fi
   # If FluentBit's old public key is registered, delete it.
-  fingerprint=$(apt-key list | awk '$1 == "pub" {getline; gsub(" ", "", $0); fpr=$0}
-  /Fluentbit releases/ {print substr(fpr, length(fpr)-7)}')
-  if test "x$fingerprint" != "x" &&
-     test "x$OPT_COREDEVEL" = "xtrue" ; then
-    sudo apt-key del $fingerprint
-    sudo sed -i '/https:\/\/packages.fluentbit.io\/ubuntu\//d' /etc/apt/sources.list
+  # 従来の trusted.gpg 内から Fluentbit のキー ID を検索して削除
+  if [ -f /etc/apt/trusted.gpg ]; then
+    fingerprint=$(gpg --no-default-keyring --keyring /etc/apt/trusted.gpg --list-keys 2>/dev/null | \
+      awk '/Fluentbit releases/ {print fpr} $1 == "pub" {getline; gsub(" ", "", $0); fpr=$0}')
+    if test "x$fingerprint" != "x" &&
+       test "x$OPT_COREDEVEL" = "xtrue" ; then
+      sudo gpg --no-default-keyring --keyring /etc/apt/trusted.gpg --batch --yes --delete-keys "$fingerprint"
+      sudo sed -i '/https:\/\/packages.fluentbit.io\/ubuntu\//d' /etc/apt/sources.list
+    fi
   fi
   if [ ! -e /usr/share/keyrings/fluentbit-keyring.gpg ] &&
      test "x$OPT_COREDEVEL" = "xtrue" ; then


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #1231 
## Identify the Bug

Link to #1231 
- OSをdo-release-upgradeコマンドでバージョンアップグレードした場合、/etc/apt/sources.list.d/openrtm.list は /etc/apt/sources.list.d/openrtm.list.disabled としてバックアップされる
- この .disabled ファイルの存在を考慮していなかったため、一括インストールスクリプトを実行しても、新しいOSバージョン用のopenrtm.list登録処理がスルーされ、結果、aptによるパッケージインストールに失敗していた

## Description of the Change

- openrtm.listファイルの存在チェックに変更し、openrtm.list.disabledが存在していても新しいopenrtm.listが登録されるようにした
- この変更をUbuntu用だけでなくraspbian用スクリプトに対しても行った
- Ubuntu用スクリプトだけの修正を追加
  - 今回の修正動作を確認していたところ、スクリプトをOpenRTM core developer向けの「-l c++ -c」オプションで実行した場合、FluentBitのGPG公開鍵登録処理部分で廃止となった apt-key を使用している部分が残っていたため、apt-keyを使わない処理に修正した
  - raspbian用スクリプトでは apt-keyによる旧方式でのFluentBitのGPG鍵登録に対応していなかったため、今回該当する修正は無い


## Verification 
<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
if this request do not need to build and tests, delete the items and specify that these are no need.
-->
- Ubuntu24.04を26.04へアップグレードした環境で、修正後の一括インストールスクリプトでomniORBpy4.3.3のパッケージがインストールされることを確認した
- apt-key を使っていたことで not found と出ていたメッセージが出なくなったことを確認した
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
